### PR TITLE
NativeVK + Debug Panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,23 @@
-/assets
-/generated
+# Build trees. out/ holds both the host build and the container build, including
+# a ~187 MB renut binary -- past GitHub's 100 MB per-file hard limit, so this is
+# not merely noise: leaving it in gets the push rejected.
+out/
+dist/
+
+# Recompiler output. Regenerate with:
+#   cmake --build out/build/<preset> --target renut_codegen
+generated/
+
+# Game data from the disc image. Not redistributable, and 6.2 GB besides.
+assets/
+
+# Editor and backup noise.
+*.bak
+__pycache__/
+
+# Local Claude Code project settings.
+.claude/
+
+# Working/planning docs -- local reference only, not for the fork.
+docs/ai/archive/deferred-vfetch-flush.md
+docs/ai/archive/native-renderer-plan.md

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ __pycache__/
 # Working/planning docs -- local reference only, not for the fork.
 docs/ai/archive/deferred-vfetch-flush.md
 docs/ai/archive/native-renderer-plan.md
+docs/ai/archive/native-renderer-rewrite-plan.md
+docs/ai/archive/pr-description-renderer.md

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,37 +79,36 @@ renut_xenos_shader(renut
     OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/generated/renut_xenos_shader_vs_67021cae68a26b46.hlsl"
 )
 
-# Real constant-table synthesis (2026-08-16, see
-# renut_synthesize_constant_tables()'s own comment in
-# cmake/rexglue_xenosrecomp.cmake for the full story): most real captured
-# Banjo-Kazooie shaders are missing the D3DX9 constant-reflection table
-# XenosRecomp needs (a real upstream XenosRecomp limitation, not a reNut
+# Constant-table synthesis (see renut_synthesize_constant_tables()'s own
+# comment in cmake/rexglue_xenosrecomp.cmake for the full story): most
+# captured Banjo-Kazooie shaders are missing the D3DX9 constant-reflection
+# table XenosRecomp needs (an upstream XenosRecomp limitation, not a reNut
 # capture bug), so this step patches a build-tree COPY of the shader dump
 # with synthesized tables before the batch converter below ever sees it --
-# raises real conversion success from 36/253 to 101/253 shaders. Must run
-# before renut_xenos_shader_batch() so its SHADER_DUMP_DIR can point at the
-# patched copy instead of the raw dump.
+# raises conversion success from 36/253 to 101/253 shaders. Must run before
+# renut_xenos_shader_batch() so its SHADER_DUMP_DIR can point at the patched
+# copy instead of the raw dump.
 renut_synthesize_constant_tables(
     SHADER_DUMP_DIR "${CMAKE_BINARY_DIR}/shaders"
     REXSDK_DIR "${REXSDK_DIR}"
     OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/shaders_synthesized"
 )
 
-# Real container synthesis from ucode-only captures (2026-08-16, see
+# Container synthesis from ucode-only captures (see
 # renut_synthesize_containers_from_ucode()'s own comment in
-# cmake/rexglue_xenosrecomp.cmake for the full story): this game's actual
+# cmake/rexglue_xenosrecomp.cmake for the full story): this game's
 # MOST-USED shaders never call D3D9's CreateVertexShader/CreatePixelShader
 # at all (loaded via GPU command-stream IM_LOAD packets instead), so
 # shader_dump.cpp's capture above structurally can never see them --
-# confirmed 0% overlap between that capture and real live draw identities.
+# confirmed 0% overlap between that capture and live draw identities.
 # renut_dump_ucode_hash's raw microcode captures (shaders_ucode_hash/) DO
 # cover them; this step rebuilds full containers for those and adds them
 # into the SAME shaders_synthesized/ directory the constant-table step
 # above just populated (that step clears+repopulates the directory from
 # shaders/ FIRST, this step only adds -- must run in exactly this order,
 # hence the explicit dependency below, or the ucode-derived containers
-# would get wiped). Verified end-to-end: unlocks 1492 additional real,
-# actually-drawn shaders (vs 101 from the D3D9-hook path alone).
+# would get wiped). Unlocks 1492 additional actually-drawn shaders (vs 101
+# from the D3D9-hook path alone).
 renut_synthesize_containers_from_ucode(
     UCODE_DIR "${CMAKE_BINARY_DIR}/shaders_ucode_hash"
     REXSDK_DIR "${REXSDK_DIR}"
@@ -149,15 +148,14 @@ if(TARGET renut_synthesize_containers_from_ucode_target AND TARGET renut_xenos_s
     add_dependencies(renut_xenos_shader_batch renut_synthesize_containers_from_ucode_target)
 endif()
 
-# Real bug found+fixed 2026-08-16: renut_xenos_shader_batch() above only wired
-# its DEPENDS onto `renut` (the top-level executable target), not onto
-# `rexgpu-nativevk` (the SDK-side plugin .so that actually #includes the
-# generated cache .cpp -- confirmed via renut_xenos_pipeline_cache.cpp's own
-# __has_include check). Real, reproduced symptom: after regenerating the
-# cache with genuinely new/changed content, `renut` relinks (its own real
-# dependency is satisfied) but `rexgpu-nativevk` reports "no work to do" and
-# keeps shipping the STALE cache baked into its already-built .so -- confirmed
-# via a real stale-vs-fresh timestamp/content mismatch, not a guess. Fixed by
+# renut_xenos_shader_batch() above only wired its DEPENDS onto `renut` (the
+# top-level executable target), not onto `rexgpu-nativevk` (the SDK-side
+# plugin .so that actually #includes the generated cache .cpp -- confirmed
+# via nativevk_xenos_pipeline_cache.cpp's own __has_include check). Symptom:
+# after regenerating the cache with new/changed content, `renut` relinks
+# (its own dependency is satisfied) but `rexgpu-nativevk` reports "no work
+# to do" and keeps shipping the STALE cache baked into its already-built
+# .so -- confirmed via a stale-vs-fresh timestamp/content mismatch. Fixed by
 # adding the same dependency directly onto rexgpu-nativevk, once it exists (it's
 # defined inside the SDK's own add_subdirectory(), which already ran by this
 # point in the file).
@@ -172,9 +170,9 @@ endif()
 # already reaches -- rex::runtime itself never actually depended on imgui.
 # Building the SDK from source (add_subdirectory/REXSDK_DIR mode) skips that
 # install step, so that flattening never happens and the true, previously-
-# masked missing dependency surfaces as `imgui.h` not found. Real fix: link
-# imgui directly, since renut is the real consumer, not through an
-# rexruntime/rexui detour that doesn't reflect renut's actual architecture.
+# masked missing dependency surfaces as `imgui.h` not found. Link imgui
+# directly, since renut is the real consumer, not through an rexruntime/rexui
+# detour that doesn't reflect renut's actual architecture.
 target_link_libraries(renut PRIVATE imgui::imgui)
 
 rexglue_setup_target(renut GPU_PLUGINS xenos nativevk)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,9 +171,20 @@ endif()
 # Building the SDK from source (add_subdirectory/REXSDK_DIR mode) skips that
 # install step, so that flattening never happens and the true, previously-
 # masked missing dependency surfaces as `imgui.h` not found. Link imgui
-# directly, since renut is the real consumer, not through an rexruntime/rexui
-# detour that doesn't reflect renut's actual architecture.
-target_link_libraries(renut PRIVATE imgui::imgui)
+# directly in that mode, since renut is the real consumer, not through an
+# rexruntime/rexui detour that doesn't reflect renut's actual architecture.
+#
+# Guarded with if(TARGET ...): `imgui` is a local OBJECT-library target
+# defined in rexglue-sdk-src/thirdparty/CMakeLists.txt, only visible when
+# the SDK is pulled in via add_subdirectory(REXSDK_DIR). It is deliberately
+# NOT in rexglue_install.cmake's REXGLUE_INSTALL_TARGETS, so find_package(rexglue)
+# (the normal prebuilt/installed-package path most users hit, confirmed
+# 2026-08-19 via a real "target imgui::imgui not found" configure failure)
+# never has this target at all -- and per the comment above, doesn't need it,
+# since that mode's headers are already flattened by `make install`.
+if(TARGET imgui::imgui)
+    target_link_libraries(renut PRIVATE imgui::imgui)
+endif()
 
 # GPU_PLUGINS is xenos only -- rexgpu-nativevk requires a rexglue-sdk
 # checkout with cmake/patches/rexglue_sdk_native_renderer.patch applied

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,25 +9,56 @@ project(renut LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# src/core/memory.cpp (byte-swap intrinsics, in rexglue-sdk) uses
+# _mm_shuffle_epi8 unconditionally, with no runtime CPU-feature dispatch --
+# it has always required SSSE3 at compile time. The prebuilt/extracted SDK
+# package this project normally uses was built on a toolchain whose default
+# target baseline already included SSSE3, which silently masked the missing
+# flag; building the SDK from source directly on a baseline x86-64 target
+# (no implied SSSE3) surfaces it as a real "always_inline function requires
+# target feature" compile error. Set from here (before add_subdirectory()
+# pulls the SDK in below) rather than editing rexglue-sdk's own
+# CMakeLists.txt, since add_compile_options() propagates into subdirectories
+# added afterward.
+if(NOT WIN32 AND CMAKE_SYSTEM_PROCESSOR MATCHES "AMD64|x86_64")
+    add_compile_options(-mssse3)
+endif()
+
 include(generated/rexglue.cmake)
 
+# Native-renderer shader pipeline (see docs/ai/research.md). Fetches
+# XenosRecomp and, if a guest shader dump already exists, regenerates the
+# recompiled shader cache at configure time. Must come after rexglue.cmake so
+# the SDK's own fmt::fmt / xxHash::xxhash targets exist first and XenosRecomp
+# reuses them instead of redefining them.
+include(cmake/rexglue_xenosrecomp.cmake)
 
-
+# Sources
 set(RENUT_SOURCES
     src/main.cpp
     src/renut_engine/hooks.cpp
     src/renut_engine/StopNSwap.cpp
-	src/renut_engine/frameHooks.cpp
+    src/renut_engine/frameHooks.cpp
     src/renut_engine/fixes/mullhwucrash.cpp
-	src/renut_engine/cvar_menu.cpp
-	src/renut_engine/FPS.cpp
-	src/renut_engine/shader_dump.cpp
-	src/renut_engine/texture_tools.cpp
-	src/renut_engine/frontend_debug_menu.cpp
-	src/renut_engine/townsfolk.cpp
-	src/renut_engine/mnk_controls.cpp
-
+    src/renut_engine/cvar_menu.cpp
+    src/renut_engine/FPS.cpp
+    src/renut_engine/game_activity_stats.cpp
+    src/renut_engine/render_hooks_stub.cpp
+    src/renut_engine/trace_stats.cpp
+    src/renut_engine/shader_dump.cpp
+    src/renut_engine/texture_tools.cpp
+    src/renut_engine/frontend_debug_menu.cpp
+    src/renut_engine/townsfolk.cpp
+    src/renut_engine/mnk_controls.cpp
 )
+
+if(UNIX AND NOT APPLE)
+    list(APPEND RENUT_SOURCES
+        src/renut_engine/linuxfixes/audio_client_guard.cpp
+        src/renut_engine/linuxfixes/audio_backend.cpp
+        src/renut_engine/linuxfixes/posix_file_access.cpp
+    )
+endif()
 
 if(WIN32)
 list(APPEND RENUT_SOURCES icon/app.rc)
@@ -36,4 +67,151 @@ else()
     add_executable(renut ${RENUT_SOURCES})
 endif()
 
-rexglue_setup_target(renut)
+# Native-renderer: convert ONE known-good real Banjo shader to HLSL via
+# XenosRecomp (see docs/ai/research.md Phase 0 item 3/4 and Phase 1).
+# Deliberately NOT the whole shader dump -- XenosRecomp's directory-scan mode
+# hard-aborts (some shaders even segfault it) on real Banjo shaders it can't
+# fully handle yet, and Phase 1 only needs one working shader. No-ops until a
+# `shaders/` guest dump exists next to the exe (produced by the
+# `dump_guest_shaders` cvar at runtime).
+renut_xenos_shader(renut
+    INPUT "${CMAKE_BINARY_DIR}/shaders/vs_67021cae68a26b46.bin"
+    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/generated/renut_xenos_shader_vs_67021cae68a26b46.hlsl"
+)
+
+# Real constant-table synthesis (2026-08-16, see
+# renut_synthesize_constant_tables()'s own comment in
+# cmake/rexglue_xenosrecomp.cmake for the full story): most real captured
+# Banjo-Kazooie shaders are missing the D3DX9 constant-reflection table
+# XenosRecomp needs (a real upstream XenosRecomp limitation, not a reNut
+# capture bug), so this step patches a build-tree COPY of the shader dump
+# with synthesized tables before the batch converter below ever sees it --
+# raises real conversion success from 36/253 to 101/253 shaders. Must run
+# before renut_xenos_shader_batch() so its SHADER_DUMP_DIR can point at the
+# patched copy instead of the raw dump.
+renut_synthesize_constant_tables(
+    SHADER_DUMP_DIR "${CMAKE_BINARY_DIR}/shaders"
+    REXSDK_DIR "${REXSDK_DIR}"
+    OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/shaders_synthesized"
+)
+
+# Real container synthesis from ucode-only captures (2026-08-16, see
+# renut_synthesize_containers_from_ucode()'s own comment in
+# cmake/rexglue_xenosrecomp.cmake for the full story): this game's actual
+# MOST-USED shaders never call D3D9's CreateVertexShader/CreatePixelShader
+# at all (loaded via GPU command-stream IM_LOAD packets instead), so
+# shader_dump.cpp's capture above structurally can never see them --
+# confirmed 0% overlap between that capture and real live draw identities.
+# renut_dump_ucode_hash's raw microcode captures (shaders_ucode_hash/) DO
+# cover them; this step rebuilds full containers for those and adds them
+# into the SAME shaders_synthesized/ directory the constant-table step
+# above just populated (that step clears+repopulates the directory from
+# shaders/ FIRST, this step only adds -- must run in exactly this order,
+# hence the explicit dependency below, or the ucode-derived containers
+# would get wiped). Verified end-to-end: unlocks 1492 additional real,
+# actually-drawn shaders (vs 101 from the D3D9-hook path alone).
+renut_synthesize_containers_from_ucode(
+    UCODE_DIR "${CMAKE_BINARY_DIR}/shaders_ucode_hash"
+    REXSDK_DIR "${REXSDK_DIR}"
+    OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/shaders_synthesized"
+)
+if(TARGET renut_synthesize_constant_tables_target AND TARGET renut_synthesize_containers_from_ucode_target)
+    add_dependencies(renut_synthesize_containers_from_ucode_target renut_synthesize_constant_tables_target)
+endif()
+
+# "Convert the important/common shaders" effort (see docs/ai/research.md):
+# batch-converts the WHOLE real guest shader dump (all shaders captured by
+# `dump_guest_shaders`, hundreds of real Banjo shaders) to compiled SPIR-V,
+# isolating crash-prone shaders per-subprocess so they're skipped instead of
+# aborting the whole cache (see tools/xenos_batch_convert.py). Consumed by
+# rexgpu-nativevk (src/graphics/CMakeLists.txt in the SDK checkout) via a
+# deterministic path check, NOT a normal target_sources() call -- that SDK
+# CMakeLists is processed by include(generated/rexglue.cmake) ABOVE, i.e.
+# before this custom command exists in the build graph, so a completely
+# fresh checkout needs ONE EXTRA reconfigure after the cache is first
+# generated (`cmake --build . --target renut_xenos_shader_batch` or just a
+# normal build followed by re-running cmake) before rexgpu-nativevk picks it up
+# -- same two-step pattern renut_xenos_shader() above already requires for
+# its single-shader HLSL output.
+#
+# SHADER_DUMP_DIR points at the constant-table-patched COPY (see above), not
+# the raw ${CMAKE_BINARY_DIR}/shaders capture -- the real, unpatched dump is
+# left untouched.
+renut_xenos_shader_batch(renut
+    SHADER_DUMP_DIR "${CMAKE_CURRENT_BINARY_DIR}/shaders_synthesized"
+    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/generated/renut_xenos_shader_cache.cpp"
+    MANIFEST "${CMAKE_CURRENT_BINARY_DIR}/generated/renut_xenos_shader_cache_manifest.txt"
+)
+if(TARGET renut_synthesize_constant_tables_target AND TARGET renut_xenos_shader_batch)
+    add_dependencies(renut_xenos_shader_batch renut_synthesize_constant_tables_target)
+endif()
+if(TARGET renut_synthesize_containers_from_ucode_target AND TARGET renut_xenos_shader_batch)
+    add_dependencies(renut_xenos_shader_batch renut_synthesize_containers_from_ucode_target)
+endif()
+
+# Real bug found+fixed 2026-08-16: renut_xenos_shader_batch() above only wired
+# its DEPENDS onto `renut` (the top-level executable target), not onto
+# `rexgpu-nativevk` (the SDK-side plugin .so that actually #includes the
+# generated cache .cpp -- confirmed via renut_xenos_pipeline_cache.cpp's own
+# __has_include check). Real, reproduced symptom: after regenerating the
+# cache with genuinely new/changed content, `renut` relinks (its own real
+# dependency is satisfied) but `rexgpu-nativevk` reports "no work to do" and
+# keeps shipping the STALE cache baked into its already-built .so -- confirmed
+# via a real stale-vs-fresh timestamp/content mismatch, not a guess. Fixed by
+# adding the same dependency directly onto rexgpu-nativevk, once it exists (it's
+# defined inside the SDK's own add_subdirectory(), which already ran by this
+# point in the file).
+if(TARGET rexgpu-nativevk AND TARGET renut_xenos_shader_batch)
+    add_dependencies(rexgpu-nativevk renut_xenos_shader_batch)
+endif()
+
+# renut's own sources (FPS.cpp, mnk_controls.cpp, renut_logging_overlay.h,
+# etc.) #include "imgui.h" directly. In the prebuilt/extracted SDK package
+# this normally worked because `make install` flattens ALL SDK+thirdparty
+# headers into one include/ dir that rex::runtime's PUBLIC include path
+# already reaches -- rex::runtime itself never actually depended on imgui.
+# Building the SDK from source (add_subdirectory/REXSDK_DIR mode) skips that
+# install step, so that flattening never happens and the true, previously-
+# masked missing dependency surfaces as `imgui.h` not found. Real fix: link
+# imgui directly, since renut is the real consumer, not through an
+# rexruntime/rexui detour that doesn't reflect renut's actual architecture.
+target_link_libraries(renut PRIVATE imgui::imgui)
+
+rexglue_setup_target(renut GPU_PLUGINS xenos nativevk)
+target_compile_definitions(renut PRIVATE VK_ENABLE_BETA_EXTENSIONS)
+if(UNIX AND NOT APPLE)
+    target_compile_definitions(renut PRIVATE VK_USE_PLATFORM_XCB_KHR)
+endif()
+
+if(UNIX AND NOT APPLE)
+    # src/renut_engine/linuxfixes/posix_file_access.cpp redefines
+    # rex::filesystem::FileHandle::OpenExisting to fix the broken O_RDONLY/
+    # O_WRONLY/O_RDWR bitwise-OR in the SDK's POSIX backend. Every caller lives
+    # inside librexruntimerd.so, so our definition only wins if it is in renut's
+    # dynamic symbol table -- the executable is searched first when the library's
+    # PLT entry is resolved. Export just that one symbol rather than using
+    # -rdynamic, which would export everything.
+    #
+    # If a toolchain change ever alters this mangled name, the override silently
+    # stops applying, so the build checks for it below.
+    set(RENUT_OPENEXISTING_SYMBOL
+        "_ZN3rex10filesystem10FileHandle12OpenExistingERKNSt10filesystem7__cxx114pathEjb")
+    target_link_options(renut PRIVATE
+        "-Wl,--export-dynamic-symbol=${RENUT_OPENEXISTING_SYMBOL}")
+
+    # Same mechanism, for RenutEmitTraceRow (src/renut_engine/trace_stats.cpp):
+    # the nativevk/xenos plugin calls this weak hook (see
+    # rex/graphics/vulkan/renut_trace_hook.h in the SDK) once per frame with
+    # timing data for the "Renderer performance" overlay. extern "C" means no
+    # mangled name to keep in sync here.
+    target_link_options(renut PRIVATE
+        "-Wl,--export-dynamic-symbol=RenutEmitTraceRow")
+
+    # Fail loudly if the symbol did not make it into .dynsym.
+    add_custom_command(TARGET renut POST_BUILD
+        COMMAND ${CMAKE_COMMAND}
+                -DRENUT_BINARY=$<TARGET_FILE:renut>
+                -DRENUT_SYMBOL=${RENUT_OPENEXISTING_SYMBOL}
+                -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/check_exported_symbol.cmake
+        VERBATIM)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ set(RENUT_SOURCES
     src/renut_engine/FPS.cpp
     src/renut_engine/game_activity_stats.cpp
     src/renut_engine/render_hooks_stub.cpp
+    src/renut_engine/nativevk_phase0.cpp
     src/renut_engine/trace_stats.cpp
     src/renut_engine/shader_dump.cpp
     src/renut_engine/texture_tools.cpp
@@ -218,9 +219,11 @@ if(UNIX AND NOT APPLE)
 
     # Same mechanism, for RenutEmitTraceRow (src/renut_engine/trace_stats.cpp):
     # the nativevk/xenos plugin calls this weak hook (see
-    # rex/graphics/vulkan/renut_trace_hook.h in the SDK) once per frame with
-    # timing data for the "Renderer performance" overlay. extern "C" means no
-    # mangled name to keep in sync here.
+    # src/renut_engine/renut_trace_hook.h -- reNut's own copy of the SDK-side
+    # header of the same name, kept byte-identical; see that file's own
+    # comment for why it isn't just #include'd from the SDK checkout) once
+    # per frame with timing data for the "Renderer performance" overlay.
+    # extern "C" means no mangled name to keep in sync here.
     target_link_options(renut PRIVATE
         "-Wl,--export-dynamic-symbol=RenutEmitTraceRow")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,7 +175,15 @@ endif()
 # detour that doesn't reflect renut's actual architecture.
 target_link_libraries(renut PRIVATE imgui::imgui)
 
-rexglue_setup_target(renut GPU_PLUGINS xenos nativevk)
+# GPU_PLUGINS is xenos only -- rexgpu-nativevk requires a rexglue-sdk
+# checkout with cmake/patches/rexglue_sdk_native_renderer.patch applied
+# (see docs/ai/nativevk.md), which most builds (including any plain/
+# unpatched installed SDK package) don't have, and rexglue_configure_target()
+# hard-errors if a listed plugin's target doesn't exist. The native renderer
+# is being rebuilt with zero rexglue-sdk dependency (see
+# docs/ai/archive/native-renderer-rewrite-plan.md); until that lands, don't
+# require the SDK-dependent plugin for a normal build.
+rexglue_setup_target(renut GPU_PLUGINS xenos)
 target_compile_definitions(renut PRIVATE VK_ENABLE_BETA_EXTENSIONS)
 if(UNIX AND NOT APPLE)
     target_compile_definitions(renut PRIVATE VK_USE_PLATFORM_XCB_KHR)

--- a/cmake/apply_xenosrecomp_patch.cmake
+++ b/cmake/apply_xenosrecomp_patch.cmake
@@ -1,0 +1,34 @@
+# Idempotent patch apply for the XenosRecomp FetchContent step (see
+# rexglue_xenosrecomp.cmake). A second configure (already-patched source dir,
+# FetchContent skips re-cloning) must not fail -- `git apply --check`
+# returning non-zero means the patch is already applied, so skip re-applying.
+#
+# Written as a portable CMake script rather than `sh -c "... && ... || true"`:
+# the shell-based version only worked on Linux/macOS, since `sh` is not on
+# PATH by default on Windows -- broke the whole FetchContent populate step
+# there (patch never applies, build fails at the populate subbuild instead).
+# execute_process() needs no shell at all, so this works identically
+# everywhere CMake itself runs.
+
+find_program(RENUT_GIT NAMES git)
+if(NOT RENUT_GIT)
+    message(FATAL_ERROR "git not found - cannot apply ${PATCH_FILE}")
+endif()
+
+execute_process(
+    COMMAND "${RENUT_GIT}" apply --check "${PATCH_FILE}"
+    RESULT_VARIABLE check_result
+    OUTPUT_QUIET
+    ERROR_QUIET
+)
+
+if(check_result EQUAL 0)
+    execute_process(
+        COMMAND "${RENUT_GIT}" apply "${PATCH_FILE}"
+        RESULT_VARIABLE apply_result
+    )
+    if(NOT apply_result EQUAL 0)
+        message(FATAL_ERROR "Failed to apply ${PATCH_FILE}")
+    endif()
+    message(STATUS "Applied ${PATCH_FILE}")
+endif()

--- a/cmake/check_exported_symbol.cmake
+++ b/cmake/check_exported_symbol.cmake
@@ -1,0 +1,36 @@
+# Verifies that a symbol reached the built binary's dynamic symbol table.
+#
+# Used for the rex::filesystem::FileHandle::OpenExisting override in
+# src/renut_engine/linuxfixes/posix_file_access.cpp: that fix only takes effect
+# if the symbol is exported, and a silent failure would quietly bring back the
+# save-data corruption. Better to break the build than to ship a no-op fix.
+
+find_program(RENUT_NM NAMES nm llvm-nm)
+if(NOT RENUT_NM)
+    message(WARNING "nm not found - skipping exported symbol check for ${RENUT_SYMBOL}")
+    return()
+endif()
+
+execute_process(
+    COMMAND ${RENUT_NM} -D --defined-only ${RENUT_BINARY}
+    OUTPUT_VARIABLE nm_output
+    ERROR_VARIABLE nm_error
+    RESULT_VARIABLE nm_result)
+
+if(NOT nm_result EQUAL 0)
+    message(WARNING "nm failed on ${RENUT_BINARY}: ${nm_error}")
+    return()
+endif()
+
+if(NOT nm_output MATCHES "${RENUT_SYMBOL}")
+    message(FATAL_ERROR
+        "${RENUT_SYMBOL} is missing from the dynamic symbol table of ${RENUT_BINARY}.\n"
+        "The FileHandle::OpenExisting override in "
+        "src/renut_engine/linuxfixes/posix_file_access.cpp will NOT take effect, "
+        "and save data will be corrupted again.\n"
+        "The mangled name has most likely changed - re-derive it with:\n"
+        "  nm -D --defined-only <path to librexruntimerd.so> | grep FileHandle12OpenExisting\n"
+        "and update RENUT_OPENEXISTING_SYMBOL in CMakeLists.txt.")
+endif()
+
+message(STATUS "Verified exported override symbol: ${RENUT_SYMBOL}")

--- a/cmake/patches/rexglue_sdk_native_renderer.patch
+++ b/cmake/patches/rexglue_sdk_native_renderer.patch
@@ -76,14 +76,14 @@ index 0000000..fa3bb44
 +
 +}  // namespace rex::graphics::nativevk
 diff --git a/include/rex/graphics/vulkan/command_processor.h b/include/rex/graphics/vulkan/command_processor.h
-index 4b76791..1512d93 100644
+index 4b76791..b1b8a7b 100644
 --- a/include/rex/graphics/vulkan/command_processor.h
 +++ b/include/rex/graphics/vulkan/command_processor.h
 @@ -208,6 +208,67 @@ class VulkanCommandProcessor : public CommandProcessor {
    // scope. Submission must be open.
    void EndRenderPass();
  
-+  // Native-renderer Phase 1 (see PLAN_native_renderer.md): the render pass
++  // Native-renderer Phase 1: the render pass
 +  // currently open in the deferred command buffer, if any -- needed so an
 +  // externally-bound pipeline (see BindExternalGraphicsPipeline) can be
 +  // created against the SAME render pass a real guest draw is already
@@ -91,7 +91,7 @@ index 4b76791..1512d93 100644
 +  VkRenderPass current_render_pass() const { return current_render_pass_; }
 +
 +  // Native-renderer "convert the important/common shaders" (see
-+  // PLAN_native_renderer.md nativevk_pipeline_cache.cpp): real guest
++  // docs/ai/research.md, nativevk_xenos_pipeline_cache.cpp): real guest
 +  // vertex-fetch-constant lookups (register_file()) and the real VkBuffer
 +  // backing all of guest memory (shared_memory()->buffer()) -- needed to
 +  // bind a native pipeline's vertex input to the SAME bytes the stock
@@ -101,7 +101,7 @@ index 4b76791..1512d93 100644
 +  VulkanSharedMemory* shared_memory() const { return shared_memory_.get(); }
 +  bool in_render_pass() const { return in_render_pass_; }
 +
-+  // Real bug found+fixed (2026-08-17): stock vertex shaders (spirv_translator.cpp)
++  // Real bug found+fixed: stock vertex shaders (spirv_translator.cpp)
 +  // unconditionally apply a per-draw `oPos.xyz = oPos.xyz * ndc_scale + ndc_offset
 +  // * oPos.w` correction to every vertex position -- it's what converts the
 +  // guest's own clip-space output into the host's actual viewport-relative NDC,
@@ -184,8 +184,69 @@ index 4b76791..1512d93 100644
    // Dynamic fixed-function depth bias, blend constants, stencil state are
    // applicable only to the render target implementations where they are
    // actually involved.
+diff --git a/include/rex/graphics/vulkan/renut_trace_hook.h b/include/rex/graphics/vulkan/renut_trace_hook.h
+new file mode 100644
+index 0000000..8d6795e
+--- /dev/null
++++ b/include/rex/graphics/vulkan/renut_trace_hook.h
+@@ -0,0 +1,55 @@
++#pragma once
++
++// Minimal, additive extension point: VulkanCommandProcessor times a handful
++// of its own existing phases (already-real call sites -- primitive
++// processing, texture/sampler/render-target/pipeline setup, draw submission,
++// GPU fence waits) and hands the numbers off once per frame via this single
++// weak hook. All aggregation, storage, and display (the reNut "Renderer
++// performance" overlay) lives in reNut's own code, which defines the strong
++// symbol and exports it to the plugin -- same pattern as
++// src/renut_engine/linuxfixes/*.cpp's REX_HOOK overrides, just in the other
++// direction (SDK calling out to the host exe instead of the host exe
++// overriding an SDK symbol). rexgpu-xenos links and runs identically whether
++// or not a host defines this symbol -- the call site checks it is non-null
++// first.
++
++#include <cstdint>
++
++extern "C" {
++
++struct RenutTraceRow {
++  uint64_t frame;
++  uint64_t draws;
++  double frame_ms;
++  double issuedraw_ms;
++  double ns_per_draw;
++  double prim_ms;
++  double samp_ms;
++  double tex_ms;
++  double rt_ms;
++  double pipe_ms;
++  double shadertrans_ms;
++  double sysconst_ms;
++  double vfetch_ms;
++  double dyn_ms;
++  double bind_ms;
++  double memexport_ms;
++  double renderpass_enter_ms;
++  double drawcmd_ms;
++  double gpuwait_ms;
++  uint64_t gpuwait_n;
++  double swap_ms;
++  double issuecopy_ms;
++  uint64_t issuecopy_n;
++  uint64_t depthonly;
++  uint64_t nopixelshader;
++};
++
++// Defined by reNut's own code (src/renut_engine/trace_stats.cpp), exported
++// from the renut executable's dynamic symbol table so the plugin's PLT entry
++// resolves to it. Declared weak so rexgpu-xenos and any standalone build of
++// rexgpu-nativevk (without a host defining it) still link and run -- the call
++// site always null-checks before calling.
++void RenutEmitTraceRow(const RenutTraceRow* row) __attribute__((weak));
++
++}
 diff --git a/include/rex/ui/vulkan/device.h b/include/rex/ui/vulkan/device.h
-index 947817f..630353b 100644
+index 947817f..24a8350 100644
 --- a/include/rex/ui/vulkan/device.h
 +++ b/include/rex/ui/vulkan/device.h
 @@ -123,6 +123,35 @@ class VulkanDevice {
@@ -193,14 +254,14 @@ index 947817f..630353b 100644
      bool scalarBlockLayout = false;
  
 +    // VK_KHR_buffer_device_address (#246, promoted to 1.2). Native-renderer
-+    // Phase 1 (see PLAN_native_renderer.md): XenosRecomp's generated SPIR-V
++    // Phase 1: XenosRecomp's generated SPIR-V
 +    // shaders address constant buffers via vk::RawBufferLoad from GPU virtual
 +    // addresses passed as push constants, which requires this feature.
 +
 +    bool bufferDeviceAddress = false;
 +
 +    // VK_EXT_descriptor_indexing (#162, promoted to 1.2). Native-renderer
-+    // "convert the important/common shaders" (see PLAN_native_renderer.md):
++    // "convert the important/common shaders":
 +    // XenosRecomp's generated shaders bind textures/samplers via a bindless
 +    // descriptor array (`Texture2D<float4> g_Texture2DDescriptorHeap[] :
 +    // register(t0, space0)`, indexed by a real descriptor index baked into
@@ -247,12 +308,12 @@ index 947817f..630353b 100644
    };
 diff --git a/include/rex/ui/vulkan/functions/device_1_2_khr_buffer_device_address.inc b/include/rex/ui/vulkan/functions/device_1_2_khr_buffer_device_address.inc
 new file mode 100644
-index 0000000..03335e9
+index 0000000..64a8cb0
 --- /dev/null
 +++ b/include/rex/ui/vulkan/functions/device_1_2_khr_buffer_device_address.inc
 @@ -0,0 +1,5 @@
 +// VK_KHR_buffer_device_address functions. Promoted to Vulkan 1.2 core.
-+// Native-renderer Phase 1 (see PLAN_native_renderer.md): optional -- loaded
++// Native-renderer Phase 1: optional -- loaded
 +// only when the bufferDeviceAddress FEATURE was actually enabled (see
 +// vulkan_device.cpp), never required for stock GPU emulation.
 +XE_UI_VULKAN_FUNCTION_PROMOTED(vkGetBufferDeviceAddressKHR, vkGetBufferDeviceAddress)
@@ -267,7 +328,7 @@ index 0000000..b07e948
 +XE_UI_VULKAN_FUNCTION_PROMOTED(vkCmdSetCullModeEXT, vkCmdSetCullMode)
 +XE_UI_VULKAN_FUNCTION_PROMOTED(vkCmdSetFrontFaceEXT, vkCmdSetFrontFace)
 diff --git a/src/graphics/CMakeLists.txt b/src/graphics/CMakeLists.txt
-index 9179574..86ca286 100644
+index 9179574..9bdf13b 100644
 --- a/src/graphics/CMakeLists.txt
 +++ b/src/graphics/CMakeLists.txt
 @@ -142,3 +142,128 @@ if(REXGLUE_USE_D3D12)
@@ -290,19 +351,19 @@ index 9179574..86ca286 100644
 +        nativevk/plugin_main.cpp
 +        nativevk/graphics_system.cpp
 +        nativevk/command_processor.cpp
-+        # Native-renderer Phase 1 (see PLAN_native_renderer.md): nativevk-only,
++        # Native-renderer Phase 1: nativevk-only,
 +        # never built into rexgpu-xenos, which stays a pristine A/B reference.
 +        vulkan/nativevk_phase1_native_draw.cpp
 +        # "Convert the important/common shaders": generalized pipeline cache,
 +        # additive to Phase 1's single hardcoded pipeline above.
 +        vulkan/nativevk_xenos_pipeline_cache.cpp
-+        # Real-time native-shader debug panel (2026-08-16): see
++        # Real-time native-shader debug panel: see
 +        # nativevk_xenos_pipeline_cache.h's GetDebugShaderPairs()/
 +        # SetDebugShaderPairEnabled() and this file's own header comment.
 +        vulkan/nativevk_shader_debug_panel.cpp
 +    )
 +
-+    # "Convert the important/common shaders" (see PLAN_native_renderer.md):
++    # "Convert the important/common shaders":
 +    # the generated, decompressed multi-shader SPIR-V cache, produced by
 +    # reNut's own top-level build (renut_xenos_shader_batch() in
 +    # cmake/rexglue_xenosrecomp.cmake + tools/xenos_batch_convert.py +
@@ -340,7 +401,7 @@ index 9179574..86ca286 100644
 +        ${REXGLUE_ROOT}
 +    )
 +
-+    # Native-renderer shader debug panel (2026-08-16, see
++    # Native-renderer shader debug panel (see
 +    # nativevk_shader_debug_panel.cpp): needs imgui.h for real ImGui:: calls.
 +    # Deliberately NOT linking imgui::imgui here -- it's a real OBJECT
 +    # library (thirdparty/CMakeLists.txt), and rexruntime already contains
@@ -371,7 +432,7 @@ index 9179574..86ca286 100644
 +    # keeps stock behaviour and stays a valid A/B reference.
 +    target_compile_definitions(rexgpu-nativevk PRIVATE NATIVEVK_OPTIMISATIONS=1)
 +
-+    # Native-renderer Phase 1 (see PLAN_native_renderer.md): needed because
++    # Native-renderer Phase 1: needed because
 +    # nativevk_phase1_native_draw.cpp's include chain reaches
 +    # vulkan/vulkan_to_string.hpp, which vulkan_enums.hpp guards its AMDX/beta
 +    # extension enumerators behind this define -- the reNut host executable
@@ -401,7 +462,7 @@ index 9179574..86ca286 100644
 +endif()
 diff --git a/src/graphics/nativevk/command_processor.cpp b/src/graphics/nativevk/command_processor.cpp
 new file mode 100644
-index 0000000..1f40a05
+index 0000000..069c193
 --- /dev/null
 +++ b/src/graphics/nativevk/command_processor.cpp
 @@ -0,0 +1,82 @@
@@ -433,7 +494,7 @@ index 0000000..1f40a05
 +    rex::graphics::vulkan::VulkanShader* pixel_shader,
 +    const rex::graphics::PrimitiveProcessor::ProcessingResult& primitive_processing_result,
 +    VkBuffer index_buffer, VkDeviceSize index_buffer_offset, VkIndexType index_type) {
-+  // TEMP DIAGNOSTIC (2026-08-18): confirms whether this override is being
++  // TEMP DIAGNOSTIC: confirms whether this override is being
 +  // reached at all, and with what pixel_shader null-ness, while tracking
 +  // down why the native shader debug panel stopped appearing after the
 +  // TryNativeDraw refactor. Remove once resolved.
@@ -449,7 +510,7 @@ index 0000000..1f40a05
 +                  null_pixel_shader);
 +    }
 +  }
-+  // "Convert the important/common shaders" (see PLAN_native_renderer.md):
++  // "Convert the important/common shaders":
 +  // generalized pipeline cache, tried FIRST -- any shader pair that
 +  // successfully batch-converted (tools/xenos_batch_convert.py) gets a real
 +  // native pipeline here, not just Phase 1's one hand-picked pair below.
@@ -467,7 +528,7 @@ index 0000000..1f40a05
 +    // already logged) -- fall through rather than silently dropping this draw.
 +  }
 +
-+  // Native-renderer Phase 1 (see PLAN_native_renderer.md): substitute the ONE
++  // Native-renderer Phase 1: substitute the ONE
 +  // chosen draw with a hand-built native Vulkan pipeline instead of the
 +  // normal Xenos-translated pipeline/draw, kept as a simple, always-working
 +  // observability check for the native draw mechanism itself.
@@ -580,13 +641,207 @@ index 0000000..bd2e174
 +  return new rex::graphics::nativevk::NativeVkGraphicsSystem();
 +}
 diff --git a/src/graphics/vulkan/command_processor.cpp b/src/graphics/vulkan/command_processor.cpp
-index a40436e..ba0779c 100644
+index a40436e..ca12cd8 100644
 --- a/src/graphics/vulkan/command_processor.cpp
 +++ b/src/graphics/vulkan/command_processor.cpp
-@@ -3947,6 +3947,11 @@ bool VulkanCommandProcessor::IssueDraw(xenos::PrimitiveType prim_type, uint32_t
+@@ -36,9 +36,11 @@
+ #include <rex/graphics/vulkan/command_processor.h>
+ #include <rex/graphics/vulkan/pipeline_cache.h>
+ #include <rex/graphics/vulkan/render_target_cache.h>
++#include <rex/graphics/vulkan/renut_trace_hook.h>
+ #include <rex/graphics/vulkan/shader.h>
+ #include <rex/graphics/vulkan/shared_memory.h>
+ #include <rex/graphics/xenos.h>
++#include <chrono>
+ #include <rex/kernel/xboxkrnl/video.h>
+ #include <rex/types.h>
+ #include <rex/memory/utils.h>
+@@ -73,6 +75,31 @@ namespace rex::graphics::vulkan {
+ 
+ namespace {
+ 
++// Per-frame accumulators for the reNut "Renderer performance" overlay (see
++// renut_trace_hook.h). Reset and handed off once per frame from IssueSwap.
++// Single GPU thread, same assumption the rest of this file already makes
++// (no synchronization elsewhere in VulkanCommandProcessor either).
++RenutTraceRow g_renut_trace_row{};
++uint64_t g_renut_trace_frame_index = 0;
++std::chrono::steady_clock::time_point g_renut_trace_frame_start;
++bool g_renut_trace_frame_start_valid = false;
++
++// RAII scope timer: adds elapsed wall time in milliseconds to *out on
++// destruction, so a phase's cost is captured regardless of which of a
++// function's several return points is taken.
++class RenutScopedTimer {
++ public:
++  explicit RenutScopedTimer(double* out) : out_(out), start_(std::chrono::steady_clock::now()) {}
++  ~RenutScopedTimer() {
++    *out_ += std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - start_)
++                 .count();
++  }
++
++ private:
++  double* out_;
++  std::chrono::steady_clock::time_point start_;
++};
++
+ // glslang default built-in resource limits.
+ constexpr TBuiltInResource kGlslangDefaultTBuiltInResource = {
+     /* .maxLights = */ 32,
+@@ -2285,6 +2312,33 @@ void VulkanCommandProcessor::OnGammaRampPWLValueWritten() {
+ void VulkanCommandProcessor::IssueSwap(uint32_t frontbuffer_ptr, uint32_t frontbuffer_width,
+                                        uint32_t frontbuffer_height) {
+   SCOPE_profile_cpu_f("gpu");
++
++  // Frame boundary for the reNut "Renderer performance" overlay (see
++  // renut_trace_hook.h): hand off everything accumulated since the last
++  // swap, then start counting the next frame. Emitting here (rather than at
++  // the end of this function) means a frame that returns early below still
++  // reports the phases it actually ran before bailing.
++  {
++    const auto now = std::chrono::steady_clock::now();
++    if (g_renut_trace_frame_start_valid) {
++      g_renut_trace_row.frame_ms =
++          std::chrono::duration<double, std::milli>(now - g_renut_trace_frame_start).count();
++    }
++    g_renut_trace_row.frame = g_renut_trace_frame_index;
++    g_renut_trace_row.ns_per_draw =
++        g_renut_trace_row.draws
++            ? (g_renut_trace_row.issuedraw_ms * 1000000.0) / double(g_renut_trace_row.draws)
++            : 0.0;
++    if (RenutEmitTraceRow) {
++      RenutEmitTraceRow(&g_renut_trace_row);
++    }
++    g_renut_trace_row = RenutTraceRow{};
++    ++g_renut_trace_frame_index;
++    g_renut_trace_frame_start = now;
++    g_renut_trace_frame_start_valid = true;
++  }
++  RenutScopedTimer renut_swap_timer(&g_renut_trace_row.swap_ms);
++
+   vertex_buffers_in_sync_[0] = 0;
+   vertex_buffers_in_sync_[1] = 0;
+ 
+@@ -3607,6 +3661,9 @@ bool VulkanCommandProcessor::IssueDraw(xenos::PrimitiveType prim_type, uint32_t
+   SCOPE_profile_cpu_f("gpu");
+ #endif  // XE_GPU_FINE_GRAINED_DRAW_SCOPES
+ 
++  ++g_renut_trace_row.draws;
++  RenutScopedTimer renut_issuedraw_timer(&g_renut_trace_row.issuedraw_ms);
++
+   const RegisterFile& regs = *register_file_;
+   (void)index_buffer_info;
+   auto draw_fail = [&](const char* stage) {
+@@ -3721,8 +3778,11 @@ bool VulkanCommandProcessor::IssueDraw(xenos::PrimitiveType prim_type, uint32_t
+     }
+ 
+     // Process primitives.
+-    if (!primitive_processor_->Process(primitive_processing_result)) {
+-      return draw_fail("primitive_processing");
++    {
++      RenutScopedTimer renut_prim_timer(&g_renut_trace_row.prim_ms);
++      if (!primitive_processor_->Process(primitive_processing_result)) {
++        return draw_fail("primitive_processing");
++      }
+     }
+     if (!primitive_processing_result.host_draw_vertex_count) {
+       // Nothing to draw.
+@@ -3766,9 +3826,12 @@ bool VulkanCommandProcessor::IssueDraw(xenos::PrimitiveType prim_type, uint32_t
+         pixel_shader ? static_cast<VulkanShader::VulkanTranslation*>(
+                            pixel_shader->GetOrCreateTranslation(pixel_shader_modification.value))
+                      : nullptr;
+-    if (!pipeline_cache_->EnsureShadersTranslated(vertex_shader_translation,
+-                                                  pixel_shader_translation)) {
+-      return draw_fail("shader_translation");
++    {
++      RenutScopedTimer renut_shadertrans_timer(&g_renut_trace_row.shadertrans_ms);
++      if (!pipeline_cache_->EnsureShadersTranslated(vertex_shader_translation,
++                                                    pixel_shader_translation)) {
++        return draw_fail("shader_translation");
++      }
+     }
+ 
+     // Obtain the samplers. Note that the bindings don't depend on the shader
+@@ -3779,6 +3842,7 @@ bool VulkanCommandProcessor::IssueDraw(xenos::PrimitiveType prim_type, uint32_t
+     // TODO(Triang3l): Sampler caching and reuse for adjacent draws within one
+     // submission.
+     uint32_t samplers_overflowed_count = 0;
++    { RenutScopedTimer renut_samp_timer(&g_renut_trace_row.samp_ms);
+     for (uint32_t j = 0; j < 2; ++j) {
+       std::vector<std::pair<VulkanTextureCache::SamplerParameters, VkSampler>>& shader_samplers =
+           j ? current_samplers_pixel_ : current_samplers_vertex_;
+@@ -3822,6 +3886,7 @@ bool VulkanCommandProcessor::IssueDraw(xenos::PrimitiveType prim_type, uint32_t
+         }
+       }
+     }
++    }
+     if (!samplers_overflowed_count) {
+       break;
+     }
+@@ -3848,13 +3913,18 @@ bool VulkanCommandProcessor::IssueDraw(xenos::PrimitiveType prim_type, uint32_t
+   uint32_t used_texture_mask =
+       vertex_shader->GetUsedTextureMaskAfterTranslation() |
+       (pixel_shader != nullptr ? pixel_shader->GetUsedTextureMaskAfterTranslation() : 0);
+-  texture_cache_->RequestTextures(used_texture_mask);
++  { RenutScopedTimer renut_tex_timer(&g_renut_trace_row.tex_ms);
++    texture_cache_->RequestTextures(used_texture_mask);
++  }
+ 
+   const VulkanPipelineCache::PipelineLayoutProvider* pipeline_layout_provider;
+   // Set up the render targets - this may perform dispatches and draws.
+-  if (!render_target_cache_->Update(is_rasterization_done, normalized_depth_control,
+-                                    normalized_color_mask, *vertex_shader)) {
+-    return draw_fail("render_target_update");
++  {
++    RenutScopedTimer renut_rt_timer(&g_renut_trace_row.rt_ms);
++    if (!render_target_cache_->Update(is_rasterization_done, normalized_depth_control,
++                                      normalized_color_mask, *vertex_shader)) {
++      return draw_fail("render_target_update");
++    }
+   }
+ 
+   // Create the pipeline (for this, need the render pass from the render target
+@@ -3862,18 +3932,21 @@ bool VulkanCommandProcessor::IssueDraw(xenos::PrimitiveType prim_type, uint32_t
+   // textures.
+   VkPipeline pipeline;
+   void* pipeline_handle = nullptr;
+-  if (!pipeline_cache_->ConfigurePipeline(vertex_shader_translation, pixel_shader_translation,
+-                                          primitive_processing_result, normalized_depth_control,
+-                                          normalized_color_mask,
+-                                          render_target_cache_->last_update_render_pass_key(),
+-                                          pipeline, pipeline_layout_provider, &pipeline_handle)) {
+-    return draw_fail("configure_pipeline");
+-  }
+   bool pipeline_is_placeholder = false;
+-  // Reload the current handle state to observe async hot-swap completions that
+-  // may happen between pipeline configuration and binding.
+-  pipeline_cache_->GetPipelineAndLayoutByHandle(pipeline_handle, pipeline, pipeline_layout_provider,
+-                                                &pipeline_is_placeholder);
++  {
++    RenutScopedTimer renut_pipe_timer(&g_renut_trace_row.pipe_ms);
++    if (!pipeline_cache_->ConfigurePipeline(vertex_shader_translation, pixel_shader_translation,
++                                            primitive_processing_result, normalized_depth_control,
++                                            normalized_color_mask,
++                                            render_target_cache_->last_update_render_pass_key(),
++                                            pipeline, pipeline_layout_provider, &pipeline_handle)) {
++      return draw_fail("configure_pipeline");
++    }
++    // Reload the current handle state to observe async hot-swap completions that
++    // may happen between pipeline configuration and binding.
++    pipeline_cache_->GetPipelineAndLayoutByHandle(pipeline_handle, pipeline, pipeline_layout_provider,
++                                                  &pipeline_is_placeholder);
++  }
+   if (REXCVAR_GET(async_shader_compilation) && pipeline_is_placeholder) {
+     frame_used_async_placeholder_pipeline_ = true;
+     return true;
+@@ -3946,7 +4019,14 @@ bool VulkanCommandProcessor::IssueDraw(xenos::PrimitiveType prim_type, uint32_t
+       host_render_targets_used, pixel_shader && pixel_shader->writes_depth(), viewport_info);
  
    // Update dynamic graphics pipeline state.
-   UpdateDynamicState(viewport_info, primitive_polygonal, normalized_depth_control);
+-  UpdateDynamicState(viewport_info, primitive_polygonal, normalized_depth_control);
++  { RenutScopedTimer renut_dyn_timer(&g_renut_trace_row.dyn_ms);
++    UpdateDynamicState(viewport_info, primitive_polygonal, normalized_depth_control);
++  }
 +  // Kept for last_viewport_info() -- see its own header comment. Plugins
 +  // that substitute a native pipeline via TryNativeDraw() need the exact
 +  // same viewport transform this draw already computed, rather than
@@ -595,8 +850,69 @@ index a40436e..ba0779c 100644
  
    auto vgt_draw_initiator = regs.Get<reg::VGT_DRAW_INITIATOR>();
  
-@@ -4129,6 +4134,53 @@ bool VulkanCommandProcessor::IssueDraw(xenos::PrimitiveType prim_type, uint32_t
-       render_target_cache_->last_update_framebuffer());
+@@ -3980,18 +4060,24 @@ bool VulkanCommandProcessor::IssueDraw(xenos::PrimitiveType prim_type, uint32_t
+   }
+ 
+   // Update system constants before uploading them.
+-  UpdateSystemConstantValues(primitive_polygonal, primitive_processing_result,
+-                             shader_32bit_index_dma, 0, viewport_info, used_texture_mask,
+-                             normalized_depth_control, normalized_color_mask);
++  { RenutScopedTimer renut_sysconst_timer(&g_renut_trace_row.sysconst_ms);
++    UpdateSystemConstantValues(primitive_polygonal, primitive_processing_result,
++                               shader_32bit_index_dma, 0, viewport_info, used_texture_mask,
++                               normalized_depth_control, normalized_color_mask);
++  }
+ 
+   // Update uniform buffers and descriptor sets after binding the pipeline with
+   // the new layout.
+-  if (!UpdateBindings(vertex_shader, pixel_shader)) {
+-    return draw_fail("update_bindings");
++  {
++    RenutScopedTimer renut_bind_timer(&g_renut_trace_row.bind_ms);
++    if (!UpdateBindings(vertex_shader, pixel_shader)) {
++      return draw_fail("update_bindings");
++    }
+   }
+ 
+   // Ensure vertex buffers are resident.
+   const Shader::ConstantRegisterMap& constant_map_vertex = vertex_shader->constant_register_map();
++  { RenutScopedTimer renut_vfetch_timer(&g_renut_trace_row.vfetch_ms);
+   for (uint32_t i = 0; i < rex::countof(constant_map_vertex.vertex_fetch_bitmap); ++i) {
+     uint32_t vfetch_bits_remaining = constant_map_vertex.vertex_fetch_bitmap[i];
+     uint32_t j;
+@@ -4039,10 +4125,12 @@ bool VulkanCommandProcessor::IssueDraw(xenos::PrimitiveType prim_type, uint32_t
+       vertex_buffers_in_sync_[vfetch_index >> 6] |= vfetch_bit;
+     }
+   }
++  }
+ 
+   // Synchronize the memory pages backing memory scatter export streams, and
+   // calculate the range that includes the streams for the buffer barrier.
+   uint32_t memexport_extent_start = UINT32_MAX, memexport_extent_end = 0;
++  { RenutScopedTimer renut_memexport_timer(&g_renut_trace_row.memexport_ms);
+   for (const draw_util::MemExportRange& memexport_range : memexport_ranges_) {
+     uint32_t memexport_range_base_bytes = memexport_range.base_address_dwords << 2;
+     if (!shared_memory_->RequestRange(memexport_range_base_bytes, memexport_range.size_bytes)) {
+@@ -4064,6 +4152,7 @@ bool VulkanCommandProcessor::IssueDraw(xenos::PrimitiveType prim_type, uint32_t
+       return false;
+     }
+   }
++  }
+ 
+   ScratchBufferAcquisition guest_dma_index_scratch_buffer;
+   if (primitive_processing_result.index_buffer_type ==
+@@ -4124,11 +4213,66 @@ bool VulkanCommandProcessor::IssueDraw(xenos::PrimitiveType prim_type, uint32_t
+   // After all commands that may dispatch, copy or insert barriers, submit
+   // the barriers (may end the render pass), and (re)enter the render pass
+   // before drawing.
+-  SubmitBarriersAndEnterRenderTargetCacheRenderPass(
+-      render_target_cache_->last_update_render_pass(),
+-      render_target_cache_->last_update_framebuffer());
++  { RenutScopedTimer renut_renderpass_enter_timer(&g_renut_trace_row.renderpass_enter_ms);
++    SubmitBarriersAndEnterRenderTargetCacheRenderPass(
++        render_target_cache_->last_update_render_pass(),
++        render_target_cache_->last_update_framebuffer());
++  }
  
    // Draw.
 +  // Index-buffer resolution shared with the dispatch below, computed once
@@ -641,14 +957,47 @@ index a40436e..ba0779c 100644
 +                               : VK_INDEX_TYPE_UINT32;
 +  }
 +
++  if (!pixel_shader) {
++    ++g_renut_trace_row.depthonly;
++    ++g_renut_trace_row.nopixelshader;
++  }
++
 +  if (TryNativeDraw(vertex_shader, pixel_shader, primitive_processing_result,
 +                    resolved_index_buffer, resolved_index_buffer_offset, resolved_index_type)) {
 +    return true;
 +  }
 +
++  { RenutScopedTimer renut_drawcmd_timer(&g_renut_trace_row.drawcmd_ms);
    if (primitive_processing_result.index_buffer_type ==
            PrimitiveProcessor::ProcessedIndexBufferType::kNone ||
        shader_32bit_index_dma) {
+@@ -4166,6 +4310,7 @@ bool VulkanCommandProcessor::IssueDraw(xenos::PrimitiveType prim_type, uint32_t
+     deferred_command_buffer_.CmdVkDrawIndexed(primitive_processing_result.host_draw_vertex_count, 1,
+                                               0, 0, 0);
+   }
++  }
+ 
+   // Invalidate textures in memexported memory and watch for changes.
+   if (!memexport_ranges_.empty()) {
+@@ -4399,6 +4544,9 @@ bool VulkanCommandProcessor::IssueCopy() {
+   SCOPE_profile_cpu_f("gpu");
+ #endif  // XE_GPU_FINE_GRAINED_DRAW_SCOPES
+ 
++  ++g_renut_trace_row.issuecopy_n;
++  RenutScopedTimer renut_issuecopy_timer(&g_renut_trace_row.issuecopy_ms);
++
+   if (!BeginSubmission(true)) {
+     return false;
+   }
+@@ -5003,6 +5151,8 @@ void VulkanCommandProcessor::CheckSubmissionFenceAndDeviceLoss(uint64_t await_su
+     // defined by vkQueueSubmit additionally include in the first
+     // synchronization scope all commands that occur earlier in submission
+     // order."
++    ++g_renut_trace_row.gpuwait_n;
++    RenutScopedTimer renut_gpuwait_timer(&g_renut_trace_row.gpuwait_ms);
+     VkResult wait_result =
+         dfn.vkWaitForFences(device, uint32_t(await_submission - submission_completed_),
+                             submissions_in_flight_fences_.data(), VK_TRUE, UINT64_MAX);
 diff --git a/src/graphics/vulkan/nativevk_debug_color_spirv.h b/src/graphics/vulkan/nativevk_debug_color_spirv.h
 new file mode 100644
 index 0000000..93439f7
@@ -674,11 +1023,11 @@ index 0000000..93439f7
 +inline constexpr uint32_t kRenutDebugColorFragSpirvWordCount = 120;
 diff --git a/src/graphics/vulkan/nativevk_phase1_native_draw.cpp b/src/graphics/vulkan/nativevk_phase1_native_draw.cpp
 new file mode 100644
-index 0000000..137e5ea
+index 0000000..01ae444
 --- /dev/null
 +++ b/src/graphics/vulkan/nativevk_phase1_native_draw.cpp
-@@ -0,0 +1,413 @@
-+// Native-renderer Phase 1 (see PLAN_native_renderer.md). See the header for
+@@ -0,0 +1,412 @@
++// Native-renderer Phase 1. See the header for
 +// the overall rationale; this file is the actual implementation.
 +
 +#include "nativevk_phase1_native_draw.h"
@@ -697,7 +1046,7 @@ index 0000000..137e5ea
 +
 +namespace {
 +
-+// The ONE target draw chosen in PLAN_native_renderer.md Phase 1 step 1.
++// The ONE target draw chosen for Phase 1.
 +constexpr uint64_t kTargetVertexShaderHash = 0x67021cae68a26b46ull;
 +constexpr uint64_t kTargetPixelShaderHash = 0x12c73f3eb45dad49ull;
 +
@@ -751,7 +1100,7 @@ index 0000000..137e5ea
 +  VkRenderPass pipeline_render_pass = VK_NULL_HANDLE;
 +
 +  // CPU-side wall-time measurement around the draw's full round-trip cost,
-+  // following this session's existing RenutNow()/trace-CSV pattern (see
++  // following the existing RenutNow()/trace-CSV pattern (see
 +  // command_processor.cpp) rather than adding new GPU timestamp-query
 +  // infrastructure, which DeferredCommandBuffer does not currently expose --
 +  // out of scope for Phase 1's proof-of-concept goal.
@@ -773,10 +1122,10 @@ index 0000000..137e5ea
 +}  // namespace
 +
 +bool IsTargetDraw(uint64_t vertex_shader_ucode_hash, uint64_t pixel_shader_ucode_hash) {
-+  // FOUND 2026-08-18: this Phase 1 mechanism was NOT covered by
-+  // RENUT_DISABLE_ALL_NATIVE=1 (that flag only gates the later, general
-+  // HasNativePipeline() path in nativevk_pipeline_cache.cpp) -- meaning
-+  // every prior "native fully disabled" A/B test still had this one real,
++  // This Phase 1 mechanism is NOT covered by RENUT_DISABLE_ALL_NATIVE=1
++  // (that flag only gates the later, general HasNativePipeline() path in
++  // nativevk_xenos_pipeline_cache.cpp) -- meaning a "native fully disabled"
++  // A/B test would otherwise still have this one real,
 +  // frequently-drawn vertex shader deliberately rendered with the wrong
 +  // pixel shader (see this function's own header comment: "substituted
 +  // draws will not visually match... not a mistake"). Local copy of the
@@ -790,8 +1139,7 @@ index 0000000..137e5ea
 +    }
 +  }
 +  // Vertex-shader-only match, NOT the originally chosen vs+ps pair. Confirmed
-+  // this session (see PLAN_native_renderer.md Phase 1 step 1) that
-+  // kTargetVertexShaderHash + kTargetPixelShaderHash is not an actual live
++  // that kTargetVertexShaderHash + kTargetPixelShaderHash is not an actual live
 +  // in-game pairing -- the game never draws these two shaders together, so
 +  // matching on both would make this code permanently unreachable. Matching
 +  // on the vertex shader alone (which IS confirmed present in the real
@@ -1093,13 +1441,13 @@ index 0000000..137e5ea
 +}  // namespace rex::graphics::vulkan::nativevk_phase1
 diff --git a/src/graphics/vulkan/nativevk_phase1_native_draw.h b/src/graphics/vulkan/nativevk_phase1_native_draw.h
 new file mode 100644
-index 0000000..7fcc4a8
+index 0000000..1740ad5
 --- /dev/null
 +++ b/src/graphics/vulkan/nativevk_phase1_native_draw.h
 @@ -0,0 +1,49 @@
 +#pragma once
-+// Native-renderer Phase 1 (see PLAN_native_renderer.md in the reNut repo
-+// root): a single hand-built native draw, substituted for one specific
++// Native-renderer Phase 1: a single hand-built native draw, substituted
++// for one specific
 +// Xenos-translated draw inside VulkanCommandProcessor::IssueDraw, to prove
 +// the mechanism end-to-end (real GPU device, real command buffer, real
 +// pipeline, real measured GPU time) before any larger native-renderer effort
@@ -1117,8 +1465,8 @@ index 0000000..7fcc4a8
 +
 +namespace rex::graphics::vulkan::nativevk_phase1 {
 +
-+// True only for the ONE draw this phase targets: the shader pair chosen in
-+// PLAN_native_renderer.md Phase 1 step 1 (vs_67021cae68a26b46 +
++// True only for the ONE draw this phase targets: the shader pair chosen
++// for Phase 1 (vs_67021cae68a26b46 +
 +// ps_12c73f3eb45dad49), identified the same way the "renut color draw pair"
 +// diagnostic (command_processor.cpp) already identifies shader pairs -- by
 +// the SDK's own real ucode_data_hash() on both shaders, not a guess.
@@ -1262,11 +1610,11 @@ index 0000000..645ae7a
 +const size_t kRenutPhase1PixelShaderSpirv_size = sizeof(kRenutPhase1PixelShaderSpirv);
 diff --git a/src/graphics/vulkan/nativevk_shader_debug_panel.cpp b/src/graphics/vulkan/nativevk_shader_debug_panel.cpp
 new file mode 100644
-index 0000000..b42fa7b
+index 0000000..27ecd0f
 --- /dev/null
 +++ b/src/graphics/vulkan/nativevk_shader_debug_panel.cpp
-@@ -0,0 +1,336 @@
-+// Real-time native-shader debug panel (2026-08-16, see
+@@ -0,0 +1,309 @@
++// Real-time native-shader debug panel (see
 +// nativevk_xenos_pipeline_cache.h's GetDebugShaderPairs()/
 +// SetDebugShaderPairEnabled()): lets the user toggle each live native
 +// shader pair on/off in-game, no rebuild/relaunch, to bisect which
@@ -1274,12 +1622,13 @@ index 0000000..b42fa7b
 +// test that the bug is inside one or more currently-live native shaders,
 +// not a mixing/architecture problem -- see memory).
 +//
-+// Lazily created on first native draw (EnsureDebugPanelInitialized(),
-+// same real pattern as this file's EnsureBindlessHeapInitialized), owned
-+// by rex::Runtime::instance() via a raw pointer -- the same base-class
-+// self-registration ImGuiDialog already uses (its ctor calls
-+// imgui_drawer->AddDialog(this), see include/rex/ui/imgui_dialog.h). Never
-+// closed/deleted; lives for the process lifetime like DebugOverlayDialog.
++// Content-only (no window/Begin/End, no self-registered dialog, no
++// hotkey): exposed via one extern "C" function so reNut's own
++// DebugHubOverlayDialog (src/renut_engine/overlays/debug_hub_overlay.h) can
++// host it as a tab alongside the renderer-performance and A/B-benchmark
++// panels under a single F5 toggle, resolved with dlsym the same way that
++// file already resolves the A/B benchmark's renut_ab_* functions -- keeps
++// all window chrome/hotkey ownership in reNut's own code, not the plugin.
 +
 +#include "nativevk_xenos_pipeline_cache.h"
 +
@@ -1296,15 +1645,13 @@ index 0000000..b42fa7b
 +#include <imgui.h>
 +
 +#include <rex/filesystem.h>
-+#include <rex/runtime.h>
-+#include <rex/ui/imgui_dialog.h>
-+#include <rex/ui/imgui_drawer.h>
++#include <rex/system/gpu_plugin.h>
 +
 +namespace rex::graphics::vulkan::nativevk_pipeline {
 +
 +namespace {
 +
-+// Real "mark as bad" feature (2026-08-17, requested by the user): playtesting
++// Real "mark as bad" feature: playtesting
 +// via the debug panel's individual on/off checkboxes tells the user WHETHER a
 +// pair is broken, but with a few hundred live pairs there's no way to record
 +// WHICH ones for later offline analysis without manually transcribing hashes.
@@ -1316,11 +1663,6 @@ index 0000000..b42fa7b
 +  return rex::filesystem::GetExecutableFolder() / "marked_bad_shaders.txt";
 +}
 +
-+// Real, deliberate choice: a std::set<std::pair<uint64_t,uint64_t>> keyed by
-+// the real (vs_hash, ps_hash) pair, not a single combined/hashed key -- keeps
-+// the in-memory state trivially convertible back to the same two hex values
-+// the file format and the UI label both already use, no extra encode/decode
-+// step to get wrong.
 +std::set<std::pair<uint64_t, uint64_t>> LoadMarkedBadShaders() {
 +  std::set<std::pair<uint64_t, uint64_t>> result;
 +  std::ifstream file(BadShaderListPath());
@@ -1342,274 +1684,253 @@ index 0000000..b42fa7b
 +  file << "vs_" << std::hex << vs_hash << " ps_" << ps_hash << std::dec << "\n";
 +}
 +
-+class NativeShaderDebugDialog : public ui::ImGuiDialog {
-+ public:
-+  explicit NativeShaderDebugDialog(ui::ImGuiDrawer* imgui_drawer)
-+      : ImGuiDialog(imgui_drawer), marked_bad_(LoadMarkedBadShaders()) {}
++// Real, deliberate in-memory cache (not re-read from disk every frame):
++// avoids re-parsing the file on every draw call, and lets the button
++// immediately flip to its disabled "already marked" state without a round
++// trip through the filesystem. Lazily populated on first use rather than at
++// static-init time, since GetExecutableFolder() (via BadShaderListPath())
++// may not be safe to call that early.
++std::set<std::pair<uint64_t, uint64_t>>& MarkedBad() {
++  static std::set<std::pair<uint64_t, uint64_t>> marked_bad = LoadMarkedBadShaders();
++  return marked_bad;
++}
 +
-+ protected:
-+  // Real one-row helper shared by both sections below (Active/Disabled) --
-+  // draws the checkbox + Mark Bad button for a single pair, identical in
-+  // both lists, so the two loops in OnDraw() can't drift out of sync.
-+  void DrawPairRow(const DebugShaderPairInfo& pair) {
-+    // Real fix (2026-08-17, user-requested): the two 16-hex-digit hashes
-+    // alone are unreadable enough that re-finding a specific pair among a
-+    // few hundred rows was impractical. #<display_id> is a small, stable,
-+    // process-lifetime-unique number (see DebugShaderPairInfo::display_id)
-+    // the user can jot down and search for instead.
-+    char label[80];
-+    std::snprintf(label, sizeof(label), "#%u  vs_%016llx / ps_%016llx", pair.display_id,
-+                  static_cast<unsigned long long>(pair.vs_hash),
-+                  static_cast<unsigned long long>(pair.ps_hash));
-+    bool enabled = pair.enabled;
-+    ImGui::PushID(static_cast<int>(pair.vs_hash ^ pair.ps_hash));
-+    if (ImGui::Checkbox(label, &enabled)) {
-+      SetDebugShaderPairEnabled(pair.vs_hash, pair.ps_hash, enabled);
-+    }
++// Real one-row helper shared by both sections below (Active/Disabled) --
++// draws the checkbox + Mark Bad button for a single pair, identical in
++// both lists, so the two loops in DrawContent() can't drift out of sync.
++void DrawPairRow(const DebugShaderPairInfo& pair) {
++  // The two 16-hex-digit hashes
++  // alone are unreadable enough that re-finding a specific pair among a
++  // few hundred rows was impractical. #<display_id> is a small, stable,
++  // process-lifetime-unique number (see DebugShaderPairInfo::display_id)
++  // the user can jot down and search for instead.
++  char label[80];
++  std::snprintf(label, sizeof(label), "#%u  vs_%016llx / ps_%016llx", pair.display_id,
++                static_cast<unsigned long long>(pair.vs_hash),
++                static_cast<unsigned long long>(pair.ps_hash));
++  bool enabled = pair.enabled;
++  ImGui::PushID(static_cast<int>(pair.vs_hash ^ pair.ps_hash));
++  if (ImGui::Checkbox(label, &enabled)) {
++    SetDebugShaderPairEnabled(pair.vs_hash, pair.ps_hash, enabled);
++  }
 +
++  ImGui::SameLine();
++  auto& marked_bad = MarkedBad();
++  const auto key = std::make_pair(pair.vs_hash, pair.ps_hash);
++  const bool already_marked = marked_bad.count(key) != 0;
++  if (already_marked) {
++    ImGui::BeginDisabled();
++    ImGui::Button("Bad (saved)");
++    ImGui::EndDisabled();
++  } else if (ImGui::Button("Mark Bad")) {
++    AppendMarkedBadShader(pair.vs_hash, pair.ps_hash);
++    marked_bad.insert(key);
++    // Auto-disabling only happens the moment a pair is first RECORDED
++    // (RecordAndCheckPairEnabled() in nativevk_xenos_pipeline_cache.cpp) --
++    // marking one bad mid-session wouldn't retroactively disable it, so do
++    // that here too: same real effect (this pair goes stock-rendered
++    // immediately) without requiring a relaunch to take hold.
++    SetDebugShaderPairEnabled(pair.vs_hash, pair.ps_hash, false);
++  }
++  if (pair.marked_bad) {
 +    ImGui::SameLine();
-+    const auto key = std::make_pair(pair.vs_hash, pair.ps_hash);
-+    const bool already_marked = marked_bad_.count(key) != 0;
-+    if (already_marked) {
-+      ImGui::BeginDisabled();
-+      ImGui::Button("Bad (saved)");
-+      ImGui::EndDisabled();
-+    } else if (ImGui::Button("Mark Bad")) {
-+      AppendMarkedBadShader(pair.vs_hash, pair.ps_hash);
-+      marked_bad_.insert(key);
-+      // Auto-disabling only happens the moment a pair is first RECORDED
-+      // (RecordAndCheckPairEnabled() in nativevk_pipeline_cache.cpp) --
-+      // marking one bad mid-session wouldn't retroactively disable it, so do
-+      // that here too: same real effect (this pair goes stock-rendered
-+      // immediately) without requiring a relaunch to take hold.
-+      SetDebugShaderPairEnabled(pair.vs_hash, pair.ps_hash, false);
-+    }
-+    if (pair.marked_bad) {
-+      ImGui::SameLine();
-+      ImGui::TextDisabled("(auto-disabled: was marked bad on boot)");
-+    }
-+    ImGui::PopID();
++    ImGui::TextDisabled("(auto-disabled: was marked bad on boot)");
 +  }
++  ImGui::PopID();
++}
 +
-+  // Real "represent each shader on screen" feature (2026-08-17, user-
-+  // requested): draws a "#<display_id>" label at every native pair's most
-+  // recent recorded on-screen position (see IssueNativeDraw's own comment
-+  // on how/why this is a heuristic, not a guaranteed-correct decode).
-+  // Skips pairs that aren't currently enabled (no point labeling
-+  // something that isn't actually rendering natively right now) and
-+  // positions wildly outside the visible NDC range (a likely sign the
-+  // assumed matrix register didn't hold for that shader).
-+  //
-+  // Real fix (2026-08-17, user-reported: labels overlapping/hidden on
-+  // large or closely-packed objects): raw screen positions often land
-+  // right on top of each other (see the reported screenshot -- several
-+  // labels overlapping above one vehicle). A simple greedy declutter pass
-+  // pushes each new label down past any already-placed label its text rect
-+  // would overlap, so nearby labels form a readable stack instead of a
-+  // blob of overlapping digits. This is display-only -- it doesn't change
-+  // which position was recorded, just where the TEXT ends up drawn.
-+  void DrawOnScreenLabels(const ImGuiIO& io, const std::vector<DebugShaderPairInfo>& pairs) {
-+    ImDrawList* draw_list = ImGui::GetForegroundDrawList();
-+    struct PlacedLabel {
-+      ImVec2 top_left;
-+      ImVec2 size;
-+    };
-+    std::vector<PlacedLabel> placed;
-+    for (const DebugShaderLabel& label : GetDebugShaderLabels()) {
-+      if (label.ndc_x < -4.0f || label.ndc_x > 4.0f || label.ndc_y < -4.0f || label.ndc_y > 4.0f) {
-+        continue;
-+      }
-+      const DebugShaderPairInfo* match = nullptr;
-+      for (const DebugShaderPairInfo& pair : pairs) {
-+        if (pair.vs_hash == label.vs_hash && pair.ps_hash == label.ps_hash) {
-+          match = &pair;
-+          break;
-+        }
-+      }
-+      if (match == nullptr || !match->enabled) {
-+        continue;
-+      }
-+      char text[16];
-+      std::snprintf(text, sizeof(text), "#%u", match->display_id);
-+      const ImVec2 text_size = ImGui::CalcTextSize(text);
-+      ImVec2 top_left((label.ndc_x * 0.5f + 0.5f) * io.DisplaySize.x - text_size.x * 0.5f,
-+                       (1.0f - (label.ndc_y * 0.5f + 0.5f)) * io.DisplaySize.y - text_size.y);
-+      // Greedy declutter: as long as this rect overlaps an already-placed
-+      // one, push it down one line height and re-check from the top. Capped
-+      // so a pathological cluster can't loop for long.
-+      for (int attempt = 0; attempt < 32; ++attempt) {
-+        bool overlaps = false;
-+        for (const PlacedLabel& other : placed) {
-+          if (top_left.x < other.top_left.x + other.size.x &&
-+              top_left.x + text_size.x > other.top_left.x &&
-+              top_left.y < other.top_left.y + other.size.y &&
-+              top_left.y + text_size.y > other.top_left.y) {
-+            overlaps = true;
-+            break;
-+          }
-+        }
-+        if (!overlaps) {
-+          break;
-+        }
-+        top_left.y += text_size.y + 2.0f;
-+      }
-+      placed.push_back({top_left, text_size});
-+      // Black outline + yellow fill so the label stays legible over any
-+      // background color.
-+      draw_list->AddText(ImVec2(top_left.x + 1.0f, top_left.y + 1.0f), IM_COL32(0, 0, 0, 255), text);
-+      draw_list->AddText(top_left, IM_COL32(255, 255, 0, 255), text);
++// "Represent each shader on screen" feature: draws a "#<display_id>"
++// label at every native pair's most
++// recent recorded on-screen position (see IssueNativeDraw's own comment
++// on how/why this is a heuristic, not a guaranteed-correct decode).
++// Skips pairs that aren't currently enabled (no point labeling
++// something that isn't actually rendering natively right now) and
++// positions wildly outside the visible NDC range (a likely sign the
++// assumed matrix register didn't hold for that shader).
++//
++// Labels can overlap/hide on large or closely-packed objects -- raw
++// screen positions often land
++// right on top of each other. A simple greedy declutter pass pushes each
++// new label down past any already-placed label its text rect would
++// overlap, so nearby labels form a readable stack instead of a blob of
++// overlapping digits. This is display-only -- it doesn't change which
++// position was recorded, just where the TEXT ends up drawn.
++void DrawOnScreenLabels(const ImGuiIO& io, const std::vector<DebugShaderPairInfo>& pairs) {
++  ImDrawList* draw_list = ImGui::GetForegroundDrawList();
++  struct PlacedLabel {
++    ImVec2 top_left;
++    ImVec2 size;
++  };
++  std::vector<PlacedLabel> placed;
++  for (const DebugShaderLabel& label : GetDebugShaderLabels()) {
++    if (label.ndc_x < -4.0f || label.ndc_x > 4.0f || label.ndc_y < -4.0f || label.ndc_y > 4.0f) {
++      continue;
 +    }
-+  }
-+
-+  void OnDraw(ImGuiIO& io) override {
-+    if (!ImGui::Begin("Native Shader Debug Panel")) {
-+      ImGui::End();
-+      return;
-+    }
-+
-+    std::vector<DebugShaderPairInfo> pairs = GetDebugShaderPairs();
-+    // Real fix (2026-08-17, user-requested): the section a pair lives in
-+    // used to be driven by the LIVE enabled checkbox, so unchecking a pair
-+    // to test it immediately moved it into "Disabled" -- exactly the
-+    // opposite of what's needed when bisecting, since the pair you're
-+    // actively testing is the one you want to keep finding easily. The
-+    // split is now driven by marked_bad instead (only pairs auto-disabled
-+    // at boot from marked_bad_shaders.txt land in "Marked Bad"), so the
-+    // live checkbox is now a pure test toggle: flip it as much as you want,
-+    // the row stays put.
-+    std::vector<const DebugShaderPairInfo*> all_pairs;
-+    std::vector<const DebugShaderPairInfo*> marked_bad_pairs;
-+    size_t enabled_count = 0;
++    const DebugShaderPairInfo* match = nullptr;
 +    for (const DebugShaderPairInfo& pair : pairs) {
-+      (pair.marked_bad ? marked_bad_pairs : all_pairs).push_back(&pair);
-+      enabled_count += pair.enabled ? 1 : 0;
-+    }
-+
-+    ImGui::Text("%zu live native shader pair(s) -- %zu currently enabled, %zu currently disabled",
-+                pairs.size(), enabled_count, pairs.size() - enabled_count);
-+    ImGui::Text("%zu marked bad (saved to marked_bad_shaders.txt)", marked_bad_.size());
-+    // Real diagnostic (2026-08-17, user-requested): "N pairs enabled" only
-+    // counts DISTINCT shader pairs ever seen across a whole play session --
-+    // it says nothing about how many of any GIVEN frame's real draw calls
-+    // actually reach the native path vs silently falling back to stock.
-+    // This is the number that actually answers that.
-+    ImGui::Text("%llu native draw(s) since launch (watch it while playing -- if it never "
-+                "moves, native rendering isn't happening at all)",
-+                (unsigned long long)PeekLastFrameDrawCount());
-+
-+    if (ImGui::Button("Disable All")) {
-+      SetAllDebugShaderPairsEnabled(false);
-+    }
-+    ImGui::SameLine();
-+    if (ImGui::Button("Enable All")) {
-+      SetAllDebugShaderPairsEnabled(true);
-+    }
-+    ImGui::SameLine();
-+    if (ImGui::Button("Disable All Bad")) {
-+      SetMarkedBadShaderPairsEnabled(false);
-+    }
-+    ImGui::SameLine();
-+    if (ImGui::Button("Enable All Bad")) {
-+      SetMarkedBadShaderPairsEnabled(true);
-+    }
-+
-+    bool show_labels = GetShowNativeShaderLabels();
-+    if (ImGui::Checkbox("Show on-screen labels (heuristic, may be wrong/missing per-shader)",
-+                         &show_labels)) {
-+      SetShowNativeShaderLabels(show_labels);
-+    }
-+
-+    bool debug_colorize = GetDebugColorizeMode();
-+    if (ImGui::Checkbox(
-+            "Debug: colorize native draws by shader pair (real vertex shader, flat-color pixel shader)",
-+            &debug_colorize)) {
-+      SetDebugColorizeMode(debug_colorize);
-+    }
-+    if (debug_colorize) {
-+      ImGui::TextWrapped(
-+          "Only colorizes pairs built AFTER this was turned on (reload the area / walk to a new "
-+          "one) -- does not retrofit already-drawn geometry, to avoid rebuilding live pipelines "
-+          "under load.");
-+    }
-+    if (show_labels) {
-+      // Real fix (2026-08-17, user-reported: labels cluster above the
-+      // player instead of at each object): the fixed c0 guess for this
-+      // shader's transform matrix was wrong. Rather than ship a third
-+      // blind guess, expose the base register as a live control -- watch a
-+      // specific object in-game and drag this until its label lands on it.
-+      // Different shaders may need different values; this is a
-+      // calibration aid, not a promise that one value fits every shader.
-+      int matrix_register = int(GetNativeShaderLabelMatrixRegister());
-+      ImGui::SetNextItemWidth(120.0f);
-+      if (ImGui::SliderInt("Label matrix base register (c#)", &matrix_register, 0, 252)) {
-+        SetNativeShaderLabelMatrixRegister(uint32_t(matrix_register));
++      if (pair.vs_hash == label.vs_hash && pair.ps_hash == label.ps_hash) {
++        match = &pair;
++        break;
 +      }
-+      DrawOnScreenLabels(io, pairs);
 +    }
-+
-+    ImGui::Separator();
-+    // Real "panel within a panel" split (2026-08-17, user-requested): pairs
-+    // marked bad (auto-disabled on boot from marked_bad_shaders.txt) are
-+    // separated from everything else, so the user can see at a glance
-+    // what's already known-bad vs what's still being evaluated, without a
-+    // live test toggle relocating rows out from under them.
-+    if (ImGui::CollapsingHeader("All Shaders", ImGuiTreeNodeFlags_DefaultOpen)) {
-+      ImGui::BeginChild("native_shader_pair_list_active", ImVec2(0, 200), true);
-+      for (const DebugShaderPairInfo* pair : all_pairs) {
-+        DrawPairRow(*pair);
++    if (match == nullptr || !match->enabled) {
++      continue;
++    }
++    char text[16];
++    std::snprintf(text, sizeof(text), "#%u", match->display_id);
++    const ImVec2 text_size = ImGui::CalcTextSize(text);
++    ImVec2 top_left((label.ndc_x * 0.5f + 0.5f) * io.DisplaySize.x - text_size.x * 0.5f,
++                     (1.0f - (label.ndc_y * 0.5f + 0.5f)) * io.DisplaySize.y - text_size.y);
++    // Greedy declutter: as long as this rect overlaps an already-placed
++    // one, push it down one line height and re-check from the top. Capped
++    // so a pathological cluster can't loop for long.
++    for (int attempt = 0; attempt < 32; ++attempt) {
++      bool overlaps = false;
++      for (const PlacedLabel& other : placed) {
++        if (top_left.x < other.top_left.x + other.size.x &&
++            top_left.x + text_size.x > other.top_left.x &&
++            top_left.y < other.top_left.y + other.size.y &&
++            top_left.y + text_size.y > other.top_left.y) {
++          overlaps = true;
++          break;
++        }
 +      }
-+      ImGui::EndChild();
-+    }
-+    if (ImGui::CollapsingHeader("Marked Bad (auto-disabled at boot)")) {
-+      ImGui::BeginChild("native_shader_pair_list_disabled", ImVec2(0, 200), true);
-+      for (const DebugShaderPairInfo* pair : marked_bad_pairs) {
-+        DrawPairRow(*pair);
++      if (!overlaps) {
++        break;
 +      }
-+      ImGui::EndChild();
++      top_left.y += text_size.y + 2.0f;
 +    }
++    placed.push_back({top_left, text_size});
++    // Black outline + yellow fill so the label stays legible over any
++    // background color.
++    draw_list->AddText(ImVec2(top_left.x + 1.0f, top_left.y + 1.0f), IM_COL32(0, 0, 0, 255), text);
++    draw_list->AddText(top_left, IM_COL32(255, 255, 0, 255), text);
++  }
++}
 +
-+    ImGui::End();
++void DrawContent(const ImGuiIO& io) {
++  std::vector<DebugShaderPairInfo> pairs = GetDebugShaderPairs();
++  // the section a pair lives in
++  // used to be driven by the LIVE enabled checkbox, so unchecking a pair
++  // to test it immediately moved it into "Disabled" -- exactly the
++  // opposite of what's needed when bisecting, since the pair you're
++  // actively testing is the one you want to keep finding easily. The
++  // split is now driven by marked_bad instead (only pairs auto-disabled
++  // at boot from marked_bad_shaders.txt land in "Marked Bad"), so the
++  // live checkbox is now a pure test toggle: flip it as much as you want,
++  // the row stays put.
++  std::vector<const DebugShaderPairInfo*> all_pairs;
++  std::vector<const DebugShaderPairInfo*> marked_bad_pairs;
++  size_t enabled_count = 0;
++  for (const DebugShaderPairInfo& pair : pairs) {
++    (pair.marked_bad ? marked_bad_pairs : all_pairs).push_back(&pair);
++    enabled_count += pair.enabled ? 1 : 0;
 +  }
 +
-+ private:
-+  // Real, deliberate in-memory cache (not re-read from disk every frame):
-+  // avoids re-parsing the file on every OnDraw() call, and lets the button
-+  // immediately flip to its disabled "already marked" state without a round
-+  // trip through the filesystem.
-+  std::set<std::pair<uint64_t, uint64_t>> marked_bad_;
-+};
++  ImGui::Text("%zu live native shader pair(s) -- %zu currently enabled, %zu currently disabled",
++              pairs.size(), enabled_count, pairs.size() - enabled_count);
++  ImGui::Text("%zu marked bad (saved to marked_bad_shaders.txt)", MarkedBad().size());
++  // Real diagnostic: "N pairs enabled" only
++  // counts DISTINCT shader pairs ever seen across a whole play session --
++  // it says nothing about how many of any GIVEN frame's real draw calls
++  // actually reach the native path vs silently falling back to stock.
++  // This is the number that actually answers that.
++  ImGui::Text("%llu native draw(s) since launch (watch it while playing -- if it never "
++              "moves, native rendering isn't happening at all)",
++              (unsigned long long)PeekLastFrameDrawCount());
++
++  if (ImGui::Button("Disable All")) {
++    SetAllDebugShaderPairsEnabled(false);
++  }
++  ImGui::SameLine();
++  if (ImGui::Button("Enable All")) {
++    SetAllDebugShaderPairsEnabled(true);
++  }
++  ImGui::SameLine();
++  if (ImGui::Button("Disable All Bad")) {
++    SetMarkedBadShaderPairsEnabled(false);
++  }
++  ImGui::SameLine();
++  if (ImGui::Button("Enable All Bad")) {
++    SetMarkedBadShaderPairsEnabled(true);
++  }
++
++  bool show_labels = GetShowNativeShaderLabels();
++  if (ImGui::Checkbox("Show on-screen labels (heuristic, may be wrong/missing per-shader)",
++                       &show_labels)) {
++    SetShowNativeShaderLabels(show_labels);
++  }
++
++  bool debug_colorize = GetDebugColorizeMode();
++  if (ImGui::Checkbox(
++          "Debug: colorize native draws by shader pair (real vertex shader, flat-color pixel shader)",
++          &debug_colorize)) {
++    SetDebugColorizeMode(debug_colorize);
++  }
++  if (debug_colorize) {
++    ImGui::TextWrapped(
++        "Only colorizes pairs built AFTER this was turned on (reload the area / walk to a new "
++        "one) -- does not retrofit already-drawn geometry, to avoid rebuilding live pipelines "
++        "under load.");
++  }
++  if (show_labels) {
++    // Labels used to cluster above the player instead of at each
++    // object -- the fixed c0 guess for this
++    // shader's transform matrix was wrong. Rather than ship a third
++    // blind guess, expose the base register as a live control -- watch a
++    // specific object in-game and drag this until its label lands on it.
++    // Different shaders may need different values; this is a
++    // calibration aid, not a promise that one value fits every shader.
++    int matrix_register = int(GetNativeShaderLabelMatrixRegister());
++    ImGui::SetNextItemWidth(120.0f);
++    if (ImGui::SliderInt("Label matrix base register (c#)", &matrix_register, 0, 252)) {
++      SetNativeShaderLabelMatrixRegister(uint32_t(matrix_register));
++    }
++    DrawOnScreenLabels(io, pairs);
++  }
++
++  ImGui::Separator();
++  // Real "panel within a panel" split: pairs
++  // marked bad (auto-disabled on boot from marked_bad_shaders.txt) are
++  // separated from everything else, so the user can see at a glance
++  // what's already known-bad vs what's still being evaluated, without a
++  // live test toggle relocating rows out from under them.
++  if (ImGui::CollapsingHeader("All Shaders", ImGuiTreeNodeFlags_DefaultOpen)) {
++    ImGui::BeginChild("native_shader_pair_list_active", ImVec2(0, 200), true);
++    for (const DebugShaderPairInfo* pair : all_pairs) {
++      DrawPairRow(*pair);
++    }
++    ImGui::EndChild();
++  }
++  if (ImGui::CollapsingHeader("Marked Bad (auto-disabled at boot)")) {
++    ImGui::BeginChild("native_shader_pair_list_disabled", ImVec2(0, 200), true);
++    for (const DebugShaderPairInfo* pair : marked_bad_pairs) {
++      DrawPairRow(*pair);
++    }
++    ImGui::EndChild();
++  }
++}
 +
 +}  // namespace
 +
-+void EnsureDebugPanelInitialized() {
-+  static bool initialized = false;
-+  if (initialized) {
-+    return;
-+  }
-+  initialized = true;
-+
-+  Runtime* runtime = Runtime::instance();
-+  if (runtime == nullptr) {
-+    return;
-+  }
-+  ui::ImGuiDrawer* imgui_drawer = runtime->imgui_drawer();
-+  if (imgui_drawer == nullptr) {
-+    return;
-+  }
-+  // Self-registers with imgui_drawer via the ImGuiDialog base ctor; never
-+  // freed, same lifetime as the process (matches DebugOverlayDialog).
-+  new NativeShaderDebugDialog(imgui_drawer);
-+}
-+
 +}  // namespace rex::graphics::vulkan::nativevk_pipeline
++
++// Exported so reNut's own debug hub (a different module -- the reNut exe,
++// which dlopen's this plugin at runtime as one of several interchangeable
++// GPU backends) can host this panel's content as a tab, without reNut
++// linking against plugin-internal types. extern "C" so the name is not
++// mangled and dlsym can find it by this exact string.
++extern "C" REX_GPU_PLUGIN_EXPORT void RenutNativeShaderDebugPanelDrawContent() {
++  rex::graphics::vulkan::nativevk_pipeline::DrawContent(ImGui::GetIO());
++}
 diff --git a/src/graphics/vulkan/nativevk_xenos_pipeline_cache.cpp b/src/graphics/vulkan/nativevk_xenos_pipeline_cache.cpp
 new file mode 100644
-index 0000000..eae85f1
+index 0000000..fc0d19a
 --- /dev/null
 +++ b/src/graphics/vulkan/nativevk_xenos_pipeline_cache.cpp
-@@ -0,0 +1,2405 @@
+@@ -0,0 +1,2400 @@
 +// Native-renderer "convert the important/common shaders" effort (see
-+// PLAN_native_renderer.md and this file's header for the overall shape).
++// this file's header for the overall shape).
 +
 +#include "nativevk_xenos_pipeline_cache.h"
 +#include "nativevk_debug_color_spirv.h"
@@ -1655,7 +1976,7 @@ index 0000000..eae85f1
 +
 +namespace {
 +
-+// TEMP DIAGNOSTIC (2026-08-16): real, live bisection tool for isolating
++// TEMP DIAGNOSTIC: real, live bisection tool for isolating
 +// which specific native shader corrupts geometry (confirmed via a real A/B
 +// test that it's inside one or more of the currently-live native shaders,
 +// not a mixing/architecture problem -- see memory). Tracks every distinct
@@ -1670,7 +1991,7 @@ index 0000000..eae85f1
 +  uint64_t vs_hash;
 +  uint64_t ps_hash;
 +  bool enabled = true;
-+  // Real "auto-disabled on boot" feature (2026-08-17, user-requested): true
++  // Real "auto-disabled on boot" feature: true
 +  // when this pair started disabled because it was in marked_bad_shaders.txt
 +  // at the moment it was first recorded, not because the user manually
 +  // toggled it off in the panel -- lets the panel show WHY a pair is
@@ -1692,8 +2013,8 @@ index 0000000..eae85f1
 +  return states;
 +}
 +
-+// Real "auto-disable known-bad shaders on boot" feature (2026-08-17,
-+// user-requested): re-testing every one of a few hundred native shader
++// "Auto-disable known-bad shaders on boot" feature: re-testing every one
++// of a few hundred native shader
 +// pairs by hand every session doesn't scale, so pairs the user has already
 +// flagged bad via the debug panel's "Mark Bad" button (persisted to
 +// marked_bad_shaders.txt next to the executable by
@@ -1724,15 +2045,15 @@ index 0000000..eae85f1
 +// so this must stay cheap -- a real, small linear scan (dozens of live
 +// pairs in practice, not thousands) is fine, matching FindCacheEntry's own
 +// same real justification below.
-+// Diagnostic-only (2026-08-18): forces every native pair OFF from process
++// Diagnostic-only: forces every native pair OFF from process
 +// start, checked via env var rather than marked_bad_shaders.txt/the debug
 +// panel because both of those only take effect for pairs seen AFTER the
 +// user reaches them (panel isn't reachable until after the intro videos,
 +// by which point hundreds of pairs already built+cached as enabled -- same
 +// gotcha as DebugColorizeModeFlag's history above). Needed to re-run a
-+// clean, complete, from-boot A/B test: multiple real, verified bugs (both
-+// shader-translation-level on 2026-08-17 and the bindless-heap descriptor
-+// race on 2026-08-18) have now shipped with zero measured visual change,
++// clean, complete, from-boot A/B test: multiple real, verified bugs
++// (shader-translation-level and a bindless-heap descriptor race) have
++// shipped with zero measured visual change,
 +// which is itself a signal worth re-checking the basic premise that native
 +// rendering is the actual source of the reported flicker before chasing
 +// more per-shader bugs. Not meant to ship on -- set RENUT_DISABLE_ALL_NATIVE=1
@@ -1757,7 +2078,7 @@ index 0000000..eae85f1
 +  return !marked_bad && !force_disabled;
 +}
 +
-+// Real "represent each shader on screen" feature (2026-08-17, user-
++// Real "represent each shader on screen" feature (user-
 +// requested): storage for the most recent on-screen position recorded per
 +// native pair. See DebugShaderLabel's own header comment for what ndc_x/
 +// ndc_y mean, and IssueNativeDraw below for exactly how (and under what
@@ -1792,7 +2113,7 @@ index 0000000..eae85f1
 +}
 +
 +std::atomic<bool>& DebugColorizeModeFlag() {
-+  // Real fix (2026-08-17, user-reported): the debug panel isn't reachable
++  // The debug panel isn't reachable
 +  // until after the two intro videos finish, by which point 100-200 shader
 +  // pairs have already been built WITHOUT the debug variant (see
 +  // SetDebugColorizeMode's header comment -- it deliberately doesn't
@@ -1804,7 +2125,7 @@ index 0000000..eae85f1
 +  // this is meant to be a temporary default, not a permanent one (flat
 +  // debug color instead of real rendering is not what a normal user wants
 +  // to see).
-+  // Reverted to false (2026-08-17): defaulting this ON meant every native
++  // Reverted to false: defaulting this ON meant every native
 +  // pipeline built after a game restart used the flat-color DEBUG pixel
 +  // shader instead of its real one, which masks any pixel-stage fix
 +  // (notably the texture-descriptor-index root-cause fix) and makes the
@@ -1907,7 +2228,7 @@ index 0000000..eae85f1
 +#if NATIVEVK_HAVE_XENOS_SHADER_CACHE
 +const RenutXenosShaderCacheEntry* FindCacheEntry(uint64_t ucode_hash) {
 +  // Linear scan: the cache is a few dozen entries today (33 in the first
-+  // real batch-conversion run, see PLAN_native_renderer.md), not thousands --
++  // real batch-conversion run), not thousands --
 +  // a hash map isn't worth the complexity yet. Revisit if/when the batch
 +  // conversion's success rate improves enough to make this list large.
 +  for (size_t i = 0; i < g_renutXenosShaderCacheEntryCount; ++i) {
@@ -1920,10 +2241,9 @@ index 0000000..eae85f1
 +#endif
 +
 +// Maps a decoded Xenos vertex-fetch format + signedness/normalization to a
-+// real Vulkan format for a VkVertexInputAttributeDescription. See
-+// PLAN_native_renderer.md's "real Vulkan vertex-buffer/format decode path"
-+// note for the real caveats here (found via direct source investigation,
-+// not guessed): k_10_11_11/k_11_11_10 have NO exact unsigned-normalized
++// real Vulkan format for a VkVertexInputAttributeDescription. Caveats
++// here were found via direct source investigation, not guessed:
++// k_10_11_11/k_11_11_10 have NO exact unsigned-normalized
 +// Vulkan equivalent (Vulkan only has the _UFLOAT variant, which is not the
 +// same bit layout as Xenos's plain integer fields) -- returns
 +// VK_FORMAT_UNDEFINED for those, which callers must treat as "this shader
@@ -2009,7 +2329,7 @@ index 0000000..eae85f1
 +  // nothing extra.
 +  VkPipeline debug_pipeline = VK_NULL_HANDLE;
 +  bool debug_pipeline_attempted = false;
-+  // Dynamic-rendering fix (2026-08-16): a real VkRenderPass is always
++  // Dynamic-rendering fix: a real VkRenderPass is always
 +  // VK_NULL_HANDLE under dynamic rendering (confirmed:
 +  // command_processor.cpp's `current_render_pass_ = use_dynamic_rendering ?
 +  // VK_NULL_HANDLE : render_pass`), which is the ACTIVE mode on real
@@ -2029,7 +2349,7 @@ index 0000000..eae85f1
 +  std::vector<VertexBindingInfo> bindings;
 +  std::vector<VertexAttributeInfo> attributes;
 +
-+  // Real bug found+fixed 2026-08-17: XenosRecomp's g_SwappedTexcoords shared
++  // XenosRecomp's g_SwappedTexcoords shared
 +  // constant (shader_common.h) tells the shader which TEXCOORD semantics
 +  // need a .yxwz correction swizzle -- real, needed whenever that texcoord's
 +  // vertex data uses a 16-bit-per-channel format (k_16_16/k_16_16_16_16),
@@ -2096,7 +2416,7 @@ index 0000000..eae85f1
 +// shader samples is whatever value THIS draw's SharedConstants buffer holds
 +// at that fixed byte offset, chosen freely by the CPU side every draw.
 +//
-+// REAL BUG FOUND 2026-08-18 (bindless-heap race): with the slot value always
++// BINDLESS-HEAP RACE: with the slot value always
 +// set equal to fetch_constant (a 0-31 hardware register number), every real
 +// texture that ever binds to register N -- and many different real textures
 +// commonly share the same register across different draw calls/objects,
@@ -2156,11 +2476,11 @@ index 0000000..eae85f1
 +  // HLSL indexes them with a valid-but-unwritten descriptor, which the
 +  // Vulkan spec allows under VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT as
 +  // long as the shader never actually samples that index at draw time --
-+  // true here since no captured shader this session used tfetch3D/
++  // true here since no captured shader has used tfetch3D/
 +  // tfetchCube).
 +  std::array<BindlessHeapEntry, kBindlessHeapSlotCount> texture2d_entries;
 +
-+  // Real fix (2026-08-18, bindless-heap race -- see kBindlessHeapSlotCount's
++  // Fixes the bindless-heap race above (see kBindlessHeapSlotCount's
 +  // comment): maps a distinct real (VkImageView, VkSampler) pair to its
 +  // permanently-allocated heap slot. A texture is written to the descriptor
 +  // set exactly once, the first time it's seen; every later draw that reuses
@@ -2179,7 +2499,7 @@ index 0000000..eae85f1
 +  // file's header comment) -- generalized to any shader's real constant
 +  // registers instead of one hardcoded half-pixel-offset value.
 +  std::unique_ptr<ui::vulkan::VulkanUploadBufferPool> constants_pool;
-+  // Real bug found+fixed 2026-08-17 ("Not enough memory for command
++  // Fixes a real bug ("Not enough memory for command
 +  // submission" / amdgpu_vm_validate() failures, confirmed via a live
 +  // VRAM/GTT poll showing GTT climbing ~6MB/s with NO plateau during
 +  // ordinary gameplay, independent of scene complexity): constants_pool is a real
@@ -2226,7 +2546,7 @@ index 0000000..eae85f1
 +  VkDescriptorSetLayoutBinding binding = MakeBindlessBinding(type);
 +
 +  // The three flags XenosRecomp's bindless scheme structurally requires:
-+  // PARTIALLY_BOUND (slots this session never wrote stay valid-but-unused,
++  // PARTIALLY_BOUND (slots never written stay valid-but-unused,
 +  // matching kBindlessHeapEntry's "unbound Texture3D/Cube" note above),
 +  // UPDATE_AFTER_BIND (write new texture slots without invalidating an
 +  // already-bound descriptor set, since real gameplay loads new textures
@@ -2390,15 +2710,12 @@ index 0000000..eae85f1
 +
 +bool HasNativePipeline(uint64_t vertex_shader_ucode_hash, uint64_t pixel_shader_ucode_hash) {
 +#if NATIVEVK_HAVE_XENOS_SHADER_CACHE
-+  // Real fix (2026-08-18): used to only initialize the panel once a real
-+  // vs+ps pair was found below, so if the native shader cache genuinely has
-+  // zero matching pairs (e.g. after a fresh, not-yet-repopulated capture --
-+  // see PROJECT_MEMORY.md's capture-hash-bug writeup), the panel never
-+  // appeared at all, with no way to tell "broken" apart from "nothing to
-+  // show yet". Always initialize on the first real check regardless of
-+  // outcome, so the panel is always reachable and can show "0 live pairs"
-+  // honestly instead of not existing.
-+  EnsureDebugPanelInitialized();
++  // The debug panel used to be lazily self-registered from here (see git
++  // history: EnsureDebugPanelInitialized()). It's now hosted as a tab in
++  // reNut's own debug hub (src/renut_engine/overlays/debug_hub_overlay.h),
++  // which calls RenutNativeShaderDebugPanelDrawContent() directly whenever
++  // its window is open -- no lazy init needed, GetDebugShaderPairs() and
++  // friends are safe to call regardless of whether any pair has matched yet.
 +  if (FindCacheEntry(vertex_shader_ucode_hash) == nullptr ||
 +      FindCacheEntry(pixel_shader_ucode_hash) == nullptr) {
 +    return false;
@@ -2446,12 +2763,12 @@ index 0000000..eae85f1
 +}
 +
 +// Real cull mode + blend state, read from the guest's own PA_SU_SC_MODE_CNTL
-+// / RB_BLENDCONTROL0 registers (2026-08-16 fix): GetOrCreatePipeline
-+// previously hardcoded VK_CULL_MODE_NONE and blendEnable=false for every
-+// native pipeline, unconditionally -- confirmed via direct comparison with
++// / RB_BLENDCONTROL0 registers: GetOrCreatePipeline previously hardcoded
++// VK_CULL_MODE_NONE and blendEnable=false for every native pipeline,
++// unconditionally -- confirmed via direct comparison with
 +// pipeline_cache.cpp's real per-draw ComputePipelineDescription /
 +// WritePipelineRenderTargetDescription, which read these exact registers
-+// for the stock path. Symptom match was exact: user-reported "particles no
++// for the stock path. Symptom match was exact: reported "particles no
 +// longer move but are still rendered and stuck to the viewport" and
 +// "glowing" (alpha-blended/additive effects becoming fully opaque, so each
 +// draw overwrites instead of blending) plus "less bugs facing one direction
@@ -2470,8 +2787,8 @@ index 0000000..eae85f1
 +  VkBlendFactor src_alpha_factor = VK_BLEND_FACTOR_ONE;
 +  VkBlendFactor dst_alpha_factor = VK_BLEND_FACTOR_ZERO;
 +  VkBlendOp alpha_blend_op = VK_BLEND_OP_ADD;
-+  // Real depth-test/-write/-compare state (2026-08-16 fix), read from the
-+  // guest's own RB_DEPTHCONTROL register -- GetOrCreatePipeline previously
++  // Real depth-test/-write/-compare state, read from the guest's own
++  // RB_DEPTHCONTROL register -- GetOrCreatePipeline previously
 +  // hardcoded depthTestEnable/depthWriteEnable to VK_TRUE with a fixed
 +  // VK_COMPARE_OP_LESS_OR_EQUAL for every native pipeline whenever a depth
 +  // attachment existed, regardless of what the guest actually asked for.
@@ -2554,13 +2871,13 @@ index 0000000..eae85f1
 +                        result.dst_alpha_factor != VK_BLEND_FACTOR_ZERO ||
 +                        result.alpha_blend_op != VK_BLEND_OP_ADD;
 +
-+  // Real per-draw depth-test/-write/-compare state (2026-08-16 fix) -- see
++  // Per-draw depth-test/-write/-compare state -- see
 +  // RasterAndBlendState's own header comment. Same real
 +  // CompareFunction->VkCompareOp mapping the stock path uses
 +  // (pipeline_cache.cpp: `VK_COMPARE_OP_NEVER + xenos::CompareFunction`),
 +  // safe because both enums share the identical 3-bit never/less/equal/
 +  // lessequal/greater/notequal/greaterequal/always ordering.
-+  // Real bug found+fixed (2026-08-17): reading RB_DEPTHCONTROL raw skipped
++  // Real bug found+fixed: reading RB_DEPTHCONTROL raw skipped
 +  // the RB_MODECONTROL.edram_mode gate the stock renderer applies via
 +  // draw_util::GetNormalizedDepthControl (draw.cpp) -- whenever edram_mode
 +  // isn't kColorDepth/kDepthOnly, depth/stencil are fully ignored by the
@@ -2616,7 +2933,7 @@ index 0000000..eae85f1
 +  const ui::vulkan::VulkanDevice::Functions& dfn = vulkan_device->functions();
 +  VkDevice device = vulkan_device->device();
 +
-+  // Dynamic-rendering fix (2026-08-16): in_render_pass() is real and
++  // Dynamic-rendering fix: in_render_pass() is real and
 +  // correct under BOTH rendering modes (unlike current_render_pass(), which
 +  // is always VK_NULL_HANDLE under dynamic rendering by design -- see
 +  // PipelineEntry's own comment on pipeline_render_pass_key). This is the
@@ -2629,7 +2946,7 @@ index 0000000..eae85f1
 +      render_target_cache ? render_target_cache->last_update_render_pass_key()
 +                          : VulkanRenderTargetCache::RenderPassKey();
 +
-+  // Real per-draw cull/blend state (2026-08-16 fix, see
++  // Per-draw cull/blend state ( see
 +  // ComputeRasterAndBlendState's header comment) -- read BEFORE the cache
 +  // lookup and folded into the key, same real reason primitive topology and
 +  // render_pass_key already are: the same (vs_hash, ps_hash) pair can
@@ -2660,13 +2977,13 @@ index 0000000..eae85f1
 +  if (it != state.pipelines.end()) {
 +    PipelineEntry& entry = it->second;
 +    if (entry.pipeline != VK_NULL_HANDLE) {
-+      // Real bug found+fixed (2026-08-17): an earlier version of this fix
++      // Real bug found+fixed: an earlier version of this fix
 +      // fell through to re-run the ENTIRE build below (including
 +      // recreating entry.vertex_module/pixel_module/pipeline in place,
 +      // repeatedly, on the live render path) whenever debug mode was on and
 +      // a cached pair hadn't built its debug variant yet -- confirmed real
-+      // and harmful: user-reported symptom was native draw count
-+      // completely stalling and visible flickering the moment debug mode
++      // and harmful: the symptom was native draw count completely
++      // stalling and visible flickering the moment debug mode
 +      // was enabled, consistent with pipeline/shader-module churn under
 +      // load starting to fail. Reverted to simply never retrofitting a
 +      // debug variant onto an ALREADY-cached pipeline -- debug-colorize
@@ -2723,7 +3040,7 @@ index 0000000..eae85f1
 +  // VertexBinding corresponds to one Xenos fetch-constant slot (usually one
 +  // interleaved stream, but built generically -- not assumed to be one).
 +  //
-+  // Real fix (2026-08-16): locations are NOT sequential in vfetch-
++  // locations are NOT sequential in vfetch-
 +  // instruction order -- XenosRecomp compiles the vertex shader's SPIR-V
 +  // stage with a FIXED location per D3D9 usage/usageIndex (its own
 +  // shader_recompiler.cpp: USAGE_LOCATIONS, e.g. Position=0, Normal=1,
@@ -2750,7 +3067,7 @@ index 0000000..eae85f1
 +    binding_info.binding = next_binding;
 +    entry.bindings.push_back(binding_info);
 +
-+    // Real bug found+fixed (2026-08-17): vb.attributes is in RAW UCODE
++    // Real bug found+fixed: vb.attributes is in RAW UCODE
 +    // SCAN ORDER (whatever order vfetch instructions appear in the
 +    // program), but tools/build_synthetic_container.py's
 +    // build_vertex_container() -- which is what actually built the
@@ -2789,7 +3106,7 @@ index 0000000..eae85f1
 +                                   : kRenutVertexLocationUnset;
 +      ++raw_attribute_index;
 +
-+      // Real fix (2026-08-17): Normal0/Tangent0/Binormal0 -- Vulkan
++      // Normal0/Tangent0/Binormal0 -- Vulkan
 +      // locations 1/2/3 in XenosRecomp's own fixed USAGE_LOCATIONS table
 +      // (shader_recompiler.cpp; same table xenos_cache_unpack.cpp's
 +      // kUsageLocations mirrors to compute vertexLocations[]) -- are always
@@ -2812,7 +3129,7 @@ index 0000000..eae85f1
 +      // integer format here, bypassing the real-source-format-based
 +      // VertexFormatToVkFormat() mapping entirely for just this usage
 +      // class, matching what tfetchR11G11B10() actually expects.
-+      // Real fix (2026-08-17): vertex locations went positional (see
++      // vertex locations went positional (see
 +      // vertexLocations's own header comment in renut_xenos_shader_cache.h),
 +      // so "location == 1/2/3" no longer identifies Normal/Tangent/Binormal
 +      // -- those usages can now land at any raw attribute index. Detect the
@@ -2840,14 +3157,13 @@ index 0000000..eae85f1
 +          real_location != kRenutVertexLocationUnset ? uint32_t(real_location) : next_location;
 +      ++next_location;
 +      attribute_info.fetch_constant_index = vb.fetch_constant;
-+      // offset is in dwords per ParsedVertexFetchInstruction::Attributes
-+      // (see PLAN_native_renderer.md's vfetch decode findings) -- convert
-+      // to bytes for a real VkVertexInputAttributeDescription.
++      // offset is in dwords per ParsedVertexFetchInstruction::Attributes --
++      // convert to bytes for a real VkVertexInputAttributeDescription.
 +      attribute_info.offset_bytes = uint32_t(fetch.attributes.offset) * 4u;
 +      attribute_info.format = vk_format;
 +      entry.attributes.push_back(attribute_info);
 +
-+      // Real fix (2026-08-17): the vertex INPUT location no longer encodes
++      // the vertex INPUT location no longer encodes
 +      // D3D9 usage at all (see vertexLocations's own header comment) -- but
 +      // XenosRecomp's compiled HLSL doesn't need it to: tfetchTexcoord()'s
 +      // real semanticIndex is baked in as a compile-time literal at the
@@ -2882,7 +3198,7 @@ index 0000000..eae85f1
 +    ++next_binding;
 +  }
 +
-+  // Real constraint (2026-08-17): a shader's texture/sampler descriptor
++  // Real constraint: a shader's texture/sampler descriptor
 +  // index is read at runtime from SharedConstants at byte
 +  // `dimension * 64 + fetch_constant * 4` (see SharedConstantsLayout), so
 +  // each dimension's index array holds exactly 16 entries. A fetch constant
@@ -2911,7 +3227,7 @@ index 0000000..eae85f1
 +    return VK_NULL_HANDLE;
 +  }
 +
-+  // TEMP DIAGNOSTIC (2026-08-16): once per unique (vs_hash, ps_hash) pair,
++  // TEMP DIAGNOSTIC: once per unique (vs_hash, ps_hash) pair,
 +  // dump real per-attribute location/offset/format/binding-count/stride --
 +  // isolating which live native shader corrupts geometry, now that
 +  // topology/constant-table/bool-constant/vertex-location bugs are all
@@ -3039,14 +3355,14 @@ index 0000000..eae85f1
 +  VkPipelineRasterizationStateCreateInfo rasterization_state = {};
 +  rasterization_state.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
 +  rasterization_state.polygonMode = VK_POLYGON_MODE_FILL;
-+  // Real per-draw cull mode/winding (2026-08-16 fix) -- see
++  // Per-draw cull mode/winding -- see
 +  // ComputeRasterAndBlendState's header comment; was hardcoded to
 +  // VK_CULL_MODE_NONE for every native pipeline before this.
 +  rasterization_state.cullMode = raster_blend_state.cull_mode;
 +  rasterization_state.frontFace = raster_blend_state.front_face;
 +  rasterization_state.lineWidth = 1.0f;
 +
-+  // Real bug found+fixed 2026-08-17: this was hardcoded to
++  // this was hardcoded to
 +  // VK_SAMPLE_COUNT_1_BIT for every native pipeline regardless of the
 +  // guest's real, per-draw MSAA state -- render_pass_key.msaa_samples
 +  // (already read from the real RB_SURFACE_INFO register by
@@ -3064,7 +3380,7 @@ index 0000000..eae85f1
 +  // the later MSAA resolve step reads -- a mechanistically exact match for
 +  // a striped-looking image, and shader-content-independent (hits every
 +  // native draw against such a target, not specific shaders), matching why
-+  // four separate real shader-translation-correctness fixes this session
++  // four separate real shader-translation-correctness fixes have
 +  // produced zero visible change. Mirrors the exact same real fallback
 +  // render_target_cache.cpp's own image creation uses (2x MSAA attachments
 +  // aren't universally supported; the render target cache already silently
@@ -3082,13 +3398,13 @@ index 0000000..eae85f1
 +        VkSampleCountFlagBits(uint32_t(1) << uint32_t(render_pass_key.msaa_samples));
 +  }
 +
-+  // Real per-draw blend state (2026-08-16 fix) -- see
++  // Per-draw blend state -- see
 +  // ComputeRasterAndBlendState's header comment; blendEnable was left at
 +  // its VkPipelineColorBlendAttachmentState{} default (false) for every
 +  // native pipeline before this, so alpha-blended/additive draws (particle
 +  // effects, glow) rendered fully opaque instead.
 +  //
-+  // Real bug found+fixed (2026-08-17): attachmentCount was hardcoded to 1
++  // Real bug found+fixed: attachmentCount was hardcoded to 1
 +  // regardless of how many color render targets this draw actually uses.
 +  // Vulkan requires VkPipelineColorBlendStateCreateInfo::attachmentCount to
 +  // exactly match the real number of color attachments (both under dynamic
@@ -3133,7 +3449,7 @@ index 0000000..eae85f1
 +  // Vulkan spec requirement that pDepthStencilState be non-null if the
 +  // pipeline's render pass (or, under dynamic rendering,
 +  // VkPipelineRenderingCreateInfo) uses a depth/stencil attachment.
-+  // Real per-draw test/write/compare values (2026-08-16 fix) -- see
++  // Per-draw test/write/compare values -- see
 +  // RasterAndBlendState's own header comment; was hardcoded to always-on
 +  // LESS_OR_EQUAL for every native pipeline before this, regardless of
 +  // what the guest's own RB_DEPTHCONTROL register actually asked for.
@@ -3151,7 +3467,7 @@ index 0000000..eae85f1
 +  dynamic_state.dynamicStateCount = uint32_t(rex::countof(kDynamicStates));
 +  dynamic_state.pDynamicStates = kDynamicStates;
 +
-+  // Real bug found+fixed 2026-08-17: XenosRecomp's generated shaders read a
++  // XenosRecomp's generated shaders read a
 +  // runtime Vulkan specialization constant at constant_id(0)
 +  // (shader_common.h: "[[vk::constant_id(0)]] const uint g_SpecConstants = 0;")
 +  // to decide real per-shader behavior -- notably SPEC_CONSTANT_R11G11B10_NORMAL,
@@ -3203,7 +3519,7 @@ index 0000000..eae85f1
 +  stages[1].pName = "main";
 +  stages[1].pSpecializationInfo = &ps_spec_info;
 +
-+  // Dynamic-rendering fix (2026-08-16): real VkPipelineRenderingCreateInfo,
++  // Dynamic-rendering fix: real VkPipelineRenderingCreateInfo,
 +  // built from the SAME real RenderPassKey used above for cache validity --
 +  // mirrors the stock renderer's own already-working pattern exactly
 +  // (pipeline_cache.cpp:3602-3630), just via the real public accessors this
@@ -3215,7 +3531,7 @@ index 0000000..eae85f1
 +  VkFormat color_attachment_formats[xenos::kMaxColorRenderTargets] = {};
 +  if (use_dynamic_rendering) {
 +    pipeline_rendering_create_info.sType = VK_STRUCTURE_TYPE_PIPELINE_RENDERING_CREATE_INFO;
-+    // Real fix (2026-08-17): reuse the SAME color_attachment_count computed
++    // reuse the SAME color_attachment_count computed
 +    // above for color_blend_state instead of an independently-recomputed
 +    // local of the same name -- one real source of truth (see that
 +    // computation's own comment for why the two must never drift apart).
@@ -3458,12 +3774,12 @@ index 0000000..eae85f1
 +// g_HalfPixelOffset/g_AlphaThreshold, at a FIXED byte offset of 256
 +// (XenosRecomp's macro literally hardcodes packoffset(c16...), not computed
 +// per-shader -- see shader_recompiler.cpp lines ~1298-1321: the sampler
-+// index-field loop always ends before c16 in every real shader this session
-+// captured, real samplers use low single-digit registerIndex values).
++// index-field loop always ends before c16 in every real shader captured
++// so far, real samplers use low single-digit registerIndex values).
 +// Matches nativevk_phase1_native_draw.cpp's already-proven field values for
 +// the same 4 fields, just at the real, non-zero byte offset a multi-texture
 +// shader's SharedConstants buffer actually needs.
-+// Real fix (2026-08-17): `booleans` was a single uint32 and the three fields
++// `booleans` was a single uint32 and the three fields
 +// after it sat at bytes 260/264/272. The Xenos boolean constant file is
 +// actually 256 bits -- XE_GPU_REG_SHADER_CONSTANT_BOOL_000_031 through
 +// _224_255, 8 consecutive dwords -- with vertex-shader booleans at 0-127 and
@@ -3480,14 +3796,14 @@ index 0000000..eae85f1
 +//
 +// nativevk_phase1_native_draw.cpp keeps its own separate, smaller struct for its
 +// own pre-baked SPIR-V and is intentionally untouched by this change.
-+// Real fix (2026-08-17): half_pixel_offset replaced with the full
++// half_pixel_offset replaced with the full
 +// ndc_scale/ndc_offset pair -- see shader_common.h's g_NdcScale/g_NdcOffset
 +// comment and last_viewport_info()'s comment (command_processor.h) for the
 +// full story. Default-constructed to the identity transform (scale=1,
 +// offset=0) so any code path that somehow uses this struct without
 +// populating it from a real draw's ViewportInfo degrades to a no-op rather
 +// than zeroing out every vertex position.
-+// ROOT CAUSE FOUND+FIXED (2026-08-17, by diffing against UnleashedRecomp,
++// ROOT CAUSE FOUND+FIXED (by diffing against UnleashedRecomp,
 +// XenosRecomp's own reference consumer): this space was NOT "reserved" --
 +// it holds the real, RUNTIME-READ texture/sampler descriptor indices, and
 +// leaving it zeroed made every native shader sample heap slot 0.
@@ -3564,7 +3880,7 @@ index 0000000..eae85f1
 +  // Re-find by scanning for the matching pipeline handle rather than
 +  // recomputing the ps-inclusive key here (caller already resolved that in
 +  // GetOrCreatePipeline) -- cheap linear scan over a few dozen entries.
-+  // Real bug found+fixed (2026-08-17): this scan only ever matched
++  // Real bug found+fixed: this scan only ever matched
 +  // kv.second.pipeline, but GetOrCreatePipeline() returns
 +  // kv.second.debug_pipeline instead whenever debug-colorize mode is on
 +  // (see SetDebugColorizeMode's header comment). The caller
@@ -3597,7 +3913,7 @@ index 0000000..eae85f1
 +    return;
 +  }
 +
-+  // Real fix (2026-08-17): reclaim constants_pool's completed pages once
++  // reclaim constants_pool's completed pages once
 +  // per frame, matching the stock renderer's own uniform_buffer_pool_
 +  // cadence (command_processor.cpp's BeginSubmission) -- see
 +  // BindlessHeapState::last_reclaimed_frame's own comment for the full
@@ -3665,7 +3981,7 @@ index 0000000..eae85f1
 +  const RegisterFile& regs = *command_processor.register_file();
 +  constexpr size_t kFloatConstantsBytes = 256 * 4 * sizeof(float);
 +
-+  // TEMP DIAG (2026-08-17): investigating why vs_78963937a7788928 (a boot
++  // TEMP DIAG: investigating why vs_78963937a7788928 (a boot
 +  // video full-screen quad -- raw position passthrough, no transform
 +  // matrix) renders as a black screen when native but not when stock.
 +  // IssueNativeDraw never reads PA_CL_CLIP_CNTL.clip_disable at all, but
@@ -3696,7 +4012,7 @@ index 0000000..eae85f1
 +    }
 +  }
 +
-+  // Real bug found+fixed 2026-08-17: shared_constants was declared above
++  // shared_constants was declared above
 +  // with its in-class defaults (all zero/placeholder) and NEVER written
 +  // before being shipped to the GPU -- every native draw was supplying
 +  // g_Booleans=0, g_SwappedTexcoords=0, g_AlphaThreshold=0.5 (a constant,
@@ -3718,7 +4034,7 @@ index 0000000..eae85f1
 +  //   - g_AlphaThreshold: the guest's real per-draw alpha-test reference
 +  //     register, already a normalized float (RB_ALPHA_REF is `kFloat` in
 +  //     register_table.inc) -- no unit conversion needed.
-+  //   - g_NdcScale/g_NdcOffset (real fix, 2026-08-17, supersedes the old
++  //   - g_NdcScale/g_NdcOffset (real fix, supersedes the old
 +  //     "g_HalfPixelOffset intentionally left at zero" note below): the
 +  //     stock renderer's ndc_scale/ndc_offset ISN'T just the half-pixel
 +  //     offset, it's the entire guest-clip-space-to-host-viewport transform
@@ -3734,7 +4050,7 @@ index 0000000..eae85f1
 +  //     the stock path uses, once per draw, before the native/stock branch
 +  //     -- not re-derived here, so this can never drift out of sync with
 +  //     what the stock path itself would have used for this exact draw.
-+  // Real fix (2026-08-17): was uploading only the first dword, i.e. booleans
++  // was uploading only the first dword, i.e. booleans
 +  // 0-31, so every pixel-shader boolean (which live at 128-255 on this
 +  // hardware) was never sent to the GPU at all -- the shader read whatever
 +  // happened to be in the vertex-shader boolean bits instead. All 8 dwords of
@@ -3748,12 +4064,12 @@ index 0000000..eae85f1
 +  }
 +  shared_constants.swapped_texcoords = found->swapped_texcoords_mask;
 +  shared_constants.alpha_threshold = regs.Get<float>(XE_GPU_REG_RB_ALPHA_REF);
-+  // Real fix (2026-08-17): real per-draw alpha-test enable, matching the
++  // real per-draw alpha-test enable, matching the
 +  // same register the stock renderer reads (draw_util::DoesCoverageDependOnAlpha)
 +  // -- see g_AlphaTestEnable's own comment (shader_common.h) for why this
 +  // must be dynamic rather than baked at shader-conversion time.
 +  //
-+  // Real bug found+fixed (2026-08-17, same day): the first version of this
++  // Real bug found+fixed (same day): the first version of this
 +  // fix gated purely on RB_COLORCONTROL.alpha_test_enable, but XenosRecomp's
 +  // compiled `clip(oC0.w - g_AlphaThreshold)` hardcodes exactly ONE
 +  // comparator -- discard when oC0.w < threshold, i.e. GEQUAL-keep
@@ -3780,7 +4096,7 @@ index 0000000..eae85f1
 +    }
 +  }
 +
-+  // Real "represent each shader on screen" feature (2026-08-17, user-
++  // Real "represent each shader on screen" feature (user-
 +  // requested): best-effort on-screen label position, gated behind the
 +  // panel's toggle so this costs nothing when the feature's off (the
 +  // common case). HEURISTIC, not a verified-correct decode -- still
@@ -3788,8 +4104,8 @@ index 0000000..eae85f1
 +  // c0-c3 (the D3D9 HLSL compiler's default top-down allocation order
 +  // almost always puts the first-declared matrix there).
 +  //
-+  // Real fix (2026-08-17, "labels stick to the player/camera, not the
-+  // object" bug report): the original version of this evaluated the
++  // Fixes "labels stick to the player/camera, not the object" -- the
++  // original version of this evaluated the
 +  // matrix at a fixed, assumed LOCAL-space origin (0,0,0,1) for every
 +  // draw. That only yields a per-object world position if c0-c3 holds a
 +  // real World*View*Projection matrix that changes per draw. The reported
@@ -3838,7 +4154,7 @@ index 0000000..eae85f1
 +          rex::memory::load_and_swap<float>(raw + 8),
 +      };
 +
-+      // Real fix (2026-08-17): was a hardcoded c0 guess; now a live,
++      // was a hardcoded c0 guess; now a live,
 +      // panel-adjustable base register (see GetNativeShaderLabelMatrixRegister's
 +      // own header comment for why -- two static guesses in a row were both
 +      // wrong, so this is now a calibration knob instead of a third guess).
@@ -3937,9 +4253,9 @@ index 0000000..eae85f1
 +                             uint32_t(rex::countof(bindless_sets)), bindless_sets, 0, nullptr);
 +
 +  // Real vertex buffer binding: shared_memory_->buffer() IS a real VkBuffer
-+  // already containing live guest memory (see PLAN_native_renderer.md's
-+  // finding that stock renut has zero vkCmdBindVertexBuffers calls and
-+  // instead fetches in-shader via SSBO -- native pipelines need the real
++  // already containing live guest memory (stock renut has zero
++  // vkCmdBindVertexBuffers calls and instead fetches in-shader via SSBO --
++  // native pipelines need the real
 +  // fixed-function binding XenosRecomp's HLSL expects, into the SAME
 +  // memory, at the byte offset the fetch constant's own address already
 +  // gives). By this point in IssueDraw, the caller's earlier vfetch-
@@ -3986,7 +4302,7 @@ index 0000000..eae85f1
 +}
 +
 +uint64_t PeekLastFrameDrawCount() {
-+  // Real bug found+fixed (2026-08-17): this used to read a snapshot taken
++  // Real bug found+fixed: this used to read a snapshot taken
 +  // inside TakeDrawCount(), which is ONLY called from RenutWriteTraceRow's
 +  // fprintf argument list (command_processor.cpp) -- i.e. only when the CSV
 +  // trace file is actually open and being written to. Confirmed via the
@@ -4015,13 +4331,13 @@ index 0000000..eae85f1
 +}  // namespace rex::graphics::vulkan::nativevk_pipeline
 diff --git a/src/graphics/vulkan/nativevk_xenos_pipeline_cache.h b/src/graphics/vulkan/nativevk_xenos_pipeline_cache.h
 new file mode 100644
-index 0000000..b53a6dd
+index 0000000..dc79011
 --- /dev/null
 +++ b/src/graphics/vulkan/nativevk_xenos_pipeline_cache.h
-@@ -0,0 +1,247 @@
+@@ -0,0 +1,240 @@
 +#pragma once
-+// Native-renderer "convert the important/common shaders" effort (see
-+// PLAN_native_renderer.md). Generalizes Phase 1's single hardcoded
++// Native-renderer "convert the important/common shaders" effort. Generalizes
++// Phase 1's single hardcoded
 +// vs_67021cae68a26b46+ps_12c73f3eb45dad49 pipeline (nativevk_phase1_native_draw)
 +// into a real cache keyed by (vertex hash, pixel hash), backed by
 +// renut_xenos_shader_cache.h's batch-converted SPIR-V (see
@@ -4062,7 +4378,7 @@ index 0000000..b53a6dd
 +// buffer. Returns VK_NULL_HANDLE if creation failed (logged once per
 +// shader pair) or the device lacks bufferDeviceAddress.
 +//
-+// host_primitive_type (2026-08-16 fix): the pipeline's input assembly
++// host_primitive_type: the pipeline's input assembly
 +// topology was hardcoded to VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST regardless
 +// of what the guest actually drew -- correct only for kTriangleList itself,
 +// wrong (garbled/misconnected geometry, confirmed via real in-game visual
@@ -4079,9 +4395,8 @@ index 0000000..b53a6dd
 +// Issues the native draw: binds the pipeline via BindExternalGraphicsPipeline
 +// (the same proven seam Phase 1 uses), binds shared_memory_->buffer() at the
 +// REAL guest vertex-fetch-constant byte offsets for each vertex binding
-+// (Xenos vfetch instructions address SharedMemory directly -- see
-+// PLAN_native_renderer.md's "no vkCmdBindVertexBuffers in stock renut"
-+// finding; native pipelines DO need a real fixed-function binding, unlike
++// (Xenos vfetch instructions address SharedMemory directly, and native
++// pipelines DO need a real fixed-function binding, unlike
 +// the stock in-shader SSBO fetch, so this binds the SAME memory stock renut
 +// already made resident via RequestRange/RequestRanges earlier in IssueDraw,
 +// just via a real Vulkan vertex-input binding instead of an SSBO load), and
@@ -4093,7 +4408,7 @@ index 0000000..b53a6dd
 +// pixel shader's own texture_bindings() (fetch_constant -> heap slot) must
 +// be walked to know which real textures this draw needs bound.
 +//
-+// index_buffer (2026-08-16 fix): the caller's own draw (the normal
++// index_buffer: the caller's own draw (the normal
 +// Xenos-translated path, right below this call in command_processor.cpp)
 +// picks between CmdVkDraw and CmdVkDrawIndexed depending on whether this
 +// draw uses a real index buffer -- this native path was unconditionally
@@ -4123,8 +4438,8 @@ index 0000000..b53a6dd
 +// run in ordinary play. Safe to read from the debug panel at any time.
 +uint64_t PeekLastFrameDrawCount();
 +
-+// Bindless texture/sampler heap follow-up (see PLAN_native_renderer.md):
-+// XenosRecomp-generated shaders expect a real bindless descriptor scheme
++// Bindless texture/sampler heap: XenosRecomp-generated shaders expect a
++// real bindless descriptor scheme
 +// this SDK never had (confirmed via direct codebase search: zero
 +// UPDATE_AFTER_BIND/PARTIALLY_BOUND/bindless usage anywhere in
 +// src/graphics/vulkan or include/rex/graphics/vulkan before this) -- fixed-
@@ -4150,7 +4465,7 @@ index 0000000..b53a6dd
 +// addressed, not descriptor-set-bound).
 +VkPipelineLayout GetOrCreateBindlessPipelineLayout(VulkanCommandProcessor& command_processor);
 +
-+// Real-time native-shader debug panel support (2026-08-16): every shader
++// Real-time native-shader debug panel support: every shader
 +// pair HasNativePipeline() has ever seen (both sides genuinely converted,
 +// so a real candidate for substitution -- a few dozen at most, not every
 +// pair the game ever draws) is recorded with a live on/off toggle. The
@@ -4167,7 +4482,7 @@ index 0000000..b53a6dd
 +  // marked_bad_shaders.txt when first seen this run (see
 +  // RecordAndCheckPairEnabled()), not because of a live manual toggle.
 +  bool marked_bad;
-+  // Real "hard to find again" fix (2026-08-17, user-requested): the panel
++  // Real "hard to find again" fix: the panel
 +  // used to identify every pair only by its two 16-hex-digit hashes, which
 +  // is unreadable enough that re-locating a specific pair after toggling it
 +  // was impractical with hundreds of live pairs. A small, stable, 1-based
@@ -4189,20 +4504,14 @@ index 0000000..b53a6dd
 +void SetAllDebugShaderPairsEnabled(bool enabled);
 +
 +// Convenience for the panel's "Enable All Bad" / "Disable All Bad" buttons
-+// (2026-08-17, user-requested): flips only the pairs with marked_bad set
++//: flips only the pairs with marked_bad set
 +// (i.e. listed in marked_bad_shaders.txt), leaving every other pair's live
 +// enabled state untouched -- lets the user quickly re-test "does turning
 +// all known-bad shaders back on reproduce the corruption" without having to
 +// click every marked pair individually.
 +void SetMarkedBadShaderPairsEnabled(bool enabled);
 +
-+// Lazily creates and registers the real ImGui debug panel (see
-+// renut_shader_debug_panel.cpp), once per process. Safe to call every
-+// frame (no-ops after the first call), matching this file's
-+// EnsureBindlessHeapInitialized pattern.
-+void EnsureDebugPanelInitialized();
-+
-+// Real "represent each shader on screen" feature (2026-08-17, user-
++// Real "represent each shader on screen" feature (user-
 +// requested): a best-effort floating "#<display_id>" label the panel draws
 +// above wherever a native pair last drew. Position is a HEURISTIC, not a
 +// verified-correct per-shader decode -- see IssueNativeDraw's own comment
@@ -4229,8 +4538,8 @@ index 0000000..b53a6dd
 +void SetShowNativeShaderLabels(bool show);
 +bool GetShowNativeShaderLabels();
 +
-+// Real fix (2026-08-17, user-reported: labels cluster above the player
-+// instead of at each object): two static guesses (assumed local-space
++// Labels used to cluster above the player instead of at each object:
++// two static guesses (assumed local-space
 +// origin, then real vertex data) both put the "WorldViewProjection at
 +// c0-c3" assumption at fault -- that register block is very likely NOT a
 +// per-object matrix for this game's shaders. Rather than keep guessing
@@ -4243,7 +4552,7 @@ index 0000000..b53a6dd
 +void SetNativeShaderLabelMatrixRegister(uint32_t base_register);
 +uint32_t GetNativeShaderLabelMatrixRegister();
 +
-+// Debugging feature (2026-08-17, user-requested): user reported that after
++// Debugging feature: user reported that after
 +// several real, verified shader-translation fixes (positional vertex
 +// locations, boolean-constant width, vfetch-order/location alignment), the
 +// on-screen corruption looked visually unchanged, to the point of doubting
@@ -4267,14 +4576,14 @@ index 0000000..b53a6dd
 +
 +}  // namespace rex::graphics::vulkan::nativevk_pipeline
 diff --git a/src/ui/vulkan/vulkan_device.cpp b/src/ui/vulkan/vulkan_device.cpp
-index fc31478..285172f 100644
+index fc31478..0e20d77 100644
 --- a/src/ui/vulkan/vulkan_device.cpp
 +++ b/src/ui/vulkan/vulkan_device.cpp
 @@ -648,6 +648,26 @@ std::unique_ptr<VulkanDevice> VulkanDevice::CreateIfSupported(
        XE_UI_VULKAN_FEATURE_2(features_1_2, samplerMirrorClampToEdge);
        XE_UI_VULKAN_FEATURE_2(features_1_2, uniformBufferStandardLayout);
        XE_UI_VULKAN_FEATURE_2(features_1_2, scalarBlockLayout);
-+      // Native-renderer Phase 1 (see PLAN_native_renderer.md): optional, not
++      // Native-renderer Phase 1: optional, not
 +      // required for stock GPU emulation, so this does not gate device
 +      // creation if unsupported -- only renut's native draw path needs it,
 +      // and it checks device->properties().bufferDeviceAddress before use.
@@ -4319,7 +4628,7 @@ index fc31478..285172f 100644
    if (device->extensions_.ext_KHR_swapchain) {
  #include <rex/ui/vulkan/functions/device_khr_swapchain.inc>
    }
-+  // Native-renderer Phase 1 (see PLAN_native_renderer.md): optional, does not
++  // Native-renderer Phase 1: optional, does not
 +  // affect functions_loaded/device creation success if the function pointer
 +  // turns out to be unavailable despite the feature bit being set -- callers
 +  // must check device->properties().bufferDeviceAddress before use, not just
@@ -4329,7 +4638,7 @@ index fc31478..285172f 100644
 +    // above), so bufferDeviceAddress is always the PROMOTED/core feature
 +    // here, never the standalone extension -- must query the CORE name
 +    // ("vkGetBufferDeviceAddress"), not the legacy "...KHR" extension name.
-+    // Bug found during Phase 1 bring-up (2026-08-17): this block originally
++    // Bug found during Phase 1 bring-up: this block originally
 +    // copied the non-promoted/legacy-name macro pattern by mistake, which
 +    // queries the wrong proc name and was the root cause of a black-screen
 +    // regression -- confirmed via bisection, not assumed.

--- a/cmake/patches/rexglue_sdk_native_renderer.patch
+++ b/cmake/patches/rexglue_sdk_native_renderer.patch
@@ -1,0 +1,4383 @@
+diff --git a/include/rex/graphics/nativevk/command_processor.h b/include/rex/graphics/nativevk/command_processor.h
+new file mode 100644
+index 0000000..3469994
+--- /dev/null
++++ b/include/rex/graphics/nativevk/command_processor.h
+@@ -0,0 +1,35 @@
++#pragma once
++/**
++ * @file        graphics/nativevk/command_processor.h
++ * @brief       reNut native command processor
++ *
++ * Derives from VulkanCommandProcessor so it reuses the Vulkan subsystem caches
++ * (shared memory, primitive processor, render target / pipeline / texture
++ * caches) unchanged, while owning the draw submission path that reNut
++ * diverges. rexgpu-xenos is unaffected and remains the A/B reference.
++ */
++
++#include <rex/graphics/vulkan/command_processor.h>
++
++namespace rex::graphics::nativevk {
++
++class NativeVkCommandProcessor : public rex::graphics::vulkan::VulkanCommandProcessor {
++ public:
++  NativeVkCommandProcessor(rex::graphics::vulkan::VulkanGraphicsSystem* graphics_system,
++                        system::KernelState* kernel_state);
++  ~NativeVkCommandProcessor();
++
++ protected:
++  // Substitutes a native, statically-compiled pipeline for this draw when
++  // one is available -- see VulkanCommandProcessor::TryNativeDraw's own
++  // comment for the contract. This is the one point where reNut's native
++  // renderer diverges from stock draw submission.
++  bool TryNativeDraw(rex::graphics::vulkan::VulkanShader* vertex_shader,
++                     rex::graphics::vulkan::VulkanShader* pixel_shader,
++                     const rex::graphics::PrimitiveProcessor::ProcessingResult&
++                         primitive_processing_result,
++                     VkBuffer index_buffer, VkDeviceSize index_buffer_offset,
++                     VkIndexType index_type) override;
++};
++
++}  // namespace rex::graphics::nativevk
+diff --git a/include/rex/graphics/nativevk/graphics_system.h b/include/rex/graphics/nativevk/graphics_system.h
+new file mode 100644
+index 0000000..fa3bb44
+--- /dev/null
++++ b/include/rex/graphics/nativevk/graphics_system.h
+@@ -0,0 +1,30 @@
++#pragma once
++/**
++ * @file        graphics/nativevk/graphics_system.h
++ * @brief       reNut graphics system
++ *
++ * Reuses VulkanGraphicsSystem's provider setup and only swaps in reNut's own
++ * command processor.
++ */
++
++#include <memory>
++
++#include <rex/graphics/command_processor.h>
++#include <rex/graphics/vulkan/graphics_system.h>
++
++namespace rex::graphics::nativevk {
++
++class NativeVkGraphicsSystem : public rex::graphics::vulkan::VulkanGraphicsSystem {
++ public:
++  NativeVkGraphicsSystem();
++  ~NativeVkGraphicsSystem() override;
++
++  static bool IsAvailable() { return true; }
++
++  std::string name() const override;
++
++ private:
++  std::unique_ptr<CommandProcessor> CreateCommandProcessor() override;
++};
++
++}  // namespace rex::graphics::nativevk
+diff --git a/include/rex/graphics/vulkan/command_processor.h b/include/rex/graphics/vulkan/command_processor.h
+index 4b76791..1512d93 100644
+--- a/include/rex/graphics/vulkan/command_processor.h
++++ b/include/rex/graphics/vulkan/command_processor.h
+@@ -208,6 +208,67 @@ class VulkanCommandProcessor : public CommandProcessor {
+   // scope. Submission must be open.
+   void EndRenderPass();
+ 
++  // Native-renderer Phase 1 (see PLAN_native_renderer.md): the render pass
++  // currently open in the deferred command buffer, if any -- needed so an
++  // externally-bound pipeline (see BindExternalGraphicsPipeline) can be
++  // created against the SAME render pass a real guest draw is already
++  // targeting, rather than guessing the format ahead of time.
++  VkRenderPass current_render_pass() const { return current_render_pass_; }
++
++  // Native-renderer "convert the important/common shaders" (see
++  // PLAN_native_renderer.md nativevk_pipeline_cache.cpp): real guest
++  // vertex-fetch-constant lookups (register_file()) and the real VkBuffer
++  // backing all of guest memory (shared_memory()->buffer()) -- needed to
++  // bind a native pipeline's vertex input to the SAME bytes the stock
++  // Xenos-translated path already made resident via RequestRange/
++  // RequestRanges earlier in IssueDraw, instead of a fabricated buffer.
++  const RegisterFile* register_file() const { return register_file_; }
++  VulkanSharedMemory* shared_memory() const { return shared_memory_.get(); }
++  bool in_render_pass() const { return in_render_pass_; }
++
++  // Real bug found+fixed (2026-08-17): stock vertex shaders (spirv_translator.cpp)
++  // unconditionally apply a per-draw `oPos.xyz = oPos.xyz * ndc_scale + ndc_offset
++  // * oPos.w` correction to every vertex position -- it's what converts the
++  // guest's own clip-space output into the host's actual viewport-relative NDC,
++  // covering viewport scale/offset, window offset, half-pixel offset, the D3D-vs-
++  // GL clip-space convention, reverse-Z, AND the entire clip-disabled/screen-space
++  // draw case (full-screen quads, UI, video -- see draw.cpp's GetHostViewportInfo).
++  // XenosRecomp-compiled native shaders have NO equivalent of this at all -- it's
++  // a Xenia-runtime fixed-function step, not part of the guest microcode, so
++  // there's nothing in the compiled SPIR-V to apply it. Exposing the SAME
++  // already-computed ViewportInfo (computed once per real IssueDraw call, before
++  // the native/stock branch -- see IssueDraw's own GetHostViewportInfo call) lets
++  // the native path apply the identical correction via g_NdcScale/g_NdcOffset
++  // shared constants instead of silently doing nothing, which is what produced
++  // wildly mispositioned/oversized geometry for any draw relying on this (most
++  // visibly, screen-space full-screen quads rendering as huge stray triangles).
++  const draw_util::ViewportInfo& last_viewport_info() const { return last_viewport_info_; }
++
++  // Native-renderer "convert the important/common shaders": real bound
++  // texture lookups for a native pipeline's descriptor bindings (real
++  // shaders sample real textures -- see nativevk_pipeline_cache.cpp).
++  // TextureCache::GetValidTextureBinding() is `protected`, and the
++  // shader-translation-derived accessors used by the stock draw path
++  // (Shader::GetUsedTextureMaskAfterTranslation()/
++  // GetSamplerBindingsAfterTranslation()) are populated only by the SDK's
++  // OWN SPIR-V translator, which synthetic-container shaders (compiled
++  // externally by XenosRecomp) never run through -- so this exposes the
++  // texture cache itself instead, letting native-pipeline code look up a
++  // real bound texture directly by fetch-constant index via the texture
++  // cache's own already-public API surface.
++  VulkanTextureCache* texture_cache() const { return texture_cache_.get(); }
++
++  // Dynamic-rendering support follow-up (nativevk_pipeline_cache.cpp):
++  // native pipelines need the real active color/depth attachment FORMATS to
++  // build a VkPipelineRenderingCreateInfo (dynamic rendering has no
++  // VkRenderPass to key on -- see command_processor.cpp's
++  // `current_render_pass_ = use_dynamic_rendering ? VK_NULL_HANDLE :
++  // render_pass`). VulkanRenderTargetCache::last_update_render_pass_key()
++  // and GetColorVulkanFormat()/GetDepthVulkanFormat() are already public and
++  // already used by the stock pipeline_cache.cpp for exactly this -- this
++  // just exposes the cache itself so native-pipeline code can call them too.
++  VulkanRenderTargetCache* render_target_cache() const { return render_target_cache_.get(); }
++
+   VkDescriptorSetLayout GetSingleTransientDescriptorLayout(
+       SingleTransientDescriptorLayout transient_descriptor_layout) const {
+     return descriptor_set_layouts_single_transient_[size_t(transient_descriptor_layout)];
+@@ -273,7 +334,26 @@ class VulkanCommandProcessor : public CommandProcessor {
+ 
+   void InitializeTrace() override;
+ 
+- private:
++ protected:
++  // Extension point for plugins built on top of VulkanCommandProcessor (e.g.
++  // rexgpu-nativevk) to substitute a native, statically-compiled pipeline for
++  // this draw instead of the normal Xenos-translated one. Called from
++  // IssueDraw() once submission management, primitive processing, shader
++  // translation, barriers, render-pass entry, and vertex-fetch residency
++  // have already run normally -- only the final draw call itself may be
++  // swapped. vertex_shader is never null; pixel_shader may be. Returning
++  // true means the draw has been fully issued and IssueDraw() returns
++  // immediately; returning false falls through to the normal
++  // Xenos-translated draw path. Default implementation does nothing, so
++  // this has no effect unless overridden.
++  virtual bool TryNativeDraw(VulkanShader* vertex_shader, VulkanShader* pixel_shader,
++                             const PrimitiveProcessor::ProcessingResult& primitive_processing_result,
++                             VkBuffer index_buffer, VkDeviceSize index_buffer_offset,
++                             VkIndexType index_type) {
++    return false;
++  }
++
++
+   struct CommandBuffer {
+     VkCommandPool pool;
+     VkCommandBuffer buffer;
+@@ -762,6 +842,8 @@ class VulkanCommandProcessor : public CommandProcessor {
+   // declared as dynamic in the pipeline) invalidates such dynamic state.
+   VkViewport dynamic_viewport_;
+   VkRect2D dynamic_scissor_;
++  // Backing storage for last_viewport_info() -- see its own comment.
++  draw_util::ViewportInfo last_viewport_info_{};
+   // Dynamic fixed-function depth bias, blend constants, stencil state are
+   // applicable only to the render target implementations where they are
+   // actually involved.
+diff --git a/include/rex/ui/vulkan/device.h b/include/rex/ui/vulkan/device.h
+index 947817f..630353b 100644
+--- a/include/rex/ui/vulkan/device.h
++++ b/include/rex/ui/vulkan/device.h
+@@ -123,6 +123,35 @@ class VulkanDevice {
+ 
+     bool scalarBlockLayout = false;
+ 
++    // VK_KHR_buffer_device_address (#246, promoted to 1.2). Native-renderer
++    // Phase 1 (see PLAN_native_renderer.md): XenosRecomp's generated SPIR-V
++    // shaders address constant buffers via vk::RawBufferLoad from GPU virtual
++    // addresses passed as push constants, which requires this feature.
++
++    bool bufferDeviceAddress = false;
++
++    // VK_EXT_descriptor_indexing (#162, promoted to 1.2). Native-renderer
++    // "convert the important/common shaders" (see PLAN_native_renderer.md):
++    // XenosRecomp's generated shaders bind textures/samplers via a bindless
++    // descriptor array (`Texture2D<float4> g_Texture2DDescriptorHeap[] :
++    // register(t0, space0)`, indexed by a real descriptor index baked into
++    // the shader), not per-draw descriptor sets like the stock renderer's
++    // SPIR-V translator output -- these specific sub-features are what that
++    // scheme needs on the Vulkan side. Optional, gated the same way as
++    // bufferDeviceAddress -- callers must check these before use.
++
++    bool descriptorIndexing = false;
++    bool runtimeDescriptorArray = false;
++    bool shaderSampledImageArrayNonUniformIndexing = false;
++    bool descriptorBindingPartiallyBound = false;
++    bool descriptorBindingVariableDescriptorCount = false;
++    // Required in addition to descriptorBindingPartiallyBound whenever a
++    // binding uses VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT (as
++    // CreateBindlessSetLayout() does for both its sampled-image and sampler
++    // bindings) -- callers must check before enabling that bit.
++    bool descriptorBindingSampledImageUpdateAfterBind = false;
++    bool descriptorBindingUpdateUnusedWhilePending = false;
++
+     // VK_KHR_portability_subset (#164)
+ 
+     bool constantAlphaColorBlendFactors = false;
+@@ -154,6 +183,9 @@ class VulkanDevice {
+     // VK_KHR_dynamic_rendering (#55, promoted to 1.3)
+ 
+     bool dynamicRendering = false;
++    // VK_EXT_extended_dynamic_state, promoted to 1.3 core: cull mode and front
++    // face can be set per draw instead of baked into the pipeline.
++    bool extendedDynamicState = false;
+ 
+     // VK_EXT_non_seamless_cube_map (#423)
+ 
+@@ -220,6 +252,10 @@ class VulkanDevice {
+ #include <rex/ui/vulkan/functions/device_1_3_khr_maintenance4.inc>
+     // VK_KHR_dynamic_rendering (#55, promoted to 1.3)
+ #include <rex/ui/vulkan/functions/device_1_3_khr_dynamic_rendering.inc>
++    // VK_EXT_extended_dynamic_state (#268, promoted to 1.3)
++#include <rex/ui/vulkan/functions/device_1_3_ext_extended_dynamic_state.inc>
++    // VK_KHR_buffer_device_address (#246, promoted to 1.2)
++#include <rex/ui/vulkan/functions/device_1_2_khr_buffer_device_address.inc>
+ #undef XE_UI_VULKAN_FUNCTION_PROMOTED
+ #undef XE_UI_VULKAN_FUNCTION
+   };
+diff --git a/include/rex/ui/vulkan/functions/device_1_2_khr_buffer_device_address.inc b/include/rex/ui/vulkan/functions/device_1_2_khr_buffer_device_address.inc
+new file mode 100644
+index 0000000..03335e9
+--- /dev/null
++++ b/include/rex/ui/vulkan/functions/device_1_2_khr_buffer_device_address.inc
+@@ -0,0 +1,5 @@
++// VK_KHR_buffer_device_address functions. Promoted to Vulkan 1.2 core.
++// Native-renderer Phase 1 (see PLAN_native_renderer.md): optional -- loaded
++// only when the bufferDeviceAddress FEATURE was actually enabled (see
++// vulkan_device.cpp), never required for stock GPU emulation.
++XE_UI_VULKAN_FUNCTION_PROMOTED(vkGetBufferDeviceAddressKHR, vkGetBufferDeviceAddress)
+diff --git a/include/rex/ui/vulkan/functions/device_1_3_ext_extended_dynamic_state.inc b/include/rex/ui/vulkan/functions/device_1_3_ext_extended_dynamic_state.inc
+new file mode 100644
+index 0000000..b07e948
+--- /dev/null
++++ b/include/rex/ui/vulkan/functions/device_1_3_ext_extended_dynamic_state.inc
+@@ -0,0 +1,4 @@
++// VK_EXT_extended_dynamic_state functions used in ReXGlue.
++// Promoted to Vulkan 1.3 core.
++XE_UI_VULKAN_FUNCTION_PROMOTED(vkCmdSetCullModeEXT, vkCmdSetCullMode)
++XE_UI_VULKAN_FUNCTION_PROMOTED(vkCmdSetFrontFaceEXT, vkCmdSetFrontFace)
+diff --git a/src/graphics/CMakeLists.txt b/src/graphics/CMakeLists.txt
+index 9179574..86ca286 100644
+--- a/src/graphics/CMakeLists.txt
++++ b/src/graphics/CMakeLists.txt
+@@ -142,3 +142,128 @@ if(REXGLUE_USE_D3D12)
+         dxguid
+     )
+ endif()
++
++# rexgpu-nativevk: reNut's native D3D9->Vulkan renderer plugin. Selected at
++# runtime via --gpu_plugin=nativevk (librexgpu-nativevk*.so, loaded from next
++# to the host exe).
++#
++# Shares the backend-agnostic GPU core and the Vulkan subsystem caches with
++# rexgpu-xenos, but owns its own command processor, graphics system and plugin
++# entry point (src/graphics/nativevk/). rexgpu-xenos is never affected by edits
++# there, so it stays a pristine A/B reference.
++if(REXGLUE_USE_VULKAN)
++    set(REXGPU_NATIVEVK_SOURCES ${REXGPU_XENOS_SOURCES})
++    list(REMOVE_ITEM REXGPU_NATIVEVK_SOURCES plugin_main.cpp)
++    list(APPEND REXGPU_NATIVEVK_SOURCES
++        nativevk/plugin_main.cpp
++        nativevk/graphics_system.cpp
++        nativevk/command_processor.cpp
++        # Native-renderer Phase 1 (see PLAN_native_renderer.md): nativevk-only,
++        # never built into rexgpu-xenos, which stays a pristine A/B reference.
++        vulkan/nativevk_phase1_native_draw.cpp
++        # "Convert the important/common shaders": generalized pipeline cache,
++        # additive to Phase 1's single hardcoded pipeline above.
++        vulkan/nativevk_xenos_pipeline_cache.cpp
++        # Real-time native-shader debug panel (2026-08-16): see
++        # nativevk_xenos_pipeline_cache.h's GetDebugShaderPairs()/
++        # SetDebugShaderPairEnabled() and this file's own header comment.
++        vulkan/nativevk_shader_debug_panel.cpp
++    )
++
++    # "Convert the important/common shaders" (see PLAN_native_renderer.md):
++    # the generated, decompressed multi-shader SPIR-V cache, produced by
++    # reNut's own top-level build (renut_xenos_shader_batch() in
++    # cmake/rexglue_xenosrecomp.cmake + tools/xenos_batch_convert.py +
++    # tools/xenos_cache_unpack.cpp) at ${CMAKE_BINARY_DIR}/generated/ relative
++    # to reNut's OWN build tree -- this SDK build is a separate CMake project
++    # (only reachable via reNut's FetchContent), so it cannot receive that
++    # path as a normal target_sources() call from outside; it reconstructs
++    # the same deterministic path instead. No-ops (real source list, just one
++    # file fewer) if the file doesn't exist yet, matching every other
++    # opt-in-capture-then-generate step in this effort (dump_guest_shaders,
++    # renut_xenos_shader()) -- a fresh checkout must not fail to configure.
++    if(EXISTS "${CMAKE_BINARY_DIR}/generated/renut_xenos_shader_cache.cpp")
++        list(APPEND REXGPU_NATIVEVK_SOURCES
++            "${CMAKE_BINARY_DIR}/generated/renut_xenos_shader_cache.cpp"
++        )
++    else()
++        message(STATUS
++            "rexgpu-nativevk: no generated/renut_xenos_shader_cache.cpp yet -- "
++            "native-renderer shader-pipeline-cache lookups will find zero "
++            "shaders until reNut's own build produces one (see "
++            "renut_xenos_shader_batch() in the top-level CMakeLists.txt).")
++    endif()
++
++    add_library(rexgpu-nativevk SHARED ${REXGPU_NATIVEVK_SOURCES})
++    add_library(rex::gpu-nativevk ALIAS rexgpu-nativevk)
++
++    set_target_properties(rexgpu-nativevk PROPERTIES
++        EXPORT_NAME gpu-nativevk
++        CXX_VISIBILITY_PRESET hidden
++        VISIBILITY_INLINES_HIDDEN ON
++    )
++
++    target_include_directories(rexgpu-nativevk PRIVATE
++        ${REXGLUE_ROOT}/thirdparty/renderdoc
++        ${REXGLUE_ROOT}
++    )
++
++    # Native-renderer shader debug panel (2026-08-16, see
++    # nativevk_shader_debug_panel.cpp): needs imgui.h for real ImGui:: calls.
++    # Deliberately NOT linking imgui::imgui here -- it's a real OBJECT
++    # library (thirdparty/CMakeLists.txt), and rexruntime already contains
++    # those exact objects (confirmed via `nm -D` showing real, exported
++    # ImGui::Begin etc symbols in librexruntimerd.so) -- relinking would
++    # duplicate global ImGui state (same real risk the comment above about
++    # "Never link the OBJECT libraries... rexruntime already contains those
++    # objects" already warns about for rexcore/rexui). Header-only use;
++    # symbols resolve against rexruntime's own copy at load time.
++    get_target_property(_imgui_include_dirs imgui INTERFACE_INCLUDE_DIRECTORIES)
++    target_include_directories(rexgpu-nativevk PRIVATE ${_imgui_include_dirs})
++
++    # renut_xenos_shader_cache.h lives in reNut's own src/ tree (not this
++    # SDK's), so the generated cache .cpp added above can #include it.
++    # CMAKE_SOURCE_DIR is reNut's root here (this SDK is pulled in via
++    # add_subdirectory() from reNut's top-level CMakeLists.txt, and
++    # CMAKE_SOURCE_DIR is a global set once at the outermost project() call,
++    # unlike CMAKE_CURRENT_SOURCE_DIR) -- confirmed, not assumed, by reading
++    # generated/rexglue.cmake's real add_subdirectory("${REXSDK_DIR}" ...)
++    # call.
++    if(EXISTS "${CMAKE_SOURCE_DIR}/src/renut_engine/renut_xenos_shader_cache.h")
++        target_include_directories(rexgpu-nativevk PRIVATE "${CMAKE_SOURCE_DIR}/src")
++    endif()
++
++    target_compile_options(rexgpu-nativevk PRIVATE -Wno-unused-variable)
++
++    # Scopes reNut's draw-submission optimisations to this plugin so rexgpu-xenos
++    # keeps stock behaviour and stays a valid A/B reference.
++    target_compile_definitions(rexgpu-nativevk PRIVATE NATIVEVK_OPTIMISATIONS=1)
++
++    # Native-renderer Phase 1 (see PLAN_native_renderer.md): needed because
++    # nativevk_phase1_native_draw.cpp's include chain reaches
++    # vulkan/vulkan_to_string.hpp, which vulkan_enums.hpp guards its AMDX/beta
++    # extension enumerators behind this define -- the reNut host executable
++    # already sets it (CMakeLists.txt), but rexgpu-nativevk (this plugin) never
++    # did until now, since no prior SDK source here happened to trigger that
++    # specific include path.
++    target_compile_definitions(rexgpu-nativevk PRIVATE VK_ENABLE_BETA_EXTENSIONS)
++    if(UNIX AND NOT APPLE)
++        # Same include chain also reaches the XCB surface types, gated behind
++        # this define -- matches reNut's own CMakeLists.txt for the host exe.
++        target_compile_definitions(rexgpu-nativevk PRIVATE VK_USE_PLATFORM_XCB_KHR)
++    endif()
++
++    target_link_libraries(rexgpu-nativevk PRIVATE
++        rexruntime
++        xxHash::xxhash
++        snappy
++        volk::volk
++        glslang::SPIRV
++        GPUOpen::VulkanMemoryAllocator
++        glslang
++        MachineIndependent
++        GenericCodeGen
++        OSDependent
++        OGLCompiler
++    )
++endif()
+diff --git a/src/graphics/nativevk/command_processor.cpp b/src/graphics/nativevk/command_processor.cpp
+new file mode 100644
+index 0000000..1f40a05
+--- /dev/null
++++ b/src/graphics/nativevk/command_processor.cpp
+@@ -0,0 +1,82 @@
++/**
++ * @file        graphics/nativevk/command_processor.cpp
++ * @brief       reNut native command processor
++ */
++
++#include <rex/graphics/nativevk/command_processor.h>
++
++#include <rex/logging.h>
++
++#include "../vulkan/nativevk_phase1_native_draw.h"
++#include "../vulkan/nativevk_xenos_pipeline_cache.h"
++
++namespace rex::graphics::nativevk {
++
++NativeVkCommandProcessor::NativeVkCommandProcessor(
++    rex::graphics::vulkan::VulkanGraphicsSystem* graphics_system,
++    system::KernelState* kernel_state)
++    : rex::graphics::vulkan::VulkanCommandProcessor(graphics_system, kernel_state) {
++  REXLOG_INFO("renut: native command processor active");
++}
++
++NativeVkCommandProcessor::~NativeVkCommandProcessor() = default;
++
++bool NativeVkCommandProcessor::TryNativeDraw(
++    rex::graphics::vulkan::VulkanShader* vertex_shader,
++    rex::graphics::vulkan::VulkanShader* pixel_shader,
++    const rex::graphics::PrimitiveProcessor::ProcessingResult& primitive_processing_result,
++    VkBuffer index_buffer, VkDeviceSize index_buffer_offset, VkIndexType index_type) {
++  // TEMP DIAGNOSTIC (2026-08-18): confirms whether this override is being
++  // reached at all, and with what pixel_shader null-ness, while tracking
++  // down why the native shader debug panel stopped appearing after the
++  // TryNativeDraw refactor. Remove once resolved.
++  {
++    static uint64_t calls = 0;
++    static uint64_t null_pixel_shader = 0;
++    ++calls;
++    if (!pixel_shader) {
++      ++null_pixel_shader;
++    }
++    if (calls == 1 || calls % 2000 == 0) {
++      REXLOG_INFO("renut TryNativeDraw diag: calls={} null_pixel_shader={}", calls,
++                  null_pixel_shader);
++    }
++  }
++  // "Convert the important/common shaders" (see PLAN_native_renderer.md):
++  // generalized pipeline cache, tried FIRST -- any shader pair that
++  // successfully batch-converted (tools/xenos_batch_convert.py) gets a real
++  // native pipeline here, not just Phase 1's one hand-picked pair below.
++  if (pixel_shader && rex::graphics::vulkan::nativevk_pipeline::HasNativePipeline(
++                          vertex_shader->ucode_data_hash(), pixel_shader->ucode_data_hash())) {
++    VkPipeline native_pipeline = rex::graphics::vulkan::nativevk_pipeline::GetOrCreatePipeline(
++        *this, vertex_shader, pixel_shader, primitive_processing_result.host_primitive_type);
++    if (native_pipeline != VK_NULL_HANDLE) {
++      rex::graphics::vulkan::nativevk_pipeline::IssueNativeDraw(
++          *this, native_pipeline, vertex_shader, pixel_shader, primitive_processing_result,
++          index_buffer, index_buffer_offset, index_type);
++      return true;
++    }
++    // Pipeline unavailable (unmappable vertex format, creation failed, etc,
++    // already logged) -- fall through rather than silently dropping this draw.
++  }
++
++  // Native-renderer Phase 1 (see PLAN_native_renderer.md): substitute the ONE
++  // chosen draw with a hand-built native Vulkan pipeline instead of the
++  // normal Xenos-translated pipeline/draw, kept as a simple, always-working
++  // observability check for the native draw mechanism itself.
++  if (pixel_shader && rex::graphics::vulkan::nativevk_phase1::IsTargetDraw(
++                          vertex_shader->ucode_data_hash(), pixel_shader->ucode_data_hash())) {
++    VkPipeline phase1_pipeline = rex::graphics::vulkan::nativevk_phase1::GetOrCreatePipeline(*this);
++    if (phase1_pipeline != VK_NULL_HANDLE) {
++      rex::graphics::vulkan::nativevk_phase1::IssueNativeDraw(*this, phase1_pipeline);
++      return true;
++    }
++    // Pipeline unavailable (device lacks bufferDeviceAddress, or creation
++    // failed and was already logged) -- fall through to the normal
++    // Xenos-translated draw rather than silently dropping this draw.
++  }
++
++  return false;
++}
++
++}  // namespace rex::graphics::nativevk
+diff --git a/src/graphics/nativevk/graphics_system.cpp b/src/graphics/nativevk/graphics_system.cpp
+new file mode 100644
+index 0000000..63e0918
+--- /dev/null
++++ b/src/graphics/nativevk/graphics_system.cpp
+@@ -0,0 +1,24 @@
++/**
++ * @file        graphics/nativevk/graphics_system.cpp
++ * @brief       reNut graphics system
++ */
++
++#include <rex/graphics/nativevk/command_processor.h>
++#include <rex/graphics/nativevk/graphics_system.h>
++#include <rex/system/kernel_state.h>
++
++namespace rex::graphics::nativevk {
++
++NativeVkGraphicsSystem::NativeVkGraphicsSystem() {}
++
++NativeVkGraphicsSystem::~NativeVkGraphicsSystem() {}
++
++std::string NativeVkGraphicsSystem::name() const {
++  return "reNut";
++}
++
++std::unique_ptr<CommandProcessor> NativeVkGraphicsSystem::CreateCommandProcessor() {
++  return std::make_unique<NativeVkCommandProcessor>(this, kernel_state_);
++}
++
++}  // namespace rex::graphics::nativevk
+diff --git a/src/graphics/nativevk/plugin_main.cpp b/src/graphics/nativevk/plugin_main.cpp
+new file mode 100644
+index 0000000..bd2e174
+--- /dev/null
++++ b/src/graphics/nativevk/plugin_main.cpp
+@@ -0,0 +1,56 @@
++/**
++ * @file        graphics/nativevk/plugin_main.cpp
++ * @brief       rexgpu-nativevk plugin entry points
++ *
++ * @copyright   Copyright (c) 2026 Tom Clay <tomc@tctechstuff.com>
++ *              All rights reserved.
++ *
++ * @license     BSD 3-Clause License
++ *              See LICENSE file in the project root for full license text.
++ */
++
++#include <string_view>
++
++#if defined(__linux__)
++#include <dlfcn.h>
++#endif
++
++#include <rex/logging.h>
++#include <rex/system/gpu_plugin.h>
++
++#include <rex/graphics/nativevk/graphics_system.h>
++
++extern "C" REX_GPU_PLUGIN_EXPORT uint32_t rex_gpu_abi_version(void) {
++  return rex::system::kGpuPluginAbiVersion;
++}
++
++extern "C" REX_GPU_PLUGIN_EXPORT rex::system::IGraphicsSystem* rex_gpu_create(
++    uint32_t abi_version, const rex::system::GpuCreateInfo* info) {
++  if (abi_version != rex::system::kGpuPluginAbiVersion) {
++    REXLOG_ERROR("rexgpu-nativevk: host requested ABI {}, plugin is ABI {}", abi_version,
++                 rex::system::kGpuPluginAbiVersion);
++    return nullptr;
++  }
++  if (!info || info->struct_size < sizeof(rex::system::GpuCreateInfo)) {
++    REXLOG_ERROR("rexgpu-nativevk: invalid GpuCreateInfo");
++    return nullptr;
++  }
++
++  std::string_view backend = info->backend ? info->backend : "any";
++  if (backend != "any" && backend != "vulkan") {
++    REXLOG_ERROR("rexgpu-nativevk: requested backend '{}' is not compiled into this plugin", backend);
++    return nullptr;
++  }
++  REXLOG_INFO("rexgpu-nativevk: creating reNut native renderer");
++#if defined(__linux__)
++  {
++    // Logged so barrier-site return addresses can be resolved back to source.
++    Dl_info plugin_info;
++    if (dladdr(reinterpret_cast<const void*>(&rex_gpu_create), &plugin_info) &&
++        plugin_info.dli_fbase) {
++      REXLOG_INFO("renut: plugin base {}", plugin_info.dli_fbase);
++    }
++  }
++#endif
++  return new rex::graphics::nativevk::NativeVkGraphicsSystem();
++}
+diff --git a/src/graphics/vulkan/command_processor.cpp b/src/graphics/vulkan/command_processor.cpp
+index a40436e..ba0779c 100644
+--- a/src/graphics/vulkan/command_processor.cpp
++++ b/src/graphics/vulkan/command_processor.cpp
+@@ -3947,6 +3947,11 @@ bool VulkanCommandProcessor::IssueDraw(xenos::PrimitiveType prim_type, uint32_t
+ 
+   // Update dynamic graphics pipeline state.
+   UpdateDynamicState(viewport_info, primitive_polygonal, normalized_depth_control);
++  // Kept for last_viewport_info() -- see its own header comment. Plugins
++  // that substitute a native pipeline via TryNativeDraw() need the exact
++  // same viewport transform this draw already computed, rather than
++  // re-deriving it and risking drift.
++  last_viewport_info_ = viewport_info;
+ 
+   auto vgt_draw_initiator = regs.Get<reg::VGT_DRAW_INITIATOR>();
+ 
+@@ -4129,6 +4134,53 @@ bool VulkanCommandProcessor::IssueDraw(xenos::PrimitiveType prim_type, uint32_t
+       render_target_cache_->last_update_framebuffer());
+ 
+   // Draw.
++  // Index-buffer resolution shared with the dispatch below, computed once
++  // here so it can also be handed to TryNativeDraw() -- plugins that
++  // substitute a native pipeline for this draw (see TryNativeDraw's own
++  // comment) still need the real index buffer/offset/type. VK_NULL_HANDLE
++  // means non-indexed.
++  VkBuffer resolved_index_buffer = VK_NULL_HANDLE;
++  VkDeviceSize resolved_index_buffer_offset = 0;
++  VkIndexType resolved_index_type = VK_INDEX_TYPE_UINT16;
++  if (primitive_processing_result.index_buffer_type !=
++          PrimitiveProcessor::ProcessedIndexBufferType::kNone &&
++      !shader_32bit_index_dma) {
++    std::pair<VkBuffer, VkDeviceSize> resolved_index_buffer_pair;
++    switch (primitive_processing_result.index_buffer_type) {
++      case PrimitiveProcessor::ProcessedIndexBufferType::kGuestDMA:
++        if (guest_dma_index_scratch_buffer.buffer() != VK_NULL_HANDLE) {
++          resolved_index_buffer_pair.first = guest_dma_index_scratch_buffer.buffer();
++          resolved_index_buffer_pair.second = 0;
++        } else {
++          resolved_index_buffer_pair.first = shared_memory_->buffer();
++          resolved_index_buffer_pair.second = primitive_processing_result.guest_index_base;
++        }
++        break;
++      case PrimitiveProcessor::ProcessedIndexBufferType::kHostConverted:
++        resolved_index_buffer_pair = primitive_processor_->GetConvertedIndexBuffer(
++            primitive_processing_result.host_index_buffer_handle);
++        break;
++      case PrimitiveProcessor::ProcessedIndexBufferType::kHostBuiltinForAuto:
++      case PrimitiveProcessor::ProcessedIndexBufferType::kHostBuiltinForDMA:
++        resolved_index_buffer_pair = primitive_processor_->GetBuiltinIndexBuffer(
++            primitive_processing_result.host_index_buffer_handle);
++        break;
++      default:
++        resolved_index_buffer_pair = {VK_NULL_HANDLE, 0};
++        break;
++    }
++    resolved_index_buffer = resolved_index_buffer_pair.first;
++    resolved_index_buffer_offset = resolved_index_buffer_pair.second;
++    resolved_index_type = primitive_processing_result.host_index_format == xenos::IndexFormat::kInt16
++                               ? VK_INDEX_TYPE_UINT16
++                               : VK_INDEX_TYPE_UINT32;
++  }
++
++  if (TryNativeDraw(vertex_shader, pixel_shader, primitive_processing_result,
++                    resolved_index_buffer, resolved_index_buffer_offset, resolved_index_type)) {
++    return true;
++  }
++
+   if (primitive_processing_result.index_buffer_type ==
+           PrimitiveProcessor::ProcessedIndexBufferType::kNone ||
+       shader_32bit_index_dma) {
+diff --git a/src/graphics/vulkan/nativevk_debug_color_spirv.h b/src/graphics/vulkan/nativevk_debug_color_spirv.h
+new file mode 100644
+index 0000000..93439f7
+--- /dev/null
++++ b/src/graphics/vulkan/nativevk_debug_color_spirv.h
+@@ -0,0 +1,17 @@
++// Auto-generated: glslangValidator -V renut_debug_color.frag
++#pragma once
++#include <cstdint>
++inline constexpr uint32_t kRenutDebugColorFragSpirv[] = {
++119734787,65536,524299,15,0,131089,1,393227,1,1280527431,1685353262,808793134,
++0,196622,0,1,393231,4,4,1852399981,0,9,196624,4,
++7,196611,2,450,262149,4,1852399981,0,327685,9,1131705711,1919904879,
++0,262149,10,1650803819,5400437,262149,11,1650803819,4679541,262149,12,1650803819,
++4351861,262215,9,30,0,262215,10,1,0,262215,11,1,
++1,262215,12,1,2,131091,2,196641,3,2,196630,6,
++32,262167,7,6,4,262176,8,3,7,262203,8,9,
++3,262194,6,10,1065353216,262194,6,11,0,262194,6,12,
++1065353216,262187,6,13,1065353216,458803,7,14,10,11,12,13,
++327734,2,4,0,3,131320,5,196670,9,14,65789,65592,
++
++};
++inline constexpr uint32_t kRenutDebugColorFragSpirvWordCount = 120;
+diff --git a/src/graphics/vulkan/nativevk_phase1_native_draw.cpp b/src/graphics/vulkan/nativevk_phase1_native_draw.cpp
+new file mode 100644
+index 0000000..137e5ea
+--- /dev/null
++++ b/src/graphics/vulkan/nativevk_phase1_native_draw.cpp
+@@ -0,0 +1,413 @@
++// Native-renderer Phase 1 (see PLAN_native_renderer.md). See the header for
++// the overall rationale; this file is the actual implementation.
++
++#include "nativevk_phase1_native_draw.h"
++
++#include <array>
++#include <chrono>
++#include <cstdlib>
++#include <cstring>
++
++#include <rex/logging.h>
++#include <rex/ui/vulkan/util.h>
++
++#include "nativevk_phase1_shaders_spirv.inc"
++
++namespace rex::graphics::vulkan::nativevk_phase1 {
++
++namespace {
++
++// The ONE target draw chosen in PLAN_native_renderer.md Phase 1 step 1.
++constexpr uint64_t kTargetVertexShaderHash = 0x67021cae68a26b46ull;
++constexpr uint64_t kTargetPixelShaderHash = 0x12c73f3eb45dad49ull;
++
++// Matches XenosRecomp's generated PushConstants struct (see the HLSL comment
++// in either shader's output): three GPU virtual addresses, one per constant
++// buffer. This shader pair never reads VertexShaderConstants/
++// PixelShaderConstants (both cbuffers are empty in the generated HLSL), so
++// those two addresses are never dereferenced -- only SharedConstants
++// (g_HalfPixelOffset) is read, by the vertex shader.
++struct PushConstants {
++  uint64_t vertex_shader_constants;
++  uint64_t pixel_shader_constants;
++  uint64_t shared_constants;
++};
++
++// Layout of SharedConstants matches XenosRecomp's DEFINE_SHARED_CONSTANTS()
++// macro (see the generated HLSL): g_Booleans (u32) at +0, g_SwappedTexcoords
++// (u32) at +4, g_HalfPixelOffset (float2) at +8, g_AlphaThreshold (float) at
++// +16. Only g_HalfPixelOffset is actually read by this shader pair.
++struct SharedConstants {
++  uint32_t booleans = 0;
++  uint32_t swapped_texcoords = 0;
++  float half_pixel_offset[2] = {0.0f, 0.0f};
++  float alpha_threshold = 0.0f;
++  float _pad[3] = {0.0f, 0.0f, 0.0f};
++};
++static_assert(sizeof(SharedConstants) == 32, "must match DEFINE_SHARED_CONSTANTS() layout");
++
++// A simple hardcoded quad (two triangles via a triangle-strip-shaped
++// triangle-list is avoided for simplicity -- 6 vertices, 2 triangles), in
++// clip space directly (the shader does oPos = iPosition0, no transform), so
++// this appears as a fixed on-screen quad regardless of camera. Small and
++// off to a corner so it does not obscure normal gameplay if left running.
++constexpr float kQuadVertices[6][4] = {
++    {-1.0f, -1.0f, 0.5f, 1.0f}, {-0.5f, -1.0f, 0.5f, 1.0f}, {-1.0f, -0.5f, 0.5f, 1.0f},
++    {-0.5f, -1.0f, 0.5f, 1.0f}, {-0.5f, -0.5f, 0.5f, 1.0f}, {-1.0f, -0.5f, 0.5f, 1.0f},
++};
++
++struct State {
++  bool attempted = false;
++  bool available = false;
++  VkPipeline pipeline = VK_NULL_HANDLE;
++  VkPipelineLayout pipeline_layout = VK_NULL_HANDLE;
++  VkShaderModule vertex_module = VK_NULL_HANDLE;
++  VkShaderModule pixel_module = VK_NULL_HANDLE;
++  VkBuffer vertex_buffer = VK_NULL_HANDLE;
++  VkDeviceMemory vertex_buffer_memory = VK_NULL_HANDLE;
++  VkBuffer constants_buffer = VK_NULL_HANDLE;
++  VkDeviceMemory constants_buffer_memory = VK_NULL_HANDLE;
++  uint64_t shared_constants_address = 0;
++  VkRenderPass pipeline_render_pass = VK_NULL_HANDLE;
++
++  // CPU-side wall-time measurement around the draw's full round-trip cost,
++  // following this session's existing RenutNow()/trace-CSV pattern (see
++  // command_processor.cpp) rather than adding new GPU timestamp-query
++  // infrastructure, which DeferredCommandBuffer does not currently expose --
++  // out of scope for Phase 1's proof-of-concept goal.
++  uint64_t draw_count = 0;
++  uint64_t total_ns = 0;
++};
++
++State& GetState() {
++  static State state;
++  return state;
++}
++
++uint64_t Now() {
++  return uint64_t(std::chrono::duration_cast<std::chrono::nanoseconds>(
++                      std::chrono::steady_clock::now().time_since_epoch())
++                      .count());
++}
++
++}  // namespace
++
++bool IsTargetDraw(uint64_t vertex_shader_ucode_hash, uint64_t pixel_shader_ucode_hash) {
++  // FOUND 2026-08-18: this Phase 1 mechanism was NOT covered by
++  // RENUT_DISABLE_ALL_NATIVE=1 (that flag only gates the later, general
++  // HasNativePipeline() path in nativevk_pipeline_cache.cpp) -- meaning
++  // every prior "native fully disabled" A/B test still had this one real,
++  // frequently-drawn vertex shader deliberately rendered with the wrong
++  // pixel shader (see this function's own header comment: "substituted
++  // draws will not visually match... not a mistake"). Local copy of the
++  // same env-var check (can't reach the anonymous-namespace one in
++  // nativevk_pipeline_cache.cpp from this translation unit) so a genuine
++  // full-disable test is possible.
++  {
++    const char* env = std::getenv("RENUT_DISABLE_ALL_NATIVE");
++    if (env != nullptr && env[0] == '1') {
++      return false;
++    }
++  }
++  // Vertex-shader-only match, NOT the originally chosen vs+ps pair. Confirmed
++  // this session (see PLAN_native_renderer.md Phase 1 step 1) that
++  // kTargetVertexShaderHash + kTargetPixelShaderHash is not an actual live
++  // in-game pairing -- the game never draws these two shaders together, so
++  // matching on both would make this code permanently unreachable. Matching
++  // on the vertex shader alone (which IS confirmed present in the real
++  // shader dump, i.e. actually used by the game) makes Phase 1 observable:
++  // the native pipeline still uses the chosen SIMPLE pixel shader
++  // (ps_12c73f3eb45dad49), which means substituted draws will not visually
++  // match what the guest draw would have looked like -- an explicit,
++  // understood tradeoff for making the mechanism observable/measurable at
++  // all, not a mistake.
++  (void)pixel_shader_ucode_hash;
++  return vertex_shader_ucode_hash == kTargetVertexShaderHash;
++}
++
++VkPipeline GetOrCreatePipeline(VulkanCommandProcessor& command_processor) {
++  State& state = GetState();
++
++  const ui::vulkan::VulkanDevice* vulkan_device = command_processor.GetVulkanDevice();
++  const ui::vulkan::VulkanDevice::Functions& dfn = vulkan_device->functions();
++  VkDevice device = vulkan_device->device();
++
++  VkRenderPass current_render_pass = command_processor.current_render_pass();
++
++  // Rebuild the pipeline if the render pass it was created against is gone
++  // (render passes can be recreated by the render target cache) or if this
++  // is the very first call.
++  if (state.pipeline != VK_NULL_HANDLE && state.pipeline_render_pass == current_render_pass) {
++    return state.pipeline;
++  }
++  if (state.attempted && state.pipeline_render_pass == current_render_pass) {
++    // Already tried and failed against this exact render pass; do not retry
++    // every draw.
++    return state.available ? state.pipeline : VK_NULL_HANDLE;
++  }
++
++  if (!vulkan_device->properties().bufferDeviceAddress) {
++    if (!state.attempted) {
++      REXGPU_WARN(
++          "renut Phase 1: device lacks bufferDeviceAddress, native draw "
++          "substitution disabled for this device");
++    }
++    state.attempted = true;
++    state.available = false;
++    return VK_NULL_HANDLE;
++  }
++
++  if (current_render_pass == VK_NULL_HANDLE) {
++    // Dynamic rendering path or no render pass open yet -- Phase 1 only
++    // targets the render-pass path for now, matching the gamma-apply
++    // pipeline's own real precedent (command_processor.cpp).
++    return VK_NULL_HANDLE;
++  }
++
++  state.attempted = true;
++  state.pipeline_render_pass = current_render_pass;
++
++  // --- Shader modules ---
++  state.vertex_module = ui::vulkan::util::CreateShaderModule(
++      vulkan_device, kRenutPhase1VertexShaderSpirv, kRenutPhase1VertexShaderSpirv_size);
++  state.pixel_module = ui::vulkan::util::CreateShaderModule(
++      vulkan_device, kRenutPhase1PixelShaderSpirv, kRenutPhase1PixelShaderSpirv_size);
++  if (state.vertex_module == VK_NULL_HANDLE || state.pixel_module == VK_NULL_HANDLE) {
++    REXGPU_ERROR("renut Phase 1: failed to create shader modules");
++    state.available = false;
++    return VK_NULL_HANDLE;
++  }
++
++  // --- Pipeline layout: one push-constant range, no descriptor sets (this
++  // shader pair samples no textures and reads no non-empty constant
++  // buffers other than SharedConstants) ---
++  VkPushConstantRange push_constant_range;
++  push_constant_range.stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
++  push_constant_range.offset = 0;
++  push_constant_range.size = sizeof(PushConstants);
++
++  VkPipelineLayoutCreateInfo pipeline_layout_create_info = {};
++  pipeline_layout_create_info.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
++  pipeline_layout_create_info.setLayoutCount = 0;
++  pipeline_layout_create_info.pSetLayouts = nullptr;
++  pipeline_layout_create_info.pushConstantRangeCount = 1;
++  pipeline_layout_create_info.pPushConstantRanges = &push_constant_range;
++  if (dfn.vkCreatePipelineLayout(device, &pipeline_layout_create_info, nullptr,
++                                 &state.pipeline_layout) != VK_SUCCESS) {
++    REXGPU_ERROR("renut Phase 1: failed to create pipeline layout");
++    state.available = false;
++    return VK_NULL_HANDLE;
++  }
++
++  // --- Vertex input: one binding, one attribute (POSITION0 -> location 0,
++  // float4) ---
++  VkVertexInputBindingDescription vertex_binding;
++  vertex_binding.binding = 0;
++  vertex_binding.stride = sizeof(float) * 4;
++  vertex_binding.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
++
++  VkVertexInputAttributeDescription vertex_attribute;
++  vertex_attribute.location = 0;
++  vertex_attribute.binding = 0;
++  vertex_attribute.format = VK_FORMAT_R32G32B32A32_SFLOAT;
++  vertex_attribute.offset = 0;
++
++  VkPipelineVertexInputStateCreateInfo vertex_input_state = {};
++  vertex_input_state.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
++  vertex_input_state.vertexBindingDescriptionCount = 1;
++  vertex_input_state.pVertexBindingDescriptions = &vertex_binding;
++  vertex_input_state.vertexAttributeDescriptionCount = 1;
++  vertex_input_state.pVertexAttributeDescriptions = &vertex_attribute;
++
++  VkPipelineInputAssemblyStateCreateInfo input_assembly_state = {};
++  input_assembly_state.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
++  input_assembly_state.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
++  input_assembly_state.primitiveRestartEnable = VK_FALSE;
++
++  VkPipelineViewportStateCreateInfo viewport_state = {};
++  viewport_state.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
++  viewport_state.viewportCount = 1;
++  viewport_state.pViewports = nullptr;
++  viewport_state.scissorCount = 1;
++  viewport_state.pScissors = nullptr;
++
++  VkPipelineRasterizationStateCreateInfo rasterization_state = {};
++  rasterization_state.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
++  rasterization_state.polygonMode = VK_POLYGON_MODE_FILL;
++  rasterization_state.cullMode = VK_CULL_MODE_NONE;
++  rasterization_state.frontFace = VK_FRONT_FACE_CLOCKWISE;
++  rasterization_state.lineWidth = 1.0f;
++
++  VkPipelineMultisampleStateCreateInfo multisample_state = {};
++  multisample_state.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
++  multisample_state.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
++
++  VkPipelineColorBlendAttachmentState color_blend_attachment_state = {};
++  color_blend_attachment_state.colorWriteMask = VK_COLOR_COMPONENT_R_BIT |
++                                                VK_COLOR_COMPONENT_G_BIT |
++                                                VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
++  VkPipelineColorBlendStateCreateInfo color_blend_state = {};
++  color_blend_state.sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
++  color_blend_state.attachmentCount = 1;
++  color_blend_state.pAttachments = &color_blend_attachment_state;
++
++  static const VkDynamicState kDynamicStates[] = {
++      VK_DYNAMIC_STATE_VIEWPORT,
++      VK_DYNAMIC_STATE_SCISSOR,
++  };
++  VkPipelineDynamicStateCreateInfo dynamic_state = {};
++  dynamic_state.sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
++  dynamic_state.dynamicStateCount = uint32_t(rex::countof(kDynamicStates));
++  dynamic_state.pDynamicStates = kDynamicStates;
++
++  VkPipelineShaderStageCreateInfo stages[2];
++  stages[0] = {};
++  stages[0].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
++  stages[0].stage = VK_SHADER_STAGE_VERTEX_BIT;
++  stages[0].module = state.vertex_module;
++  stages[0].pName = "main";
++  stages[1] = {};
++  stages[1].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
++  stages[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT;
++  stages[1].module = state.pixel_module;
++  stages[1].pName = "main";
++
++  VkGraphicsPipelineCreateInfo pipeline_create_info = {};
++  pipeline_create_info.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
++  pipeline_create_info.stageCount = uint32_t(rex::countof(stages));
++  pipeline_create_info.pStages = stages;
++  pipeline_create_info.pVertexInputState = &vertex_input_state;
++  pipeline_create_info.pInputAssemblyState = &input_assembly_state;
++  pipeline_create_info.pViewportState = &viewport_state;
++  pipeline_create_info.pRasterizationState = &rasterization_state;
++  pipeline_create_info.pMultisampleState = &multisample_state;
++  pipeline_create_info.pDepthStencilState = nullptr;
++  pipeline_create_info.pColorBlendState = &color_blend_state;
++  pipeline_create_info.pDynamicState = &dynamic_state;
++  pipeline_create_info.layout = state.pipeline_layout;
++  pipeline_create_info.renderPass = current_render_pass;
++  pipeline_create_info.subpass = 0;
++  pipeline_create_info.basePipelineHandle = VK_NULL_HANDLE;
++  pipeline_create_info.basePipelineIndex = -1;
++
++  VkResult pipeline_result = dfn.vkCreateGraphicsPipelines(
++      device, VK_NULL_HANDLE, 1, &pipeline_create_info, nullptr, &state.pipeline);
++  if (pipeline_result != VK_SUCCESS) {
++    REXGPU_ERROR("renut Phase 1: vkCreateGraphicsPipelines failed (VkResult {})",
++                 int32_t(pipeline_result));
++    state.available = false;
++    return VK_NULL_HANDLE;
++  }
++
++  // --- Vertex buffer: upload the hardcoded quad once ---
++  if (state.vertex_buffer == VK_NULL_HANDLE) {
++    if (!ui::vulkan::util::CreateDedicatedAllocationBuffer(
++            vulkan_device, sizeof(kQuadVertices), VK_BUFFER_USAGE_VERTEX_BUFFER_BIT,
++            ui::vulkan::util::MemoryPurpose::kUpload, state.vertex_buffer,
++            state.vertex_buffer_memory)) {
++      REXGPU_ERROR("renut Phase 1: failed to create vertex buffer");
++      state.available = false;
++      return VK_NULL_HANDLE;
++    }
++    void* mapped = nullptr;
++    if (dfn.vkMapMemory(device, state.vertex_buffer_memory, 0, sizeof(kQuadVertices), 0,
++                        &mapped) != VK_SUCCESS) {
++      REXGPU_ERROR("renut Phase 1: failed to map vertex buffer");
++      state.available = false;
++      return VK_NULL_HANDLE;
++    }
++    std::memcpy(mapped, kQuadVertices, sizeof(kQuadVertices));
++    dfn.vkUnmapMemory(device, state.vertex_buffer_memory);
++  }
++
++  // --- Constants buffer: SharedConstants only (g_HalfPixelOffset), needs
++  // VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT so vkGetBufferDeviceAddress
++  // works on it ---
++  if (state.constants_buffer == VK_NULL_HANDLE) {
++    if (!ui::vulkan::util::CreateDedicatedAllocationBuffer(
++            vulkan_device, sizeof(SharedConstants),
++            VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT | VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
++            ui::vulkan::util::MemoryPurpose::kUpload, state.constants_buffer,
++            state.constants_buffer_memory)) {
++      REXGPU_ERROR("renut Phase 1: failed to create constants buffer");
++      state.available = false;
++      return VK_NULL_HANDLE;
++    }
++    SharedConstants shared_constants;
++    // Half-pixel offset is only meaningful relative to the actual render
++    // target size; 0 is a safe, real value for this proof (no output-space
++    // correction), not a placeholder that will be wired up later.
++    shared_constants.half_pixel_offset[0] = 0.0f;
++    shared_constants.half_pixel_offset[1] = 0.0f;
++    void* mapped = nullptr;
++    if (dfn.vkMapMemory(device, state.constants_buffer_memory, 0, sizeof(SharedConstants), 0,
++                        &mapped) != VK_SUCCESS) {
++      REXGPU_ERROR("renut Phase 1: failed to map constants buffer");
++      state.available = false;
++      return VK_NULL_HANDLE;
++    }
++    std::memcpy(mapped, &shared_constants, sizeof(SharedConstants));
++    dfn.vkUnmapMemory(device, state.constants_buffer_memory);
++
++    VkBufferDeviceAddressInfo address_info = {};
++    address_info.sType = VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO;
++    address_info.buffer = state.constants_buffer;
++    state.shared_constants_address = dfn.vkGetBufferDeviceAddress(device, &address_info);
++    if (state.shared_constants_address == 0) {
++      REXGPU_ERROR("renut Phase 1: vkGetBufferDeviceAddress returned 0");
++      state.available = false;
++      return VK_NULL_HANDLE;
++    }
++  }
++
++  state.available = true;
++  REXGPU_INFO("renut Phase 1: native pipeline created (vs_{:016x} ps_{:016x})",
++             kTargetVertexShaderHash, kTargetPixelShaderHash);
++  return state.pipeline;
++}
++
++void IssueNativeDraw(VulkanCommandProcessor& command_processor, VkPipeline pipeline) {
++  State& state = GetState();
++  if (pipeline == VK_NULL_HANDLE || !state.available) {
++    return;
++  }
++
++  uint64_t start_ns = Now();
++
++  command_processor.BindExternalGraphicsPipeline(pipeline);
++
++  PushConstants push_constants;
++  push_constants.vertex_shader_constants = 0;
++  push_constants.pixel_shader_constants = 0;
++  push_constants.shared_constants = state.shared_constants_address;
++
++  DeferredCommandBuffer& cmd = command_processor.deferred_command_buffer();
++  cmd.CmdVkPushConstants(state.pipeline_layout,
++                        VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT, 0,
++                        sizeof(push_constants), &push_constants);
++
++  VkBuffer vertex_buffers[1] = {state.vertex_buffer};
++  VkDeviceSize vertex_offsets[1] = {0};
++  cmd.CmdVkBindVertexBuffers(0, 1, vertex_buffers, vertex_offsets);
++
++  cmd.CmdVkDraw(6, 1, 0, 0);
++
++  ++state.draw_count;
++  state.total_ns += Now() - start_ns;
++}
++
++uint64_t TakeDrawCount() {
++  State& state = GetState();
++  uint64_t count = state.draw_count;
++  state.draw_count = 0;
++  return count;
++}
++
++uint64_t TakeTotalNs() {
++  State& state = GetState();
++  uint64_t ns = state.total_ns;
++  state.total_ns = 0;
++  return ns;
++}
++
++}  // namespace rex::graphics::vulkan::nativevk_phase1
+diff --git a/src/graphics/vulkan/nativevk_phase1_native_draw.h b/src/graphics/vulkan/nativevk_phase1_native_draw.h
+new file mode 100644
+index 0000000..7fcc4a8
+--- /dev/null
++++ b/src/graphics/vulkan/nativevk_phase1_native_draw.h
+@@ -0,0 +1,49 @@
++#pragma once
++// Native-renderer Phase 1 (see PLAN_native_renderer.md in the reNut repo
++// root): a single hand-built native draw, substituted for one specific
++// Xenos-translated draw inside VulkanCommandProcessor::IssueDraw, to prove
++// the mechanism end-to-end (real GPU device, real command buffer, real
++// pipeline, real measured GPU time) before any larger native-renderer effort
++// is attempted.
++//
++// Deliberately isolated in its own file/namespace, not spread through
++// command_processor.cpp, so it is trivial to find, review, and delete if
++// Phase 1 does not pan out -- consistent with the plan's hard scope rule.
++
++#include <cstdint>
++
++#include <volk.h>
++
++#include <rex/graphics/vulkan/command_processor.h>
++
++namespace rex::graphics::vulkan::nativevk_phase1 {
++
++// True only for the ONE draw this phase targets: the shader pair chosen in
++// PLAN_native_renderer.md Phase 1 step 1 (vs_67021cae68a26b46 +
++// ps_12c73f3eb45dad49), identified the same way the "renut color draw pair"
++// diagnostic (command_processor.cpp) already identifies shader pairs -- by
++// the SDK's own real ucode_data_hash() on both shaders, not a guess.
++bool IsTargetDraw(uint64_t vertex_shader_ucode_hash, uint64_t pixel_shader_ucode_hash);
++
++// Lazily creates (once) and returns the native pipeline for the target draw,
++// or VK_NULL_HANDLE if creation failed (logged) or the device lacks
++// bufferDeviceAddress (checked once, logged once, then treated as a
++// permanent no-op for the rest of the process).
++VkPipeline GetOrCreatePipeline(VulkanCommandProcessor& command_processor);
++
++// Issues the actual native draw into the command processor's currently open
++// render pass (assumes the caller already has the correct render
++// pass/framebuffer bound -- this function only binds the external pipeline,
++// its descriptor set, and issues one draw call). Measures real GPU-side wall
++// time via the same RenutNow()/trace-CSV pattern the rest of renut's capture
++// tooling uses (see command_processor.cpp's g_renut_ns_* counters).
++void IssueNativeDraw(VulkanCommandProcessor& command_processor, VkPipeline pipeline);
++
++// Trace-CSV plumbing (see RenutWriteTraceRow in command_processor.cpp): the
++// number of native draws issued and their total CPU-side wall-time cost
++// since the last reset, so this shows up as real per-frame columns
++// alongside every other renut_trace_*.csv metric, not just a log line.
++uint64_t TakeDrawCount();
++uint64_t TakeTotalNs();
++
++}  // namespace rex::graphics::vulkan::nativevk_phase1
+diff --git a/src/graphics/vulkan/nativevk_phase1_shaders_spirv.inc b/src/graphics/vulkan/nativevk_phase1_shaders_spirv.inc
+new file mode 100644
+index 0000000..645ae7a
+--- /dev/null
++++ b/src/graphics/vulkan/nativevk_phase1_shaders_spirv.inc
+@@ -0,0 +1,108 @@
++const uint32_t kRenutPhase1VertexShaderSpirv[] = {
++    0x07230203u, 0x00010000u, 0x000e0000u, 0x0000003eu, 0x00000000u, 0x00020011u, 0x00000001u, 0x00020011u,
++    0x0000000bu, 0x00020011u, 0x000014b6u, 0x00020011u, 0x000014e3u, 0x0008000au, 0x5f565053u, 0x5f545845u,
++    0x63736564u, 0x74706972u, 0x695f726fu, 0x7865646eu, 0x00676e69u, 0x0009000au, 0x5f565053u, 0x5f52484bu,
++    0x73796870u, 0x6c616369u, 0x6f74735fu, 0x65676172u, 0x6675625fu, 0x00726566u, 0x0006000bu, 0x00000001u,
++    0x4c534c47u, 0x6474732eu, 0x3035342eu, 0x00000000u, 0x0003000eu, 0x000014e4u, 0x00000001u, 0x0019000fu,
++    0x00000000u, 0x00000002u, 0x6e69616du, 0x00000000u, 0x00000003u, 0x00000004u, 0x00000005u, 0x00000006u,
++    0x00000007u, 0x00000008u, 0x00000009u, 0x0000000au, 0x0000000bu, 0x0000000cu, 0x0000000du, 0x0000000eu,
++    0x0000000fu, 0x00000010u, 0x00000011u, 0x00000012u, 0x00000013u, 0x00000014u, 0x00000015u, 0x00000016u,
++    0x00040047u, 0x00000004u, 0x0000000bu, 0x00000000u, 0x00040047u, 0x00000003u, 0x0000001eu, 0x00000000u,
++    0x00040047u, 0x00000005u, 0x0000001eu, 0x00000000u, 0x00040047u, 0x00000006u, 0x0000001eu, 0x00000001u,
++    0x00040047u, 0x00000007u, 0x0000001eu, 0x00000002u, 0x00040047u, 0x00000008u, 0x0000001eu, 0x00000003u,
++    0x00040047u, 0x00000009u, 0x0000001eu, 0x00000004u, 0x00040047u, 0x0000000au, 0x0000001eu, 0x00000005u,
++    0x00040047u, 0x0000000bu, 0x0000001eu, 0x00000006u, 0x00040047u, 0x0000000cu, 0x0000001eu, 0x00000007u,
++    0x00040047u, 0x0000000du, 0x0000001eu, 0x00000008u, 0x00040047u, 0x0000000eu, 0x0000001eu, 0x00000009u,
++    0x00040047u, 0x0000000fu, 0x0000001eu, 0x0000000au, 0x00040047u, 0x00000010u, 0x0000001eu, 0x0000000bu,
++    0x00040047u, 0x00000011u, 0x0000001eu, 0x0000000cu, 0x00040047u, 0x00000012u, 0x0000001eu, 0x0000000du,
++    0x00040047u, 0x00000013u, 0x0000001eu, 0x0000000eu, 0x00040047u, 0x00000014u, 0x0000001eu, 0x0000000fu,
++    0x00040047u, 0x00000015u, 0x0000001eu, 0x00000010u, 0x00040047u, 0x00000016u, 0x0000001eu, 0x00000011u,
++    0x00050048u, 0x00000017u, 0x00000000u, 0x00000023u, 0x00000000u, 0x00050048u, 0x00000017u, 0x00000001u,
++    0x00000023u, 0x00000008u, 0x00050048u, 0x00000017u, 0x00000002u, 0x00000023u, 0x00000010u, 0x00030047u,
++    0x00000017u, 0x00000002u, 0x00030016u, 0x0000001au, 0x00000020u, 0x0004002bu, 0x0000001au, 0x0000001bu,
++    0x00000000u, 0x00040017u, 0x0000001cu, 0x0000001au, 0x00000004u, 0x0007002cu, 0x0000001cu, 0x0000001du,
++    0x0000001bu, 0x0000001bu, 0x0000001bu, 0x0000001bu, 0x00040015u, 0x0000001eu, 0x00000020u, 0x00000001u,
++    0x0004002bu, 0x0000001eu, 0x0000001fu, 0x00000002u, 0x00040015u, 0x00000020u, 0x00000040u, 0x00000000u,
++    0x0005002bu, 0x00000020u, 0x00000021u, 0x00000108u, 0x00000000u, 0x0004002bu, 0x0000001eu, 0x00000022u,
++    0x00000003u, 0x0005001eu, 0x00000017u, 0x00000020u, 0x00000020u, 0x00000020u, 0x00040020u, 0x00000023u,
++    0x00000009u, 0x00000017u, 0x00040020u, 0x00000024u, 0x00000001u, 0x0000001cu, 0x00040020u, 0x00000025u,
++    0x00000003u, 0x0000001cu, 0x00020013u, 0x00000026u, 0x00030021u, 0x00000027u, 0x00000026u, 0x00040020u,
++    0x00000028u, 0x00000007u, 0x0000001cu, 0x00040020u, 0x00000029u, 0x00000007u, 0x0000001au, 0x00040020u,
++    0x0000002au, 0x00000009u, 0x00000020u, 0x00040017u, 0x0000002bu, 0x0000001au, 0x00000002u, 0x00040020u,
++    0x0000002cu, 0x000014e5u, 0x0000002bu, 0x0004003bu, 0x00000023u, 0x00000018u, 0x00000009u, 0x0004003bu,
++    0x00000024u, 0x00000003u, 0x00000001u, 0x0004003bu, 0x00000025u, 0x00000004u, 0x00000003u, 0x0004003bu,
++    0x00000025u, 0x00000005u, 0x00000003u, 0x0004003bu, 0x00000025u, 0x00000006u, 0x00000003u, 0x0004003bu,
++    0x00000025u, 0x00000007u, 0x00000003u, 0x0004003bu, 0x00000025u, 0x00000008u, 0x00000003u, 0x0004003bu,
++    0x00000025u, 0x00000009u, 0x00000003u, 0x0004003bu, 0x00000025u, 0x0000000au, 0x00000003u, 0x0004003bu,
++    0x00000025u, 0x0000000bu, 0x00000003u, 0x0004003bu, 0x00000025u, 0x0000000cu, 0x00000003u, 0x0004003bu,
++    0x00000025u, 0x0000000du, 0x00000003u, 0x0004003bu, 0x00000025u, 0x0000000eu, 0x00000003u, 0x0004003bu,
++    0x00000025u, 0x0000000fu, 0x00000003u, 0x0004003bu, 0x00000025u, 0x00000010u, 0x00000003u, 0x0004003bu,
++    0x00000025u, 0x00000011u, 0x00000003u, 0x0004003bu, 0x00000025u, 0x00000012u, 0x00000003u, 0x0004003bu,
++    0x00000025u, 0x00000013u, 0x00000003u, 0x0004003bu, 0x00000025u, 0x00000014u, 0x00000003u, 0x0004003bu,
++    0x00000025u, 0x00000015u, 0x00000003u, 0x0004003bu, 0x00000025u, 0x00000016u, 0x00000003u, 0x00050036u,
++    0x00000026u, 0x00000002u, 0x00000000u, 0x00000027u, 0x000200f8u, 0x0000002du, 0x0004003bu, 0x00000028u,
++    0x00000019u, 0x00000007u, 0x0004003du, 0x0000001cu, 0x0000002eu, 0x00000003u, 0x0007000cu, 0x0000001cu,
++    0x0000002fu, 0x00000001u, 0x00000050u, 0x0000002eu, 0x0000002eu, 0x0003003eu, 0x00000019u, 0x0000002fu,
++    0x00050041u, 0x0000002au, 0x00000030u, 0x00000018u, 0x0000001fu, 0x0004003du, 0x00000020u, 0x00000031u,
++    0x00000030u, 0x00050080u, 0x00000020u, 0x00000032u, 0x00000031u, 0x00000021u, 0x0004007cu, 0x0000002cu,
++    0x00000033u, 0x00000032u, 0x0006003du, 0x0000002bu, 0x00000034u, 0x00000033u, 0x00000002u, 0x00000004u,
++    0x00050041u, 0x00000029u, 0x00000035u, 0x00000019u, 0x00000022u, 0x0004003du, 0x0000001au, 0x00000036u,
++    0x00000035u, 0x0005008eu, 0x0000002bu, 0x00000037u, 0x00000034u, 0x00000036u, 0x0007004fu, 0x0000002bu,
++    0x00000038u, 0x0000002fu, 0x0000002fu, 0x00000000u, 0x00000001u, 0x00050081u, 0x0000002bu, 0x00000039u,
++    0x00000038u, 0x00000037u, 0x0009004fu, 0x0000001cu, 0x0000003au, 0x0000002fu, 0x00000039u, 0x00000004u,
++    0x00000005u, 0x00000002u, 0x00000003u, 0x0003003eu, 0x00000019u, 0x0000003au, 0x00050051u, 0x0000001au,
++    0x0000003bu, 0x00000039u, 0x00000001u, 0x0004007fu, 0x0000001au, 0x0000003cu, 0x0000003bu, 0x00060052u,
++    0x0000001cu, 0x0000003du, 0x0000003cu, 0x0000003au, 0x00000001u, 0x0003003eu, 0x00000004u, 0x0000003du,
++    0x0003003eu, 0x00000005u, 0x0000001du, 0x0003003eu, 0x00000006u, 0x0000001du, 0x0003003eu, 0x00000007u,
++    0x0000001du, 0x0003003eu, 0x00000008u, 0x0000001du, 0x0003003eu, 0x00000009u, 0x0000001du, 0x0003003eu,
++    0x0000000au, 0x0000001du, 0x0003003eu, 0x0000000bu, 0x0000001du, 0x0003003eu, 0x0000000cu, 0x0000001du,
++    0x0003003eu, 0x0000000du, 0x0000001du, 0x0003003eu, 0x0000000eu, 0x0000001du, 0x0003003eu, 0x0000000fu,
++    0x0000001du, 0x0003003eu, 0x00000010u, 0x0000001du, 0x0003003eu, 0x00000011u, 0x0000001du, 0x0003003eu,
++    0x00000012u, 0x0000001du, 0x0003003eu, 0x00000013u, 0x0000001du, 0x0003003eu, 0x00000014u, 0x0000001du,
++    0x0003003eu, 0x00000015u, 0x0000001du, 0x0003003eu, 0x00000016u, 0x0000001du, 0x000100fdu, 0x00010038u,
++};
++const size_t kRenutPhase1VertexShaderSpirv_size = sizeof(kRenutPhase1VertexShaderSpirv);
++
++const uint32_t kRenutPhase1PixelShaderSpirv[] = {
++    0x07230203u, 0x00010000u, 0x000e0000u, 0x00000034u, 0x00000000u, 0x00020011u, 0x00000001u, 0x00020011u,
++    0x0000000bu, 0x00020011u, 0x000014b6u, 0x00020011u, 0x000014e3u, 0x0008000au, 0x5f565053u, 0x5f545845u,
++    0x63736564u, 0x74706972u, 0x695f726fu, 0x7865646eu, 0x00676e69u, 0x0009000au, 0x5f565053u, 0x5f52484bu,
++    0x73796870u, 0x6c616369u, 0x6f74735fu, 0x65676172u, 0x6675625fu, 0x00726566u, 0x0006000bu, 0x00000001u,
++    0x4c534c47u, 0x6474732eu, 0x3035342eu, 0x00000000u, 0x0003000eu, 0x000014e4u, 0x00000001u, 0x0007000fu,
++    0x00000004u, 0x00000002u, 0x6e69616du, 0x00000000u, 0x00000003u, 0x00000004u, 0x00030010u, 0x00000002u,
++    0x00000007u, 0x00040047u, 0x00000005u, 0x00000001u, 0x00000000u, 0x00040047u, 0x00000003u, 0x0000001eu,
++    0x00000010u, 0x00040047u, 0x00000004u, 0x0000001eu, 0x00000000u, 0x00050048u, 0x00000006u, 0x00000000u,
++    0x00000023u, 0x00000000u, 0x00050048u, 0x00000006u, 0x00000001u, 0x00000023u, 0x00000008u, 0x00050048u,
++    0x00000006u, 0x00000002u, 0x00000023u, 0x00000010u, 0x00030047u, 0x00000006u, 0x00000002u, 0x00040015u,
++    0x00000009u, 0x00000020u, 0x00000000u, 0x00040032u, 0x00000009u, 0x00000005u, 0x00000000u, 0x00030016u,
++    0x0000000au, 0x00000020u, 0x0004002bu, 0x0000000au, 0x0000000bu, 0x00000000u, 0x00040017u, 0x0000000cu,
++    0x0000000au, 0x00000004u, 0x0007002cu, 0x0000000cu, 0x0000000du, 0x0000000bu, 0x0000000bu, 0x0000000bu,
++    0x0000000bu, 0x00040015u, 0x0000000eu, 0x00000020u, 0x00000001u, 0x00020014u, 0x0000000fu, 0x0004002bu,
++    0x00000009u, 0x00000010u, 0x00000002u, 0x0004002bu, 0x0000000au, 0x00000011u, 0x3f800000u, 0x0007002cu,
++    0x0000000cu, 0x00000012u, 0x00000011u, 0x00000011u, 0x00000011u, 0x00000011u, 0x0004002bu, 0x00000009u,
++    0x00000013u, 0x00000000u, 0x0004002bu, 0x0000000eu, 0x00000014u, 0x00000003u, 0x0004002bu, 0x0000000eu,
++    0x00000015u, 0x00000002u, 0x00040015u, 0x00000016u, 0x00000040u, 0x00000000u, 0x0005002bu, 0x00000016u,
++    0x00000017u, 0x00000110u, 0x00000000u, 0x0005001eu, 0x00000006u, 0x00000016u, 0x00000016u, 0x00000016u,
++    0x00040020u, 0x00000018u, 0x00000009u, 0x00000006u, 0x00040020u, 0x00000019u, 0x00000001u, 0x0000000cu,
++    0x00040020u, 0x0000001au, 0x00000003u, 0x0000000cu, 0x00020013u, 0x0000001bu, 0x00030021u, 0x0000001cu,
++    0x0000001bu, 0x00040020u, 0x0000001du, 0x00000007u, 0x0000000cu, 0x00040020u, 0x0000001eu, 0x00000007u,
++    0x0000000au, 0x00060034u, 0x00000009u, 0x0000001fu, 0x000000c7u, 0x00000005u, 0x00000010u, 0x00040020u,
++    0x00000020u, 0x00000009u, 0x00000016u, 0x00040020u, 0x00000021u, 0x000014e5u, 0x0000000au, 0x0004003bu,
++    0x00000018u, 0x00000007u, 0x00000009u, 0x0004003bu, 0x00000019u, 0x00000003u, 0x00000001u, 0x0004003bu,
++    0x0000001au, 0x00000004u, 0x00000003u, 0x00050036u, 0x0000001bu, 0x00000002u, 0x00000000u, 0x0000001cu,
++    0x000200f8u, 0x00000022u, 0x0004003bu, 0x0000001du, 0x00000008u, 0x00000007u, 0x0004003du, 0x0000000cu,
++    0x00000023u, 0x00000003u, 0x0007000cu, 0x0000000cu, 0x00000024u, 0x00000001u, 0x00000050u, 0x00000023u,
++    0x00000023u, 0x0008000cu, 0x0000000cu, 0x00000025u, 0x00000001u, 0x0000002bu, 0x00000024u, 0x0000000du,
++    0x00000012u, 0x0003003eu, 0x00000008u, 0x00000025u, 0x000500abu, 0x0000000fu, 0x00000026u, 0x0000001fu,
++    0x00000013u, 0x000300f7u, 0x00000027u, 0x00000002u, 0x000400fau, 0x00000026u, 0x00000028u, 0x00000027u,
++    0x000200f8u, 0x00000028u, 0x00050041u, 0x0000001eu, 0x00000029u, 0x00000008u, 0x00000014u, 0x0004003du,
++    0x0000000au, 0x0000002au, 0x00000029u, 0x00050041u, 0x00000020u, 0x0000002bu, 0x00000007u, 0x00000015u,
++    0x0004003du, 0x00000016u, 0x0000002cu, 0x0000002bu, 0x00050080u, 0x00000016u, 0x0000002du, 0x0000002cu,
++    0x00000017u, 0x0004007cu, 0x00000021u, 0x0000002eu, 0x0000002du, 0x0006003du, 0x0000000au, 0x0000002fu,
++    0x0000002eu, 0x00000002u, 0x00000004u, 0x00050083u, 0x0000000au, 0x00000030u, 0x0000002au, 0x0000002fu,
++    0x000500b8u, 0x0000000fu, 0x00000031u, 0x00000030u, 0x0000000bu, 0x000300f7u, 0x00000032u, 0x00000000u,
++    0x000400fau, 0x00000031u, 0x00000033u, 0x00000032u, 0x000200f8u, 0x00000033u, 0x000100fcu, 0x000200f8u,
++    0x00000032u, 0x000200f9u, 0x00000027u, 0x000200f8u, 0x00000027u, 0x0003003eu, 0x00000004u, 0x00000025u,
++    0x000100fdu, 0x00010038u,
++};
++const size_t kRenutPhase1PixelShaderSpirv_size = sizeof(kRenutPhase1PixelShaderSpirv);
+diff --git a/src/graphics/vulkan/nativevk_shader_debug_panel.cpp b/src/graphics/vulkan/nativevk_shader_debug_panel.cpp
+new file mode 100644
+index 0000000..b42fa7b
+--- /dev/null
++++ b/src/graphics/vulkan/nativevk_shader_debug_panel.cpp
+@@ -0,0 +1,336 @@
++// Real-time native-shader debug panel (2026-08-16, see
++// nativevk_xenos_pipeline_cache.h's GetDebugShaderPairs()/
++// SetDebugShaderPairEnabled()): lets the user toggle each live native
++// shader pair on/off in-game, no rebuild/relaunch, to bisect which
++// converted shader(s) cause visible corruption (confirmed via a real A/B
++// test that the bug is inside one or more currently-live native shaders,
++// not a mixing/architecture problem -- see memory).
++//
++// Lazily created on first native draw (EnsureDebugPanelInitialized(),
++// same real pattern as this file's EnsureBindlessHeapInitialized), owned
++// by rex::Runtime::instance() via a raw pointer -- the same base-class
++// self-registration ImGuiDialog already uses (its ctor calls
++// imgui_drawer->AddDialog(this), see include/rex/ui/imgui_dialog.h). Never
++// closed/deleted; lives for the process lifetime like DebugOverlayDialog.
++
++#include "nativevk_xenos_pipeline_cache.h"
++
++#include <cstdio>
++#include <filesystem>
++#include <fstream>
++#include <mutex>
++#include <set>
++#include <sstream>
++#include <string>
++#include <utility>
++#include <vector>
++
++#include <imgui.h>
++
++#include <rex/filesystem.h>
++#include <rex/runtime.h>
++#include <rex/ui/imgui_dialog.h>
++#include <rex/ui/imgui_drawer.h>
++
++namespace rex::graphics::vulkan::nativevk_pipeline {
++
++namespace {
++
++// Real "mark as bad" feature (2026-08-17, requested by the user): playtesting
++// via the debug panel's individual on/off checkboxes tells the user WHETHER a
++// pair is broken, but with a few hundred live pairs there's no way to record
++// WHICH ones for later offline analysis without manually transcribing hashes.
++// This persists marked pairs to a plain-text file next to the executable
++// (same real GetExecutableFolder() location shader_dump.cpp's captures
++// already use), one "vs_<hash> ps_<hash>" line per pair, so a later session
++// can just read the file instead of asking the user to retype hashes.
++std::filesystem::path BadShaderListPath() {
++  return rex::filesystem::GetExecutableFolder() / "marked_bad_shaders.txt";
++}
++
++// Real, deliberate choice: a std::set<std::pair<uint64_t,uint64_t>> keyed by
++// the real (vs_hash, ps_hash) pair, not a single combined/hashed key -- keeps
++// the in-memory state trivially convertible back to the same two hex values
++// the file format and the UI label both already use, no extra encode/decode
++// step to get wrong.
++std::set<std::pair<uint64_t, uint64_t>> LoadMarkedBadShaders() {
++  std::set<std::pair<uint64_t, uint64_t>> result;
++  std::ifstream file(BadShaderListPath());
++  std::string line;
++  while (std::getline(file, line)) {
++    unsigned long long vs = 0, ps = 0;
++    if (std::sscanf(line.c_str(), "vs_%llx ps_%llx", &vs, &ps) == 2) {
++      result.emplace(vs, ps);
++    }
++  }
++  return result;
++}
++
++void AppendMarkedBadShader(uint64_t vs_hash, uint64_t ps_hash) {
++  std::ofstream file(BadShaderListPath(), std::ios::app);
++  if (!file) {
++    return;
++  }
++  file << "vs_" << std::hex << vs_hash << " ps_" << ps_hash << std::dec << "\n";
++}
++
++class NativeShaderDebugDialog : public ui::ImGuiDialog {
++ public:
++  explicit NativeShaderDebugDialog(ui::ImGuiDrawer* imgui_drawer)
++      : ImGuiDialog(imgui_drawer), marked_bad_(LoadMarkedBadShaders()) {}
++
++ protected:
++  // Real one-row helper shared by both sections below (Active/Disabled) --
++  // draws the checkbox + Mark Bad button for a single pair, identical in
++  // both lists, so the two loops in OnDraw() can't drift out of sync.
++  void DrawPairRow(const DebugShaderPairInfo& pair) {
++    // Real fix (2026-08-17, user-requested): the two 16-hex-digit hashes
++    // alone are unreadable enough that re-finding a specific pair among a
++    // few hundred rows was impractical. #<display_id> is a small, stable,
++    // process-lifetime-unique number (see DebugShaderPairInfo::display_id)
++    // the user can jot down and search for instead.
++    char label[80];
++    std::snprintf(label, sizeof(label), "#%u  vs_%016llx / ps_%016llx", pair.display_id,
++                  static_cast<unsigned long long>(pair.vs_hash),
++                  static_cast<unsigned long long>(pair.ps_hash));
++    bool enabled = pair.enabled;
++    ImGui::PushID(static_cast<int>(pair.vs_hash ^ pair.ps_hash));
++    if (ImGui::Checkbox(label, &enabled)) {
++      SetDebugShaderPairEnabled(pair.vs_hash, pair.ps_hash, enabled);
++    }
++
++    ImGui::SameLine();
++    const auto key = std::make_pair(pair.vs_hash, pair.ps_hash);
++    const bool already_marked = marked_bad_.count(key) != 0;
++    if (already_marked) {
++      ImGui::BeginDisabled();
++      ImGui::Button("Bad (saved)");
++      ImGui::EndDisabled();
++    } else if (ImGui::Button("Mark Bad")) {
++      AppendMarkedBadShader(pair.vs_hash, pair.ps_hash);
++      marked_bad_.insert(key);
++      // Auto-disabling only happens the moment a pair is first RECORDED
++      // (RecordAndCheckPairEnabled() in nativevk_pipeline_cache.cpp) --
++      // marking one bad mid-session wouldn't retroactively disable it, so do
++      // that here too: same real effect (this pair goes stock-rendered
++      // immediately) without requiring a relaunch to take hold.
++      SetDebugShaderPairEnabled(pair.vs_hash, pair.ps_hash, false);
++    }
++    if (pair.marked_bad) {
++      ImGui::SameLine();
++      ImGui::TextDisabled("(auto-disabled: was marked bad on boot)");
++    }
++    ImGui::PopID();
++  }
++
++  // Real "represent each shader on screen" feature (2026-08-17, user-
++  // requested): draws a "#<display_id>" label at every native pair's most
++  // recent recorded on-screen position (see IssueNativeDraw's own comment
++  // on how/why this is a heuristic, not a guaranteed-correct decode).
++  // Skips pairs that aren't currently enabled (no point labeling
++  // something that isn't actually rendering natively right now) and
++  // positions wildly outside the visible NDC range (a likely sign the
++  // assumed matrix register didn't hold for that shader).
++  //
++  // Real fix (2026-08-17, user-reported: labels overlapping/hidden on
++  // large or closely-packed objects): raw screen positions often land
++  // right on top of each other (see the reported screenshot -- several
++  // labels overlapping above one vehicle). A simple greedy declutter pass
++  // pushes each new label down past any already-placed label its text rect
++  // would overlap, so nearby labels form a readable stack instead of a
++  // blob of overlapping digits. This is display-only -- it doesn't change
++  // which position was recorded, just where the TEXT ends up drawn.
++  void DrawOnScreenLabels(const ImGuiIO& io, const std::vector<DebugShaderPairInfo>& pairs) {
++    ImDrawList* draw_list = ImGui::GetForegroundDrawList();
++    struct PlacedLabel {
++      ImVec2 top_left;
++      ImVec2 size;
++    };
++    std::vector<PlacedLabel> placed;
++    for (const DebugShaderLabel& label : GetDebugShaderLabels()) {
++      if (label.ndc_x < -4.0f || label.ndc_x > 4.0f || label.ndc_y < -4.0f || label.ndc_y > 4.0f) {
++        continue;
++      }
++      const DebugShaderPairInfo* match = nullptr;
++      for (const DebugShaderPairInfo& pair : pairs) {
++        if (pair.vs_hash == label.vs_hash && pair.ps_hash == label.ps_hash) {
++          match = &pair;
++          break;
++        }
++      }
++      if (match == nullptr || !match->enabled) {
++        continue;
++      }
++      char text[16];
++      std::snprintf(text, sizeof(text), "#%u", match->display_id);
++      const ImVec2 text_size = ImGui::CalcTextSize(text);
++      ImVec2 top_left((label.ndc_x * 0.5f + 0.5f) * io.DisplaySize.x - text_size.x * 0.5f,
++                       (1.0f - (label.ndc_y * 0.5f + 0.5f)) * io.DisplaySize.y - text_size.y);
++      // Greedy declutter: as long as this rect overlaps an already-placed
++      // one, push it down one line height and re-check from the top. Capped
++      // so a pathological cluster can't loop for long.
++      for (int attempt = 0; attempt < 32; ++attempt) {
++        bool overlaps = false;
++        for (const PlacedLabel& other : placed) {
++          if (top_left.x < other.top_left.x + other.size.x &&
++              top_left.x + text_size.x > other.top_left.x &&
++              top_left.y < other.top_left.y + other.size.y &&
++              top_left.y + text_size.y > other.top_left.y) {
++            overlaps = true;
++            break;
++          }
++        }
++        if (!overlaps) {
++          break;
++        }
++        top_left.y += text_size.y + 2.0f;
++      }
++      placed.push_back({top_left, text_size});
++      // Black outline + yellow fill so the label stays legible over any
++      // background color.
++      draw_list->AddText(ImVec2(top_left.x + 1.0f, top_left.y + 1.0f), IM_COL32(0, 0, 0, 255), text);
++      draw_list->AddText(top_left, IM_COL32(255, 255, 0, 255), text);
++    }
++  }
++
++  void OnDraw(ImGuiIO& io) override {
++    if (!ImGui::Begin("Native Shader Debug Panel")) {
++      ImGui::End();
++      return;
++    }
++
++    std::vector<DebugShaderPairInfo> pairs = GetDebugShaderPairs();
++    // Real fix (2026-08-17, user-requested): the section a pair lives in
++    // used to be driven by the LIVE enabled checkbox, so unchecking a pair
++    // to test it immediately moved it into "Disabled" -- exactly the
++    // opposite of what's needed when bisecting, since the pair you're
++    // actively testing is the one you want to keep finding easily. The
++    // split is now driven by marked_bad instead (only pairs auto-disabled
++    // at boot from marked_bad_shaders.txt land in "Marked Bad"), so the
++    // live checkbox is now a pure test toggle: flip it as much as you want,
++    // the row stays put.
++    std::vector<const DebugShaderPairInfo*> all_pairs;
++    std::vector<const DebugShaderPairInfo*> marked_bad_pairs;
++    size_t enabled_count = 0;
++    for (const DebugShaderPairInfo& pair : pairs) {
++      (pair.marked_bad ? marked_bad_pairs : all_pairs).push_back(&pair);
++      enabled_count += pair.enabled ? 1 : 0;
++    }
++
++    ImGui::Text("%zu live native shader pair(s) -- %zu currently enabled, %zu currently disabled",
++                pairs.size(), enabled_count, pairs.size() - enabled_count);
++    ImGui::Text("%zu marked bad (saved to marked_bad_shaders.txt)", marked_bad_.size());
++    // Real diagnostic (2026-08-17, user-requested): "N pairs enabled" only
++    // counts DISTINCT shader pairs ever seen across a whole play session --
++    // it says nothing about how many of any GIVEN frame's real draw calls
++    // actually reach the native path vs silently falling back to stock.
++    // This is the number that actually answers that.
++    ImGui::Text("%llu native draw(s) since launch (watch it while playing -- if it never "
++                "moves, native rendering isn't happening at all)",
++                (unsigned long long)PeekLastFrameDrawCount());
++
++    if (ImGui::Button("Disable All")) {
++      SetAllDebugShaderPairsEnabled(false);
++    }
++    ImGui::SameLine();
++    if (ImGui::Button("Enable All")) {
++      SetAllDebugShaderPairsEnabled(true);
++    }
++    ImGui::SameLine();
++    if (ImGui::Button("Disable All Bad")) {
++      SetMarkedBadShaderPairsEnabled(false);
++    }
++    ImGui::SameLine();
++    if (ImGui::Button("Enable All Bad")) {
++      SetMarkedBadShaderPairsEnabled(true);
++    }
++
++    bool show_labels = GetShowNativeShaderLabels();
++    if (ImGui::Checkbox("Show on-screen labels (heuristic, may be wrong/missing per-shader)",
++                         &show_labels)) {
++      SetShowNativeShaderLabels(show_labels);
++    }
++
++    bool debug_colorize = GetDebugColorizeMode();
++    if (ImGui::Checkbox(
++            "Debug: colorize native draws by shader pair (real vertex shader, flat-color pixel shader)",
++            &debug_colorize)) {
++      SetDebugColorizeMode(debug_colorize);
++    }
++    if (debug_colorize) {
++      ImGui::TextWrapped(
++          "Only colorizes pairs built AFTER this was turned on (reload the area / walk to a new "
++          "one) -- does not retrofit already-drawn geometry, to avoid rebuilding live pipelines "
++          "under load.");
++    }
++    if (show_labels) {
++      // Real fix (2026-08-17, user-reported: labels cluster above the
++      // player instead of at each object): the fixed c0 guess for this
++      // shader's transform matrix was wrong. Rather than ship a third
++      // blind guess, expose the base register as a live control -- watch a
++      // specific object in-game and drag this until its label lands on it.
++      // Different shaders may need different values; this is a
++      // calibration aid, not a promise that one value fits every shader.
++      int matrix_register = int(GetNativeShaderLabelMatrixRegister());
++      ImGui::SetNextItemWidth(120.0f);
++      if (ImGui::SliderInt("Label matrix base register (c#)", &matrix_register, 0, 252)) {
++        SetNativeShaderLabelMatrixRegister(uint32_t(matrix_register));
++      }
++      DrawOnScreenLabels(io, pairs);
++    }
++
++    ImGui::Separator();
++    // Real "panel within a panel" split (2026-08-17, user-requested): pairs
++    // marked bad (auto-disabled on boot from marked_bad_shaders.txt) are
++    // separated from everything else, so the user can see at a glance
++    // what's already known-bad vs what's still being evaluated, without a
++    // live test toggle relocating rows out from under them.
++    if (ImGui::CollapsingHeader("All Shaders", ImGuiTreeNodeFlags_DefaultOpen)) {
++      ImGui::BeginChild("native_shader_pair_list_active", ImVec2(0, 200), true);
++      for (const DebugShaderPairInfo* pair : all_pairs) {
++        DrawPairRow(*pair);
++      }
++      ImGui::EndChild();
++    }
++    if (ImGui::CollapsingHeader("Marked Bad (auto-disabled at boot)")) {
++      ImGui::BeginChild("native_shader_pair_list_disabled", ImVec2(0, 200), true);
++      for (const DebugShaderPairInfo* pair : marked_bad_pairs) {
++        DrawPairRow(*pair);
++      }
++      ImGui::EndChild();
++    }
++
++    ImGui::End();
++  }
++
++ private:
++  // Real, deliberate in-memory cache (not re-read from disk every frame):
++  // avoids re-parsing the file on every OnDraw() call, and lets the button
++  // immediately flip to its disabled "already marked" state without a round
++  // trip through the filesystem.
++  std::set<std::pair<uint64_t, uint64_t>> marked_bad_;
++};
++
++}  // namespace
++
++void EnsureDebugPanelInitialized() {
++  static bool initialized = false;
++  if (initialized) {
++    return;
++  }
++  initialized = true;
++
++  Runtime* runtime = Runtime::instance();
++  if (runtime == nullptr) {
++    return;
++  }
++  ui::ImGuiDrawer* imgui_drawer = runtime->imgui_drawer();
++  if (imgui_drawer == nullptr) {
++    return;
++  }
++  // Self-registers with imgui_drawer via the ImGuiDialog base ctor; never
++  // freed, same lifetime as the process (matches DebugOverlayDialog).
++  new NativeShaderDebugDialog(imgui_drawer);
++}
++
++}  // namespace rex::graphics::vulkan::nativevk_pipeline
+diff --git a/src/graphics/vulkan/nativevk_xenos_pipeline_cache.cpp b/src/graphics/vulkan/nativevk_xenos_pipeline_cache.cpp
+new file mode 100644
+index 0000000..eae85f1
+--- /dev/null
++++ b/src/graphics/vulkan/nativevk_xenos_pipeline_cache.cpp
+@@ -0,0 +1,2405 @@
++// Native-renderer "convert the important/common shaders" effort (see
++// PLAN_native_renderer.md and this file's header for the overall shape).
++
++#include "nativevk_xenos_pipeline_cache.h"
++#include "nativevk_debug_color_spirv.h"
++
++#include <algorithm>
++#include <array>
++#include <atomic>
++#include <chrono>
++#include <cstdlib>
++#include <cstring>
++#include <fstream>
++#include <mutex>
++#include <set>
++#include <string>
++#include <unordered_map>
++#include <unordered_set>
++#include <utility>
++#include <vector>
++
++#include <rex/filesystem.h>
++#include <rex/graphics/util/draw.h>
++#include <rex/graphics/vulkan/shared_memory.h>
++#include <rex/memory/utils.h>
++#include <rex/runtime.h>
++#include <rex/graphics/xenos.h>
++#include <rex/logging.h>
++#include <rex/ui/vulkan/upload_buffer_pool.h>
++#include <rex/ui/vulkan/util.h>
++
++// Batch-converted SPIR-V cache (see tools/xenos_batch_convert.py +
++// tools/xenos_cache_unpack.cpp) -- lives in reNut's own src/ tree, not this
++// SDK's, wired in via CMAKE_SOURCE_DIR in src/graphics/CMakeLists.txt (see
++// that file's comment for why). Guarded so this SDK still compiles clean on
++// a fresh checkout before any shader has ever been batch-converted.
++#if __has_include("renut_engine/renut_xenos_shader_cache.h")
++#include "renut_engine/renut_xenos_shader_cache.h"
++#define NATIVEVK_HAVE_XENOS_SHADER_CACHE 1
++#else
++#define NATIVEVK_HAVE_XENOS_SHADER_CACHE 0
++#endif
++
++namespace rex::graphics::vulkan::nativevk_pipeline {
++
++namespace {
++
++// TEMP DIAGNOSTIC (2026-08-16): real, live bisection tool for isolating
++// which specific native shader corrupts geometry (confirmed via a real A/B
++// test that it's inside one or more of the currently-live native shaders,
++// not a mixing/architecture problem -- see memory). Tracks every distinct
++// (vs_hash, ps_hash) pair that has ever passed HasNativePipeline(), plus a
++// per-pair enabled flag (default true) the debug panel (see
++// renut_shader_debug_panel.cpp) can toggle live, no rebuild/relaunch
++// needed. Disabling a pair here makes HasNativePipeline() return false for
++// it, falling back to the stock translated path -- same real effect as the
++// earlier cvar-blacklist version, but toggleable in real time from an
++// in-game panel instead of editing config + relaunching.
++struct ShaderPairDebugState {
++  uint64_t vs_hash;
++  uint64_t ps_hash;
++  bool enabled = true;
++  // Real "auto-disabled on boot" feature (2026-08-17, user-requested): true
++  // when this pair started disabled because it was in marked_bad_shaders.txt
++  // at the moment it was first recorded, not because the user manually
++  // toggled it off in the panel -- lets the panel show WHY a pair is
++  // disabled instead of just that it is.
++  bool marked_bad = false;
++  // Stable 1-based sequence number, assigned once at first-record time (see
++  // RecordAndCheckPairEnabled()) -- see DebugShaderPairInfo::display_id for
++  // why.
++  uint32_t display_id = 0;
++};
++
++std::mutex& DebugStateMutex() {
++  static std::mutex m;
++  return m;
++}
++
++std::vector<ShaderPairDebugState>& DebugStates() {
++  static std::vector<ShaderPairDebugState> states;
++  return states;
++}
++
++// Real "auto-disable known-bad shaders on boot" feature (2026-08-17,
++// user-requested): re-testing every one of a few hundred native shader
++// pairs by hand every session doesn't scale, so pairs the user has already
++// flagged bad via the debug panel's "Mark Bad" button (persisted to
++// marked_bad_shaders.txt next to the executable by
++// renut_shader_debug_panel.cpp's AppendMarkedBadShader()) now start
++// DISABLED the moment they're first seen this run, instead of always
++// defaulting to enabled -- the game boots straight into "only shaders not
++// already known to be broken" without the user re-clicking through the
++// panel every launch. Still fully overridable live from the panel (the
++// checkbox there doesn't care WHY a pair started disabled).
++const std::set<std::pair<uint64_t, uint64_t>>& MarkedBadShaders() {
++  static const std::set<std::pair<uint64_t, uint64_t>> marked = [] {
++    std::set<std::pair<uint64_t, uint64_t>> result;
++    std::ifstream file(rex::filesystem::GetExecutableFolder() / "marked_bad_shaders.txt");
++    std::string line;
++    while (std::getline(file, line)) {
++      unsigned long long vs = 0, ps = 0;
++      if (std::sscanf(line.c_str(), "vs_%llx ps_%llx", &vs, &ps) == 2) {
++        result.emplace(vs, ps);
++      }
++    }
++    return result;
++  }();
++  return marked;
++}
++
++// Records the pair (if not already known) and returns whether it's
++// currently enabled. Called from HasNativePipeline() on every real check,
++// so this must stay cheap -- a real, small linear scan (dozens of live
++// pairs in practice, not thousands) is fine, matching FindCacheEntry's own
++// same real justification below.
++// Diagnostic-only (2026-08-18): forces every native pair OFF from process
++// start, checked via env var rather than marked_bad_shaders.txt/the debug
++// panel because both of those only take effect for pairs seen AFTER the
++// user reaches them (panel isn't reachable until after the intro videos,
++// by which point hundreds of pairs already built+cached as enabled -- same
++// gotcha as DebugColorizeModeFlag's history above). Needed to re-run a
++// clean, complete, from-boot A/B test: multiple real, verified bugs (both
++// shader-translation-level on 2026-08-17 and the bindless-heap descriptor
++// race on 2026-08-18) have now shipped with zero measured visual change,
++// which is itself a signal worth re-checking the basic premise that native
++// rendering is the actual source of the reported flicker before chasing
++// more per-shader bugs. Not meant to ship on -- set RENUT_DISABLE_ALL_NATIVE=1
++// in the environment to use it, unset/0 otherwise.
++bool ForceDisableAllNativeFlag() {
++  const char* env = std::getenv("RENUT_DISABLE_ALL_NATIVE");
++  return env != nullptr && env[0] == '1';
++}
++
++bool RecordAndCheckPairEnabled(uint64_t vs_hash, uint64_t ps_hash) {
++  std::lock_guard<std::mutex> lock(DebugStateMutex());
++  std::vector<ShaderPairDebugState>& states = DebugStates();
++  const bool force_disabled = ForceDisableAllNativeFlag();
++  for (ShaderPairDebugState& s : states) {
++    if (s.vs_hash == vs_hash && s.ps_hash == ps_hash) {
++      return s.enabled && !force_disabled;
++    }
++  }
++  const bool marked_bad = MarkedBadShaders().count({vs_hash, ps_hash}) != 0;
++  const uint32_t display_id = static_cast<uint32_t>(states.size() + 1);
++  states.push_back({vs_hash, ps_hash, /*enabled=*/!marked_bad, marked_bad, display_id});
++  return !marked_bad && !force_disabled;
++}
++
++// Real "represent each shader on screen" feature (2026-08-17, user-
++// requested): storage for the most recent on-screen position recorded per
++// native pair. See DebugShaderLabel's own header comment for what ndc_x/
++// ndc_y mean, and IssueNativeDraw below for exactly how (and under what
++// assumption) they're computed. Keyed the same way DebugStates() is
++// (vs_hash, ps_hash)), but kept as its own map since labels are recorded
++// far more often (every draw, when enabled) than debug-state toggles.
++struct DebugLabelEntry {
++  uint64_t vs_hash = 0;
++  uint64_t ps_hash = 0;
++  float ndc_x = 0.0f;
++  float ndc_y = 0.0f;
++};
++
++std::mutex& DebugLabelMutex() {
++  static std::mutex m;
++  return m;
++}
++
++std::unordered_map<uint64_t, DebugLabelEntry>& DebugLabelPositions() {
++  static std::unordered_map<uint64_t, DebugLabelEntry> positions;
++  return positions;
++}
++
++std::atomic<bool>& ShowNativeShaderLabelsFlag() {
++  static std::atomic<bool> flag{false};
++  return flag;
++}
++
++std::atomic<uint32_t>& NativeShaderLabelMatrixRegisterFlag() {
++  static std::atomic<uint32_t> reg{0};
++  return reg;
++}
++
++std::atomic<bool>& DebugColorizeModeFlag() {
++  // Real fix (2026-08-17, user-reported): the debug panel isn't reachable
++  // until after the two intro videos finish, by which point 100-200 shader
++  // pairs have already been built WITHOUT the debug variant (see
++  // SetDebugColorizeMode's header comment -- it deliberately doesn't
++  // retrofit already-cached pipelines, to avoid a real churn bug that used
++  // to stall native rendering). Defaulting this on means every pair built
++  // from process start gets a debug variant, so a normal boot-then-play
++  // session is a clean, complete diagnostic without needing to race the
++  // panel. Flip back to {false} once this diagnostic effort is done --
++  // this is meant to be a temporary default, not a permanent one (flat
++  // debug color instead of real rendering is not what a normal user wants
++  // to see).
++  // Reverted to false (2026-08-17): defaulting this ON meant every native
++  // pipeline built after a game restart used the flat-color DEBUG pixel
++  // shader instead of its real one, which masks any pixel-stage fix
++  // (notably the texture-descriptor-index root-cause fix) and makes the
++  // game look wrong on its own. Diagnostic only -- opt in from the panel.
++  static std::atomic<bool> flag{false};
++  return flag;
++}
++
++}  // namespace
++
++// Public accessors for the debug panel (renut_shader_debug_panel.cpp) --
++// declared in the header, defined here since DebugStates()/DebugStateMutex()
++// above are only reachable from this translation unit.
++std::vector<DebugShaderPairInfo> GetDebugShaderPairs() {
++  std::lock_guard<std::mutex> lock(DebugStateMutex());
++  std::vector<DebugShaderPairInfo> result;
++  result.reserve(DebugStates().size());
++  for (const ShaderPairDebugState& s : DebugStates()) {
++    result.push_back({s.vs_hash, s.ps_hash, s.enabled, s.marked_bad, s.display_id});
++  }
++  return result;
++}
++
++void SetDebugShaderPairEnabled(uint64_t vs_hash, uint64_t ps_hash, bool enabled) {
++  std::lock_guard<std::mutex> lock(DebugStateMutex());
++  for (ShaderPairDebugState& s : DebugStates()) {
++    if (s.vs_hash == vs_hash && s.ps_hash == ps_hash) {
++      s.enabled = enabled;
++      return;
++    }
++  }
++}
++
++void SetAllDebugShaderPairsEnabled(bool enabled) {
++  std::lock_guard<std::mutex> lock(DebugStateMutex());
++  for (ShaderPairDebugState& s : DebugStates()) {
++    s.enabled = enabled;
++  }
++}
++
++void SetMarkedBadShaderPairsEnabled(bool enabled) {
++  std::lock_guard<std::mutex> lock(DebugStateMutex());
++  for (ShaderPairDebugState& s : DebugStates()) {
++    if (s.marked_bad) {
++      s.enabled = enabled;
++    }
++  }
++}
++
++std::vector<DebugShaderLabel> GetDebugShaderLabels() {
++  std::lock_guard<std::mutex> lock(DebugLabelMutex());
++  std::vector<DebugShaderLabel> result;
++  result.reserve(DebugLabelPositions().size());
++  for (const auto& [key, entry] : DebugLabelPositions()) {
++    result.push_back({entry.vs_hash, entry.ps_hash, entry.ndc_x, entry.ndc_y});
++  }
++  return result;
++}
++
++void SetShowNativeShaderLabels(bool show) {
++  ShowNativeShaderLabelsFlag().store(show, std::memory_order_relaxed);
++  if (!show) {
++    // Real, deliberate clear: otherwise re-enabling later would briefly
++    // show every pair's LAST position from before it was turned off (stale
++    // by however long the feature sat disabled), rather than starting
++    // clean and re-populating from real fresh draws.
++    std::lock_guard<std::mutex> lock(DebugLabelMutex());
++    DebugLabelPositions().clear();
++  }
++}
++
++bool GetShowNativeShaderLabels() {
++  return ShowNativeShaderLabelsFlag().load(std::memory_order_relaxed);
++}
++
++void SetNativeShaderLabelMatrixRegister(uint32_t base_register) {
++  NativeShaderLabelMatrixRegisterFlag().store(base_register, std::memory_order_relaxed);
++}
++
++uint32_t GetNativeShaderLabelMatrixRegister() {
++  return NativeShaderLabelMatrixRegisterFlag().load(std::memory_order_relaxed);
++}
++
++void SetDebugColorizeMode(bool enabled) {
++  DebugColorizeModeFlag().store(enabled, std::memory_order_relaxed);
++}
++
++bool GetDebugColorizeMode() {
++  return DebugColorizeModeFlag().load(std::memory_order_relaxed);
++}
++
++namespace {
++
++uint64_t Now() {
++  return uint64_t(std::chrono::duration_cast<std::chrono::nanoseconds>(
++                      std::chrono::steady_clock::now().time_since_epoch())
++                      .count());
++}
++
++#if NATIVEVK_HAVE_XENOS_SHADER_CACHE
++const RenutXenosShaderCacheEntry* FindCacheEntry(uint64_t ucode_hash) {
++  // Linear scan: the cache is a few dozen entries today (33 in the first
++  // real batch-conversion run, see PLAN_native_renderer.md), not thousands --
++  // a hash map isn't worth the complexity yet. Revisit if/when the batch
++  // conversion's success rate improves enough to make this list large.
++  for (size_t i = 0; i < g_renutXenosShaderCacheEntryCount; ++i) {
++    if (g_renutXenosShaderCacheEntries[i].hash == ucode_hash) {
++      return &g_renutXenosShaderCacheEntries[i];
++    }
++  }
++  return nullptr;
++}
++#endif
++
++// Maps a decoded Xenos vertex-fetch format + signedness/normalization to a
++// real Vulkan format for a VkVertexInputAttributeDescription. See
++// PLAN_native_renderer.md's "real Vulkan vertex-buffer/format decode path"
++// note for the real caveats here (found via direct source investigation,
++// not guessed): k_10_11_11/k_11_11_10 have NO exact unsigned-normalized
++// Vulkan equivalent (Vulkan only has the _UFLOAT variant, which is not the
++// same bit layout as Xenos's plain integer fields) -- returns
++// VK_FORMAT_UNDEFINED for those, which callers must treat as "this shader
++// can't get a native pipeline yet," not silently drawn wrong. Signed-
++// normalized decode is ALSO not guaranteed bit-identical to Vulkan _SNORM
++// when the fetch instruction's signed_rf_mode is kZeroClampMinusOne (the
++// Microsoft two's-complement-with-clamp convention) rather than the OpenGL-
++// style mapping Vulkan _SNORM uses -- accepted as a known, real, understood
++// gap for now (documented, not silently wrong-by-omission), not a blocker
++// for the common kNoZero/unsigned/float cases most real vertex data uses.
++VkFormat VertexFormatToVkFormat(xenos::VertexFormat format, bool is_signed, bool is_integer) {
++  switch (format) {
++    case xenos::VertexFormat::k_32_FLOAT:
++      return VK_FORMAT_R32_SFLOAT;
++    case xenos::VertexFormat::k_32_32_FLOAT:
++      return VK_FORMAT_R32G32_SFLOAT;
++    case xenos::VertexFormat::k_32_32_32_FLOAT:
++      return VK_FORMAT_R32G32B32_SFLOAT;
++    case xenos::VertexFormat::k_32_32_32_32_FLOAT:
++      return VK_FORMAT_R32G32B32A32_SFLOAT;
++    case xenos::VertexFormat::k_16_16_FLOAT:
++      return VK_FORMAT_R16G16_SFLOAT;
++    case xenos::VertexFormat::k_16_16_16_16_FLOAT:
++      return VK_FORMAT_R16G16B16A16_SFLOAT;
++    case xenos::VertexFormat::k_32:
++      // Vulkan has no 32-bit normalized-integer format (_UNORM/_SNORM only
++      // exist for 8/16-bit channels) -- is_integer is moot here, always bind
++      // as raw ints. A non-integer (normalized) 32-bit fetch is a real,
++      // known gap: the shader will see raw integer bits, not the
++      // [-1,1]/[0,1] float the guest shader expects.
++      return is_signed ? VK_FORMAT_R32_SINT : VK_FORMAT_R32_UINT;
++    case xenos::VertexFormat::k_32_32:
++      return is_signed ? VK_FORMAT_R32G32_SINT : VK_FORMAT_R32G32_UINT;
++    case xenos::VertexFormat::k_32_32_32_32:
++      return is_signed ? VK_FORMAT_R32G32B32A32_SINT : VK_FORMAT_R32G32B32A32_UINT;
++    case xenos::VertexFormat::k_16_16:
++      return is_integer ? (is_signed ? VK_FORMAT_R16G16_SINT : VK_FORMAT_R16G16_UINT)
++                         : (is_signed ? VK_FORMAT_R16G16_SNORM : VK_FORMAT_R16G16_UNORM);
++    case xenos::VertexFormat::k_16_16_16_16:
++      return is_integer ? (is_signed ? VK_FORMAT_R16G16B16A16_SINT : VK_FORMAT_R16G16B16A16_UINT)
++                         : (is_signed ? VK_FORMAT_R16G16B16A16_SNORM : VK_FORMAT_R16G16B16A16_UNORM);
++    case xenos::VertexFormat::k_8_8_8_8:
++      return is_integer ? (is_signed ? VK_FORMAT_R8G8B8A8_SINT : VK_FORMAT_R8G8B8A8_UINT)
++                         : (is_signed ? VK_FORMAT_R8G8B8A8_SNORM : VK_FORMAT_R8G8B8A8_UNORM);
++    case xenos::VertexFormat::k_2_10_10_10:
++      return is_integer ? (is_signed ? VK_FORMAT_A2B10G10R10_SINT_PACK32
++                                      : VK_FORMAT_A2B10G10R10_UINT_PACK32)
++                         : (is_signed ? VK_FORMAT_A2B10G10R10_SNORM_PACK32
++                                      : VK_FORMAT_A2B10G10R10_UNORM_PACK32);
++    case xenos::VertexFormat::k_10_11_11:
++    case xenos::VertexFormat::k_11_11_10:
++      // No exact Vulkan equivalent -- see comment above.
++      return VK_FORMAT_UNDEFINED;
++    default:
++      return VK_FORMAT_UNDEFINED;
++  }
++}
++
++struct VertexAttributeInfo {
++  uint32_t location;
++  uint32_t fetch_constant_index;
++  uint32_t offset_bytes;  // relative to this fetch constant's own buffer, not a global offset
++  VkFormat format;
++};
++
++struct VertexBindingInfo {
++  uint32_t fetch_constant_index;
++  uint32_t binding;  // Vulkan binding slot for this fetch constant's buffer
++};
++
++// One fully-built native pipeline for a (vertex_hash, pixel_hash) pair.
++struct PipelineEntry {
++  bool attempted = false;
++  bool available = false;
++  VkPipeline pipeline = VK_NULL_HANDLE;
++  VkPipelineLayout pipeline_layout = VK_NULL_HANDLE;
++  VkShaderModule vertex_module = VK_NULL_HANDLE;
++  VkShaderModule pixel_module = VK_NULL_HANDLE;
++  // "Colorize by shader" debug mode (see SetDebugColorizeMode's header
++  // comment) -- same vertex_module, pixel stage swapped for the trivial
++  // flat-color fragment shader, built lazily the first time debug mode is
++  // requested for this pair so the common (debug mode off) path pays
++  // nothing extra.
++  VkPipeline debug_pipeline = VK_NULL_HANDLE;
++  bool debug_pipeline_attempted = false;
++  // Dynamic-rendering fix (2026-08-16): a real VkRenderPass is always
++  // VK_NULL_HANDLE under dynamic rendering (confirmed:
++  // command_processor.cpp's `current_render_pass_ = use_dynamic_rendering ?
++  // VK_NULL_HANDLE : render_pass`), which is the ACTIVE mode on real
++  // hardware this was tested against, not an edge case -- so a VkRenderPass
++  // handle can never distinguish "different real render targets" once
++  // dynamic rendering is on, and using one as the cache-validity key would
++  // make a pipeline for the wrong attachment formats look valid forever.
++  // Key on the real RenderPassKey instead (already used by the stock
++  // pipeline_cache.cpp for exactly this -- see render_target_cache.h),
++  // which carries real MSAA/depth-format/color-format bits and works
++  // correctly under BOTH rendering modes.
++  VulkanRenderTargetCache::RenderPassKey pipeline_render_pass_key;
++
++  // One real Vulkan vertex binding per distinct fetch constant this vertex
++  // shader's vfetch instructions reference (usually just 1 -- most Banjo
++  // vertex data is interleaved in a single stream -- but not assumed to be).
++  std::vector<VertexBindingInfo> bindings;
++  std::vector<VertexAttributeInfo> attributes;
++
++  // Real bug found+fixed 2026-08-17: XenosRecomp's g_SwappedTexcoords shared
++  // constant (shader_common.h) tells the shader which TEXCOORD semantics
++  // need a .yxwz correction swizzle -- real, needed whenever that texcoord's
++  // vertex data uses a 16-bit-per-channel format (k_16_16/k_16_16_16_16),
++  // because the guest's own 32-bit-word endian swap scrambles sub-word
++  // fields. Computed once here at pipeline-creation time (real vertex
++  // format data is only available here, via each attribute's real VkFormat)
++  // and reused every draw -- see IssueNativeDraw's own SharedConstantsLayout
++  // population.
++  uint32_t swapped_texcoords_mask = 0;
++};
++
++struct State {
++  std::unordered_map<uint64_t, PipelineEntry> pipelines;  // key: (vs_hash << 32) ^ ps_hash-ish combine, see Key()
++  uint64_t draw_count = 0;
++  uint64_t total_ns = 0;
++};
++
++State& GetState() {
++  static State state;
++  return state;
++}
++
++uint64_t CombineKey(uint64_t vertex_hash, uint64_t pixel_hash) {
++  // A real 64-bit combine (not a truncating XOR of two already-64-bit
++  // hashes, which would be a real collision risk) -- rotate one side so
++  // vs/ps swaps don't collide, then XOR.
++  uint64_t rotated = (pixel_hash << 17) | (pixel_hash >> (64 - 17));
++  return vertex_hash ^ rotated;
++}
++
++uint64_t CombineKeyWithRenderPass(uint64_t vertex_hash, uint64_t pixel_hash,
++                                  uint32_t render_pass_key_bits) {
++  // The SAME (vs_hash, ps_hash) pair is legitimately drawn under different
++  // render target format combinations within a single frame (e.g. HUD/UI
++  // draws with no depth vs. 3D geometry draws with depth, differing MSAA
++  // state) -- each is a genuinely distinct Vulkan pipeline object (render
++  // pass compatibility is baked into a graphics pipeline at creation time).
++  // Folding render_pass_key into the map key (instead of storing a single
++  // PipelineEntry per shader pair and overwriting it every time the render
++  // target combo changes) is what makes the cache actually cache instead of
++  // rebuilding a pipeline from scratch on every draw whose render targets
++  // differ from the last cached one.
++  uint64_t key = CombineKey(vertex_hash, pixel_hash);
++  uint64_t rp = render_pass_key_bits;
++  return key ^ ((rp << 32) | rp);
++}
++
++// Fixed array size confirmed against real XenosRecomp-generated HLSL
++// (g_Texture2DDescriptorHeap[32] etc, see this file's header comment) -- NOT
++// VK_DESCRIPTOR_BINDING_VARIABLE_DESCRIPTOR_COUNT_BIT-sized, the shaders
++// themselves declare a bounded array, so the real Vulkan layout must match
++// that bound exactly or DXC's SPIR-V will index out of the declared range.
++//
++// REAL FINDING (verified by compiling real generated HLSL through real DXC
++// and disassembling the resulting SPIR-V, not by reading the HLSL text
++// alone -- an earlier reading of this same file's non-__spirv__ branch gave
++// the wrong impression that indices were runtime cbuffer reads): under the
++// STALE, WRONG (kept for history -- see SharedConstantsLayout's own comment
++// below for the full correction): this used to claim the descriptor index
++// was a compile-time #define equal to the fetch constant, so the heap slot
++// for register N was hardcoded to N. That is false for the __spirv__ path
++// actually compiled -- shader_recompiler.cpp:1272 emits a genuine per-draw
++// `vk::RawBufferLoad<uint>(SharedConstants + ...)`, i.e. the heap slot a
++// shader samples is whatever value THIS draw's SharedConstants buffer holds
++// at that fixed byte offset, chosen freely by the CPU side every draw.
++//
++// REAL BUG FOUND 2026-08-18 (bindless-heap race): with the slot value always
++// set equal to fetch_constant (a 0-31 hardware register number), every real
++// texture that ever binds to register N -- and many different real textures
++// commonly share the same register across different draw calls/objects,
++// e.g. register 0 is almost always "the diffuse texture" -- landed in the
++// SAME heap slot N. BindTexture2DFixedSlot's vkUpdateDescriptorSets write is
++// immediate on the CPU, but draws are recorded into a command buffer and
++// executed by the GPU later/asynchronously; by the time the GPU actually
++// executes an earlier draw that used register N, a later-recorded draw for
++// a totally different object (also using register N) may have already
++// overwritten slot N's descriptor with ITS texture. Net effect: whichever
++// draw sharing a register happened to bind last (of however many recorded
++// since the earlier draw was submitted) wins for ALL of them, every frame,
++// non-deterministically depending on submission/scheduling timing -- an
++// exact mechanical match for "flickering, timing-dependent wrong textures"
++// that survived every previous constant-data fix.
++//
++// FIX: stop treating "heap slot" and "fetch constant register" as the same
++// number. Each DISTINCT real (VkImageView, VkSampler) pair now gets its own
++// permanently-allocated heap slot (see BindlessHeapState::texture2d_slot_map
++// below), written to the descriptor set exactly ONCE ever (first time that
++// exact texture/sampler pair is seen), and each draw's SharedConstants
++// buffer stores THAT texture's real assigned slot as the runtime index --
++// never a shared, register-numbered, overwritable slot. Since the pool now
++// holds one slot per distinct texture (not per hardware register), it needs
++// far more than 32 slots -- grown to comfortably cover a full game's texture
++// set for a play session (no eviction in this first pass, see
++// texture2d_slot_map's own comment).
++constexpr uint32_t kBindlessHeapSlotCount = 4096;
++
++// One real Vulkan resource per allocated heap slot, plain fixed-size array
++// sized for the grown kBindlessHeapSlotCount -- slot index is now an
++// ARBITRARY allocated id (see texture2d_slot_map), not the fetch constant.
++struct BindlessHeapEntry {
++  VkImageView view = VK_NULL_HANDLE;
++  VkSampler sampler = VK_NULL_HANDLE;
++};
++
++struct BindlessHeapState {
++  bool initialized = false;
++  bool available = false;
++
++  VkDescriptorSetLayout texture2d_set_layout = VK_NULL_HANDLE;
++  VkDescriptorSetLayout texture3d_set_layout = VK_NULL_HANDLE;
++  VkDescriptorSetLayout texturecube_set_layout = VK_NULL_HANDLE;
++  VkDescriptorSetLayout sampler_set_layout = VK_NULL_HANDLE;
++  VkDescriptorPool descriptor_pool = VK_NULL_HANDLE;
++  VkDescriptorSet texture2d_set = VK_NULL_HANDLE;
++  VkDescriptorSet texture3d_set = VK_NULL_HANDLE;
++  VkDescriptorSet texturecube_set = VK_NULL_HANDLE;
++  VkDescriptorSet sampler_set = VK_NULL_HANDLE;
++
++  VkPipelineLayout pipeline_layout = VK_NULL_HANDLE;
++
++  // Real per-slot Vulkan descriptor writes. Only Texture2D is populated for
++  // now -- the one proven shader pair (and the vast majority of real
++  // gameplay textures) samples 2D only; 3D/Cube slots stay unbound (real
++  // HLSL indexes them with a valid-but-unwritten descriptor, which the
++  // Vulkan spec allows under VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT as
++  // long as the shader never actually samples that index at draw time --
++  // true here since no captured shader this session used tfetch3D/
++  // tfetchCube).
++  std::array<BindlessHeapEntry, kBindlessHeapSlotCount> texture2d_entries;
++
++  // Real fix (2026-08-18, bindless-heap race -- see kBindlessHeapSlotCount's
++  // comment): maps a distinct real (VkImageView, VkSampler) pair to its
++  // permanently-allocated heap slot. A texture is written to the descriptor
++  // set exactly once, the first time it's seen; every later draw that reuses
++  // the same real texture just looks its already-assigned slot up here and
++  // writes THAT into its own per-draw SharedConstants -- no shared,
++  // register-numbered slot ever gets overwritten out from under an
++  // in-flight draw. No eviction in this first pass: slots accumulate for the
++  // life of the process. Acceptable for a bounded game texture set; a very
++  // long play session revisiting enough distinct textures to exceed
++  // kBindlessHeapSlotCount would need an LRU eviction scheme added here.
++  std::unordered_map<uint64_t, uint32_t> texture2d_slot_map;
++  uint32_t next_free_texture2d_slot = 0;
++
++  // Real per-draw constant-buffer upload, BDA-addressed exactly like
++  // nativevk_phase1_native_draw.cpp's proven single-shader mechanism (see this
++  // file's header comment) -- generalized to any shader's real constant
++  // registers instead of one hardcoded half-pixel-offset value.
++  std::unique_ptr<ui::vulkan::VulkanUploadBufferPool> constants_pool;
++  // Real bug found+fixed 2026-08-17 ("Not enough memory for command
++  // submission" / amdgpu_vm_validate() failures, confirmed via a live
++  // VRAM/GTT poll showing GTT climbing ~6MB/s with NO plateau during
++  // ordinary gameplay, independent of scene complexity): constants_pool is a real
++  // GraphicsUploadBufferPool (see upload_buffer_pool.h) whose whole design
++  // depends on Reclaim(completed_submission_index) being called once a
++  // page's submission has finished on the GPU, returning that page to the
++  // writable list for REUSE -- exactly how the stock renderer's own
++  // uniform_buffer_pool_ is used (command_processor.cpp:
++  // `uniform_buffer_pool_->Reclaim(frame_completed_)`, once per frame).
++  // This pool never had that call wired up anywhere: every draw's 3
++  // Request() calls (vs/ps/shared constants, ~8.5KB total) either fit in
++  // the current page or silently allocate a BRAND NEW VkBuffer+
++  // VkDeviceMemory page that then NEVER returns to the writable list --
++  // an unbounded page count, growing forever for as long as native draws
++  // keep happening. last_reclaimed_frame lets IssueNativeDraw call
++  // Reclaim() once per frame (matching the stock pool's own cadence)
++  // without doing it on every single draw.
++  uint64_t last_reclaimed_frame = UINT64_MAX;
++};
++
++BindlessHeapState& GetHeapState() {
++  static BindlessHeapState state;
++  return state;
++}
++
++}  // namespace
++
++namespace {
++
++// One VkDescriptorSetLayoutBinding for a single-binding, fixed-array-size,
++// update-after-bind set (all four bindless sets share this exact shape --
++// only descriptorType/stageFlags differ).
++VkDescriptorSetLayoutBinding MakeBindlessBinding(VkDescriptorType type) {
++  VkDescriptorSetLayoutBinding binding = {};
++  binding.binding = 0;
++  binding.descriptorType = type;
++  binding.descriptorCount = kBindlessHeapSlotCount;
++  binding.stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
++  return binding;
++}
++
++bool CreateBindlessSetLayout(VkDevice device, const ui::vulkan::VulkanDevice::Functions& dfn,
++                              VkDescriptorType type, VkDescriptorSetLayout& layout_out) {
++  VkDescriptorSetLayoutBinding binding = MakeBindlessBinding(type);
++
++  // The three flags XenosRecomp's bindless scheme structurally requires:
++  // PARTIALLY_BOUND (slots this session never wrote stay valid-but-unused,
++  // matching kBindlessHeapEntry's "unbound Texture3D/Cube" note above),
++  // UPDATE_AFTER_BIND (write new texture slots without invalidating an
++  // already-bound descriptor set, since real gameplay loads new textures
++  // continuously), and the plain descriptor-indexing capability bit set
++  // implied by using either of those. VARIABLE_DESCRIPTOR_COUNT is
++  // deliberately NOT used -- the real generated HLSL declares a bounded
++  // [32] array, not an unbounded one (confirmed via direct HLSL inspection,
++  // see this file's header comment), so a fixed descriptorCount is correct,
++  // not a placeholder.
++  VkDescriptorBindingFlags binding_flags =
++      VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT | VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT;
++  VkDescriptorSetLayoutBindingFlagsCreateInfo binding_flags_info = {};
++  binding_flags_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO;
++  binding_flags_info.bindingCount = 1;
++  binding_flags_info.pBindingFlags = &binding_flags;
++
++  VkDescriptorSetLayoutCreateInfo layout_create_info = {};
++  layout_create_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
++  layout_create_info.pNext = &binding_flags_info;
++  layout_create_info.flags = VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT;
++  layout_create_info.bindingCount = 1;
++  layout_create_info.pBindings = &binding;
++
++  return dfn.vkCreateDescriptorSetLayout(device, &layout_create_info, nullptr, &layout_out) ==
++         VK_SUCCESS;
++}
++
++}  // namespace
++
++void EnsureBindlessHeapInitialized(VulkanCommandProcessor& command_processor) {
++  BindlessHeapState& heap = GetHeapState();
++  if (heap.initialized) {
++    return;
++  }
++  heap.initialized = true;
++
++  const ui::vulkan::VulkanDevice* vulkan_device = command_processor.GetVulkanDevice();
++  const auto& properties = vulkan_device->properties();
++  if (!properties.descriptorIndexing || !properties.runtimeDescriptorArray ||
++      !properties.shaderSampledImageArrayNonUniformIndexing ||
++      !properties.descriptorBindingPartiallyBound ||
++      !properties.descriptorBindingVariableDescriptorCount ||
++      !properties.descriptorBindingSampledImageUpdateAfterBind) {
++    REXGPU_WARN(
++        "renut bindless heap: device lacks required descriptor-indexing features -- native "
++        "pipelines with real textures unavailable this run");
++    return;
++  }
++
++  const ui::vulkan::VulkanDevice::Functions& dfn = vulkan_device->functions();
++  VkDevice device = vulkan_device->device();
++
++  bool ok = CreateBindlessSetLayout(device, dfn, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
++                                    heap.texture2d_set_layout);
++  ok = ok && CreateBindlessSetLayout(device, dfn, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
++                                     heap.texture3d_set_layout);
++  ok = ok && CreateBindlessSetLayout(device, dfn, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
++                                     heap.texturecube_set_layout);
++  ok = ok && CreateBindlessSetLayout(device, dfn, VK_DESCRIPTOR_TYPE_SAMPLER,
++                                     heap.sampler_set_layout);
++  if (!ok) {
++    REXGPU_ERROR("renut bindless heap: failed to create descriptor set layout(s)");
++    return;
++  }
++
++  // One pool, sized for exactly the 4 sets this heap ever allocates (this is
++  // a process-lifetime singleton heap, not a per-frame/per-draw transient
++  // pool like the stock renderer's -- real textures accumulate across the
++  // whole session, they are not reset every frame).
++  VkDescriptorPoolSize pool_sizes[2] = {};
++  pool_sizes[0].type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
++  pool_sizes[0].descriptorCount = kBindlessHeapSlotCount * 3;  // 2D + 3D + Cube sets
++  pool_sizes[1].type = VK_DESCRIPTOR_TYPE_SAMPLER;
++  pool_sizes[1].descriptorCount = kBindlessHeapSlotCount;
++
++  VkDescriptorPoolCreateInfo pool_create_info = {};
++  pool_create_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
++  pool_create_info.flags = VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT;
++  pool_create_info.maxSets = 4;
++  pool_create_info.poolSizeCount = uint32_t(rex::countof(pool_sizes));
++  pool_create_info.pPoolSizes = pool_sizes;
++  if (dfn.vkCreateDescriptorPool(device, &pool_create_info, nullptr, &heap.descriptor_pool) !=
++      VK_SUCCESS) {
++    REXGPU_ERROR("renut bindless heap: failed to create descriptor pool");
++    return;
++  }
++
++  VkDescriptorSetLayout layouts[4] = {heap.texture2d_set_layout, heap.texture3d_set_layout,
++                                      heap.texturecube_set_layout, heap.sampler_set_layout};
++  VkDescriptorSet sets[4] = {};
++  VkDescriptorSetAllocateInfo alloc_info = {};
++  alloc_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
++  alloc_info.descriptorPool = heap.descriptor_pool;
++  alloc_info.descriptorSetCount = uint32_t(rex::countof(layouts));
++  alloc_info.pSetLayouts = layouts;
++  if (dfn.vkAllocateDescriptorSets(device, &alloc_info, sets) != VK_SUCCESS) {
++    REXGPU_ERROR("renut bindless heap: failed to allocate descriptor sets");
++    return;
++  }
++  heap.texture2d_set = sets[0];
++  heap.texture3d_set = sets[1];
++  heap.texturecube_set = sets[2];
++  heap.sampler_set = sets[3];
++
++  // Real per-draw constant-buffer upload pool -- device-address-capable so
++  // vkGetBufferDeviceAddress works on suballocations from it, matching
++  // Phase 1's proven single-buffer mechanism (see this file's header
++  // comment), generalized to a real growable pool since every native shader
++  // pair needs its own VertexShaderConstants/PixelShaderConstants/
++  // SharedConstants data every draw, not one static buffer.
++  heap.constants_pool = std::make_unique<ui::vulkan::VulkanUploadBufferPool>(
++      vulkan_device,
++      VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT);
++
++  heap.available = true;
++  REXGPU_INFO("renut bindless heap: initialized ({} slots per heap)", kBindlessHeapSlotCount);
++}
++
++VkPipelineLayout GetOrCreateBindlessPipelineLayout(VulkanCommandProcessor& command_processor) {
++  BindlessHeapState& heap = GetHeapState();
++  if (heap.pipeline_layout != VK_NULL_HANDLE) {
++    return heap.pipeline_layout;
++  }
++  if (!heap.available) {
++    return VK_NULL_HANDLE;
++  }
++
++  const ui::vulkan::VulkanDevice* vulkan_device = command_processor.GetVulkanDevice();
++  const ui::vulkan::VulkanDevice::Functions& dfn = vulkan_device->functions();
++  VkDevice device = vulkan_device->device();
++
++  // Same 3-uint64 push-constant range as the existing (non-bindless) native
++  // pipeline layout -- constants stay BDA-addressed via push constants, only
++  // the descriptor sets are new (see this file's header comment).
++  VkPushConstantRange push_constant_range;
++  push_constant_range.stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
++  push_constant_range.offset = 0;
++  push_constant_range.size = sizeof(uint64_t) * 3;
++
++  // Set indices MUST match DXC's default HLSL space->Vulkan set mapping
++  // exactly (space0..3 for the four bindless arrays -- confirmed via direct
++  // HLSL/dxc_compiler.cpp inspection, no -fvk-bind-* overrides are used to
++  // remap them, see this file's header comment).
++  VkDescriptorSetLayout set_layouts[4] = {heap.texture2d_set_layout, heap.texture3d_set_layout,
++                                          heap.texturecube_set_layout, heap.sampler_set_layout};
++
++  VkPipelineLayoutCreateInfo pipeline_layout_create_info = {};
++  pipeline_layout_create_info.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
++  pipeline_layout_create_info.setLayoutCount = uint32_t(rex::countof(set_layouts));
++  pipeline_layout_create_info.pSetLayouts = set_layouts;
++  pipeline_layout_create_info.pushConstantRangeCount = 1;
++  pipeline_layout_create_info.pPushConstantRanges = &push_constant_range;
++
++  if (dfn.vkCreatePipelineLayout(device, &pipeline_layout_create_info, nullptr,
++                                 &heap.pipeline_layout) != VK_SUCCESS) {
++    REXGPU_ERROR("renut bindless heap: failed to create pipeline layout");
++    return VK_NULL_HANDLE;
++  }
++  return heap.pipeline_layout;
++}
++
++bool HasNativePipeline(uint64_t vertex_shader_ucode_hash, uint64_t pixel_shader_ucode_hash) {
++#if NATIVEVK_HAVE_XENOS_SHADER_CACHE
++  // Real fix (2026-08-18): used to only initialize the panel once a real
++  // vs+ps pair was found below, so if the native shader cache genuinely has
++  // zero matching pairs (e.g. after a fresh, not-yet-repopulated capture --
++  // see PROJECT_MEMORY.md's capture-hash-bug writeup), the panel never
++  // appeared at all, with no way to tell "broken" apart from "nothing to
++  // show yet". Always initialize on the first real check regardless of
++  // outcome, so the panel is always reachable and can show "0 live pairs"
++  // honestly instead of not existing.
++  EnsureDebugPanelInitialized();
++  if (FindCacheEntry(vertex_shader_ucode_hash) == nullptr ||
++      FindCacheEntry(pixel_shader_ucode_hash) == nullptr) {
++    return false;
++  }
++  // Real pair (both sides genuinely converted) -- record it for the debug
++  // panel and respect any live toggle.
++  return RecordAndCheckPairEnabled(vertex_shader_ucode_hash, pixel_shader_ucode_hash);
++#else
++  (void)vertex_shader_ucode_hash;
++  (void)pixel_shader_ucode_hash;
++  return false;
++#endif
++}
++
++// Real Xenos-primitive-type -> Vulkan-topology mapping for the subset this
++// native path can draw directly (no geometry-shader expansion available).
++// Mirrors pipeline_cache.cpp's own real mapping (ComputePipelineDescription)
++// for these specific cases. kRectangleList/kQuadList/kTriangleFan and
++// anything else return false -- callers must fall back to the normal
++// Xenos-translated draw for those.
++bool PrimitiveTypeToVkTopology(xenos::PrimitiveType type, VkPrimitiveTopology& topology_out) {
++  switch (type) {
++    case xenos::PrimitiveType::kPointList:
++      topology_out = VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
++      return true;
++    case xenos::PrimitiveType::kLineList:
++      topology_out = VK_PRIMITIVE_TOPOLOGY_LINE_LIST;
++      return true;
++    case xenos::PrimitiveType::kLineStrip:
++      topology_out = VK_PRIMITIVE_TOPOLOGY_LINE_STRIP;
++      return true;
++    case xenos::PrimitiveType::kTriangleList:
++      topology_out = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
++      return true;
++    case xenos::PrimitiveType::kTriangleStrip:
++      topology_out = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP;
++      return true;
++    default:
++      // kTriangleFan (expected pre-converted to a list upstream, and if not,
++      // wrong here anyway), kRectangleList, kQuadList, kQuadStrip, kPolygon,
++      // tessellation patches -- all need real geometry-shader/CPU expansion
++      // this native path doesn't implement. Fall back rather than draw wrong.
++      return false;
++  }
++}
++
++// Real cull mode + blend state, read from the guest's own PA_SU_SC_MODE_CNTL
++// / RB_BLENDCONTROL0 registers (2026-08-16 fix): GetOrCreatePipeline
++// previously hardcoded VK_CULL_MODE_NONE and blendEnable=false for every
++// native pipeline, unconditionally -- confirmed via direct comparison with
++// pipeline_cache.cpp's real per-draw ComputePipelineDescription /
++// WritePipelineRenderTargetDescription, which read these exact registers
++// for the stock path. Symptom match was exact: user-reported "particles no
++// longer move but are still rendered and stuck to the viewport" and
++// "glowing" (alpha-blended/additive effects becoming fully opaque, so each
++// draw overwrites instead of blending) plus "less bugs facing one direction
++// than the other" (missing backface culling letting invisible-should-be
++// backfaces render/z-fight). Only render target 0 is read -- this native
++// path only ever builds one color attachment (see PipelineEntry's single
++// VkPipelineColorBlendAttachmentState usage below), matching its existing
++// single-attachment assumption elsewhere in this file.
++struct RasterAndBlendState {
++  VkCullModeFlags cull_mode = VK_CULL_MODE_NONE;
++  VkFrontFace front_face = VK_FRONT_FACE_CLOCKWISE;
++  bool blend_enable = false;
++  VkBlendFactor src_color_factor = VK_BLEND_FACTOR_ONE;
++  VkBlendFactor dst_color_factor = VK_BLEND_FACTOR_ZERO;
++  VkBlendOp color_blend_op = VK_BLEND_OP_ADD;
++  VkBlendFactor src_alpha_factor = VK_BLEND_FACTOR_ONE;
++  VkBlendFactor dst_alpha_factor = VK_BLEND_FACTOR_ZERO;
++  VkBlendOp alpha_blend_op = VK_BLEND_OP_ADD;
++  // Real depth-test/-write/-compare state (2026-08-16 fix), read from the
++  // guest's own RB_DEPTHCONTROL register -- GetOrCreatePipeline previously
++  // hardcoded depthTestEnable/depthWriteEnable to VK_TRUE with a fixed
++  // VK_COMPARE_OP_LESS_OR_EQUAL for every native pipeline whenever a depth
++  // attachment existed, regardless of what the guest actually asked for.
++  // Confirmed real-world impact: a shader pair reused for a real captured
++  // 2D/UI-shaped vertex shader (2-float position, no 3D depth-worthy
++  // shape) combined with a pixel shader that manually writes depth
++  // (RB_DEPTHCONTROL governs whether/how that write and any depth TEST
++  // against existing depth actually happens) -- forcing depth test+write
++  // on unconditionally can make a draw that should always be visible get
++  // incorrectly occluded, or incorrectly occlude other geometry.
++  bool depth_test_enable = false;
++  bool depth_write_enable = false;
++  VkCompareOp depth_compare_op = VK_COMPARE_OP_LESS_OR_EQUAL;
++  // Cheap, real per-draw-state key bits folded into the pipeline cache key
++  // (see CombineKeyWithRenderPass's own comment on why render-target-combo
++  // and topology need the same treatment) -- cull(2)+face(1)+blend(1) fit in
++  // 4 bits; the 5 blend factor/op fields (real, small guest enums, <=8 each)
++  // fit in 3 bits apiece, for 19 bits total; depth test/write(1 bit each)
++  // and compare op (3 bits) add 5 more, for 24 bits total, comfortably
++  // inside the 32-bit budget CombineKeyWithRenderPass already reserves for
++  // extra state.
++  uint32_t key_bits = 0;
++};
++
++RasterAndBlendState ComputeRasterAndBlendState(const RegisterFile& regs) {
++  RasterAndBlendState result;
++
++  auto pa_su_sc_mode_cntl = regs.Get<reg::PA_SU_SC_MODE_CNTL>();
++  if (pa_su_sc_mode_cntl.cull_front) {
++    result.cull_mode |= VK_CULL_MODE_FRONT_BIT;
++  }
++  if (pa_su_sc_mode_cntl.cull_back) {
++    result.cull_mode |= VK_CULL_MODE_BACK_BIT;
++  }
++  result.front_face =
++      pa_su_sc_mode_cntl.face != 0 ? VK_FRONT_FACE_CLOCKWISE : VK_FRONT_FACE_COUNTER_CLOCKWISE;
++
++  // Same real Xenos-BlendFactor -> Vulkan-VkBlendFactor table as
++  // pipeline_cache.cpp's stock path (WritePipelineRenderTargetDescription +
++  // its ComputePipeline consumer) -- 32 entries for safety since the guest
++  // field is 5 bits, only ~17 are real/defined.
++  static const VkBlendFactor kBlendFactorMap[32] = {
++      /*  0 */ VK_BLEND_FACTOR_ZERO,
++      /*  1 */ VK_BLEND_FACTOR_ONE,
++      /*  2 */ VK_BLEND_FACTOR_ZERO,  // ?
++      /*  3 */ VK_BLEND_FACTOR_ZERO,  // ?
++      /*  4 */ VK_BLEND_FACTOR_SRC_COLOR,
++      /*  5 */ VK_BLEND_FACTOR_ONE_MINUS_SRC_COLOR,
++      /*  6 */ VK_BLEND_FACTOR_SRC_ALPHA,
++      /*  7 */ VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA,
++      /*  8 */ VK_BLEND_FACTOR_DST_COLOR,
++      /*  9 */ VK_BLEND_FACTOR_ONE_MINUS_DST_COLOR,
++      /* 10 */ VK_BLEND_FACTOR_DST_ALPHA,
++      /* 11 */ VK_BLEND_FACTOR_ONE_MINUS_DST_ALPHA,
++      /* 12 */ VK_BLEND_FACTOR_CONSTANT_COLOR,
++      /* 13 */ VK_BLEND_FACTOR_ONE_MINUS_CONSTANT_COLOR,
++      /* 14 */ VK_BLEND_FACTOR_CONSTANT_ALPHA,
++      /* 15 */ VK_BLEND_FACTOR_ONE_MINUS_CONSTANT_ALPHA,
++      /* 16 */ VK_BLEND_FACTOR_SRC_ALPHA_SATURATE,
++  };
++  static const VkBlendOp kBlendOpMap[8] = {
++      VK_BLEND_OP_ADD,          VK_BLEND_OP_SUBTRACT, VK_BLEND_OP_MIN,      VK_BLEND_OP_MAX,
++      VK_BLEND_OP_REVERSE_SUBTRACT, VK_BLEND_OP_ADD,      VK_BLEND_OP_ADD,      VK_BLEND_OP_ADD,
++  };
++
++  auto blend_control = regs.Get<reg::RB_BLENDCONTROL>(reg::RB_BLENDCONTROL::rt_register_indices[0]);
++  result.src_color_factor = kBlendFactorMap[uint32_t(blend_control.color_srcblend) & 0x1F];
++  result.dst_color_factor = kBlendFactorMap[uint32_t(blend_control.color_destblend) & 0x1F];
++  result.color_blend_op = kBlendOpMap[uint32_t(blend_control.color_comb_fcn) & 0x7];
++  result.src_alpha_factor = kBlendFactorMap[uint32_t(blend_control.alpha_srcblend) & 0x1F];
++  result.dst_alpha_factor = kBlendFactorMap[uint32_t(blend_control.alpha_destblend) & 0x1F];
++  result.alpha_blend_op = kBlendOpMap[uint32_t(blend_control.alpha_comb_fcn) & 0x7];
++  // Same "is this actually a no-op" check as the stock path (pipeline_cache.cpp)
++  // -- ONE/ZERO/ADD on both color and alpha is behaviorally identical to
++  // blending disabled, so only mark blendEnable when it would do something.
++  result.blend_enable = result.src_color_factor != VK_BLEND_FACTOR_ONE ||
++                        result.dst_color_factor != VK_BLEND_FACTOR_ZERO ||
++                        result.color_blend_op != VK_BLEND_OP_ADD ||
++                        result.src_alpha_factor != VK_BLEND_FACTOR_ONE ||
++                        result.dst_alpha_factor != VK_BLEND_FACTOR_ZERO ||
++                        result.alpha_blend_op != VK_BLEND_OP_ADD;
++
++  // Real per-draw depth-test/-write/-compare state (2026-08-16 fix) -- see
++  // RasterAndBlendState's own header comment. Same real
++  // CompareFunction->VkCompareOp mapping the stock path uses
++  // (pipeline_cache.cpp: `VK_COMPARE_OP_NEVER + xenos::CompareFunction`),
++  // safe because both enums share the identical 3-bit never/less/equal/
++  // lessequal/greater/notequal/greaterequal/always ordering.
++  // Real bug found+fixed (2026-08-17): reading RB_DEPTHCONTROL raw skipped
++  // the RB_MODECONTROL.edram_mode gate the stock renderer applies via
++  // draw_util::GetNormalizedDepthControl (draw.cpp) -- whenever edram_mode
++  // isn't kColorDepth/kDepthOnly, depth/stencil are fully ignored by the
++  // real hardware regardless of what RB_DEPTHCONTROL says, and stock
++  // force-disables depth testing/writes to match. Native draws under any
++  // other EDRAM mode were depth-testing/writing when they shouldn't,
++  // corrupting later draws' visibility via a wrong depth buffer -- reuse
++  // the exact same real function instead of re-deriving the same logic
++  // (and risking it drifting out of sync).
++  auto depth_control = draw_util::GetNormalizedDepthControl(regs);
++  result.depth_test_enable = depth_control.z_enable != 0;
++  result.depth_write_enable = depth_control.z_enable != 0 && depth_control.z_write_enable != 0;
++  result.depth_compare_op =
++      VkCompareOp(uint32_t(VK_COMPARE_OP_NEVER) + uint32_t(depth_control.zfunc));
++
++  result.key_bits = (uint32_t(result.cull_mode) & 0x3) | ((pa_su_sc_mode_cntl.face & 0x1) << 2) |
++                    ((result.blend_enable ? 1u : 0u) << 3) |
++                    ((uint32_t(blend_control.color_srcblend) & 0x1F) << 4) |
++                    ((uint32_t(blend_control.color_destblend) & 0x1F) << 9) |
++                    ((uint32_t(blend_control.color_comb_fcn) & 0x7) << 14) |
++                    ((uint32_t(blend_control.alpha_srcblend) & 0x1F) << 17) |
++                    ((uint32_t(blend_control.alpha_destblend) & 0x1F) << 22) |
++                    ((uint32_t(blend_control.alpha_comb_fcn) & 0x7) << 27) |
++                    ((result.depth_test_enable ? 1u : 0u) << 30) |
++                    ((result.depth_write_enable ? 1u : 0u) << 31);
++  // depth_compare_op (3 bits) folded separately via XOR -- key_bits is
++  // already fully packed to 32 bits above, matching this file's existing
++  // "XOR extra state in" pattern (CombineKeyWithRenderPass's own comment)
++  // rather than trying to find more non-overlapping bit space.
++  result.key_bits ^= uint32_t(depth_control.zfunc) << 5;
++  return result;
++}
++
++VkPipeline GetOrCreatePipeline(VulkanCommandProcessor& command_processor, Shader* vertex_shader,
++                                Shader* pixel_shader, xenos::PrimitiveType host_primitive_type) {
++#if !NATIVEVK_HAVE_XENOS_SHADER_CACHE
++  (void)command_processor;
++  (void)vertex_shader;
++  (void)pixel_shader;
++  (void)host_primitive_type;
++  return VK_NULL_HANDLE;
++#else
++  VkPrimitiveTopology vk_topology;
++  if (!PrimitiveTypeToVkTopology(host_primitive_type, vk_topology)) {
++    return VK_NULL_HANDLE;
++  }
++
++  State& state = GetState();
++  const uint64_t vs_hash = vertex_shader->ucode_data_hash();
++  const uint64_t ps_hash = pixel_shader->ucode_data_hash();
++
++  const ui::vulkan::VulkanDevice* vulkan_device = command_processor.GetVulkanDevice();
++  const ui::vulkan::VulkanDevice::Functions& dfn = vulkan_device->functions();
++  VkDevice device = vulkan_device->device();
++
++  // Dynamic-rendering fix (2026-08-16): in_render_pass() is real and
++  // correct under BOTH rendering modes (unlike current_render_pass(), which
++  // is always VK_NULL_HANDLE under dynamic rendering by design -- see
++  // PipelineEntry's own comment on pipeline_render_pass_key). This is the
++  // real "is there an active draw target to build against" check.
++  bool use_dynamic_rendering = vulkan_device->properties().dynamicRendering &&
++                               command_processor.current_render_pass() == VK_NULL_HANDLE;
++  VkRenderPass current_render_pass = command_processor.current_render_pass();
++  VulkanRenderTargetCache* render_target_cache = command_processor.render_target_cache();
++  VulkanRenderTargetCache::RenderPassKey render_pass_key =
++      render_target_cache ? render_target_cache->last_update_render_pass_key()
++                          : VulkanRenderTargetCache::RenderPassKey();
++
++  // Real per-draw cull/blend state (2026-08-16 fix, see
++  // ComputeRasterAndBlendState's header comment) -- read BEFORE the cache
++  // lookup and folded into the key, same real reason primitive topology and
++  // render_pass_key already are: the same (vs_hash, ps_hash) pair can
++  // legitimately draw with different cull/blend state at different points
++  // in a frame (e.g. opaque geometry vs. an alpha-blended particle/glow
++  // effect sharing a shader), and each combination needs its own cached
++  // pipeline.
++  const RegisterFile& raster_blend_regs = *command_processor.register_file();
++  RasterAndBlendState raster_blend_state = ComputeRasterAndBlendState(raster_blend_regs);
++
++  // Folds render_pass_key AND primitive topology AND cull/blend state into
++  // the map key (see CombineKeyWithRenderPass's comment) -- the same shader
++  // pair can draw under multiple distinct render target combos, primitive
++  // topologies (e.g. a UI/debug shader used for both triangles and lines),
++  // AND cull/blend combinations per frame, and each combination needs its
++  // OWN cached pipeline, not one shared slot that gets rebuilt every time
++  // any of them changes. render_pass_key.key is already a 32-bit value with
++  // unused high bits (see its own struct comment -- 25 real bits used), so
++  // topology (well under 8 bits) is packed into the remaining space; the
++  // cull/blend bits are XORed in as a second real, independent signal
++  // (same "fold more state in via XOR" pattern CombineKeyWithRenderPass
++  // itself already uses for vertex/pixel hash combination).
++  const uint64_t key = CombineKeyWithRenderPass(
++      vs_hash, ps_hash,
++      render_pass_key.key ^ (uint32_t(host_primitive_type) << 25) ^ raster_blend_state.key_bits);
++
++  auto it = state.pipelines.find(key);
++  if (it != state.pipelines.end()) {
++    PipelineEntry& entry = it->second;
++    if (entry.pipeline != VK_NULL_HANDLE) {
++      // Real bug found+fixed (2026-08-17): an earlier version of this fix
++      // fell through to re-run the ENTIRE build below (including
++      // recreating entry.vertex_module/pixel_module/pipeline in place,
++      // repeatedly, on the live render path) whenever debug mode was on and
++      // a cached pair hadn't built its debug variant yet -- confirmed real
++      // and harmful: user-reported symptom was native draw count
++      // completely stalling and visible flickering the moment debug mode
++      // was enabled, consistent with pipeline/shader-module churn under
++      // load starting to fail. Reverted to simply never retrofitting a
++      // debug variant onto an ALREADY-cached pipeline -- debug-colorize
++      // only takes effect for pairs built fresh (cache miss) while the mode
++      // is already on, via the real build path below, which already
++      // includes the debug-pipeline step as a one-time side effect of
++      // normal creation, no extra churn. Practical effect: toggle debug
++      // mode on, then revisit/reload a scene so its shaders get created
++      // fresh, rather than expecting it to retroactively colorize
++      // already-drawn geometry.
++      return GetDebugColorizeMode() && entry.debug_pipeline != VK_NULL_HANDLE ? entry.debug_pipeline
++                                                                              : entry.pipeline;
++    } else if (entry.attempted && !entry.available) {
++      return VK_NULL_HANDLE;  // already tried and failed against this render target combo, don't retry every draw
++    }
++  }
++
++  if (!vulkan_device->properties().bufferDeviceAddress) {
++    REXGPU_WARN("renut native pipeline DIAG: vs_{:016x} ps_{:016x} no bufferDeviceAddress", vs_hash,
++                ps_hash);
++    return VK_NULL_HANDLE;  // Phase 1's own message already covers this case process-wide
++  }
++  if (!command_processor.in_render_pass()) {
++    REXGPU_WARN("renut native pipeline DIAG: vs_{:016x} ps_{:016x} not in a draw scope", vs_hash,
++                ps_hash);
++    return VK_NULL_HANDLE;  // no active render target to build a pipeline against, real either way
++  }
++  if (!render_target_cache) {
++    REXGPU_WARN("renut native pipeline DIAG: vs_{:016x} ps_{:016x} no render target cache", vs_hash,
++                ps_hash);
++    return VK_NULL_HANDLE;
++  }
++
++  const RenutXenosShaderCacheEntry* vs_entry = FindCacheEntry(vs_hash);
++  const RenutXenosShaderCacheEntry* ps_entry = FindCacheEntry(ps_hash);
++  if (!vs_entry || !ps_entry) {
++    REXGPU_WARN(
++        "renut native pipeline DIAG: vs_{:016x} ps_{:016x} FindCacheEntry failed after "
++        "HasNativePipeline succeeded (vs_entry={} ps_entry={})",
++        vs_hash, ps_hash, vs_entry != nullptr, ps_entry != nullptr);
++    return VK_NULL_HANDLE;  // one or both sides never converted -- HasNativePipeline() should have caught this
++  }
++
++  PipelineEntry& entry = state.pipelines[key];
++  entry.attempted = true;
++  entry.pipeline_render_pass_key = render_pass_key;
++  entry.bindings.clear();
++  entry.attributes.clear();
++
++  // --- Real vertex input, derived from the vertex shader's OWN vfetch
++  // instructions (Shader::vertex_bindings(), populated by AnalyzeUcode(),
++  // already called by the time any shader has been used for a real draw --
++  // see pipeline_cache.cpp's LoadShader/EnsureShadersTranslated). Each
++  // VertexBinding corresponds to one Xenos fetch-constant slot (usually one
++  // interleaved stream, but built generically -- not assumed to be one).
++  //
++  // Real fix (2026-08-16): locations are NOT sequential in vfetch-
++  // instruction order -- XenosRecomp compiles the vertex shader's SPIR-V
++  // stage with a FIXED location per D3D9 usage/usageIndex (its own
++  // shader_recompiler.cpp: USAGE_LOCATIONS, e.g. Position=0, Normal=1,
++  // TexCoord0=4, ...), computed at build time and stored in this cache
++  // entry's vertexLocations[] (tools/xenos_cache_unpack.cpp's
++  // ExtractVertexLocations, indexed in the SAME raw-vfetch-attribute order
++  // this loop walks, including any later-skipped-for-unmappable-format
++  // ones -- raw_attribute_index tracks that raw position independently of
++  // how many attributes actually make it into entry.attributes).
++  // kRenutVertexLocationUnset (0xFF, real sentinel) falls back to the old
++  // sequential behavior for that one attribute -- real, was ALWAYS wrong
++  // for anything but the simplest shaders (confirmed: real Vulkan
++  // validation errors + visible geometry/lighting corruption once
++  // deployed at scale), kept only so shaders converted before this fix
++  // landed (whose cache entries have no real vertexLocations data) don't
++  // hard-fail outright.
++  uint32_t next_location = 0;
++  uint32_t next_binding = 0;
++  uint32_t raw_attribute_index = 0;
++  bool any_unmappable_format = false;
++  for (const Shader::VertexBinding& vb : vertex_shader->vertex_bindings()) {
++    VertexBindingInfo binding_info;
++    binding_info.fetch_constant_index = vb.fetch_constant;
++    binding_info.binding = next_binding;
++    entry.bindings.push_back(binding_info);
++
++    // Real bug found+fixed (2026-08-17): vb.attributes is in RAW UCODE
++    // SCAN ORDER (whatever order vfetch instructions appear in the
++    // program), but tools/build_synthetic_container.py's
++    // build_vertex_container() -- which is what actually built the
++    // container XenosRecomp compiled against, and what
++    // xenos_cache_unpack.cpp's ExtractVertexLocations()/
++    // ExtractVertexTexCoordSemanticIndices() read -- explicitly SORTS each
++    // binding's attributes by offset_words before assigning container
++    // array position (`attributes.sort(key=lambda a: (a["binding_index"],
++    // a["offset_words"]))`), and XenosRecomp itself assigns
++    // [[vk::location(i)]] by that same array POSITION i (shader_recompiler.cpp's
++    // `for (i = 0; i < vertexElementCount; i++) ... vertexElementsAndInterpolators[field18+i]`),
++    // not by instruction address. So vertexLocations[]/
++    // vertexTexCoordSemanticIndex[] are indexed by "position in
++    // offset-sorted order", not "position in raw ucode-scan order" -- for
++    // any shader whose vfetch instructions aren't already in ascending-
++    // offset order within a binding, iterating vb.attributes directly (as
++    // this loop did before) silently misaligns raw_attribute_index against
++    // the wrong element, binding the wrong buffer data to the wrong shader
++    // input. Sort a local copy the same way before iterating so
++    // raw_attribute_index matches the container's real element order.
++    std::vector<const Shader::VertexBinding::Attribute*> sorted_attrs;
++    sorted_attrs.reserve(vb.attributes.size());
++    for (const Shader::VertexBinding::Attribute& attr : vb.attributes) {
++      sorted_attrs.push_back(&attr);
++    }
++    std::stable_sort(sorted_attrs.begin(), sorted_attrs.end(),
++                      [](const Shader::VertexBinding::Attribute* a, const Shader::VertexBinding::Attribute* b) {
++                        return a->fetch_instr.attributes.offset < b->fetch_instr.attributes.offset;
++                      });
++
++    for (const Shader::VertexBinding::Attribute* attr_ptr : sorted_attrs) {
++      const Shader::VertexBinding::Attribute& attr = *attr_ptr;
++      const auto& fetch = attr.fetch_instr;
++      uint8_t real_location = raw_attribute_index < kRenutMaxVertexLocations
++                                   ? vs_entry->vertexLocations[raw_attribute_index]
++                                   : kRenutVertexLocationUnset;
++      ++raw_attribute_index;
++
++      // Real fix (2026-08-17): Normal0/Tangent0/Binormal0 -- Vulkan
++      // locations 1/2/3 in XenosRecomp's own fixed USAGE_LOCATIONS table
++      // (shader_recompiler.cpp; same table xenos_cache_unpack.cpp's
++      // kUsageLocations mirrors to compute vertexLocations[]) -- are always
++      // declared `uint4` in the generated HLSL and manually bit-unpacked by
++      // shader_common.h's tfetchR11G11B10(), which only ever reads `.x`: it
++      // expects ONE raw, unconverted 32-bit word holding the real packed
++      // Xenos format (10_11_11, 11_11_10, or 2_10_10_10), not anything the
++      // GPU's fixed-function vertex-input stage has auto-converted.
++      // VertexFormatToVkFormat() previously handled this the same way as
++      // every other attribute: k_10_11_11/k_11_11_10 have no direct Vulkan
++      // equivalent and returned VK_FORMAT_UNDEFINED, so the attribute was
++      // silently DROPPED entirely (see the any_unmappable_format branch
++      // below) -- no data reached the shader for it at all. k_2_10_10_10
++      // did map, but to VK_FORMAT_A2B10G10R10_UNORM_PACK32, a real hardware
++      // auto-converting format -- also wrong here, since it delivers a
++      // pre-normalized float value into an input the shader code expects to
++      // bit-twiddle as raw bits. Confirmed real, high-scope: 221 of 354
++      // (62%) of the vertex shaders in the current native shader cache
++      // declare a Normal/Tangent/Binormal usage. Force the raw single-word
++      // integer format here, bypassing the real-source-format-based
++      // VertexFormatToVkFormat() mapping entirely for just this usage
++      // class, matching what tfetchR11G11B10() actually expects.
++      // Real fix (2026-08-17): vertex locations went positional (see
++      // vertexLocations's own header comment in renut_xenos_shader_cache.h),
++      // so "location == 1/2/3" no longer identifies Normal/Tangent/Binormal
++      // -- those usages can now land at any raw attribute index. Detect the
++      // SAME condition directly from the real Xenos data instead: Normal/
++      // Tangent/Binormal are always fetched as one of the three packed
++      // formats tfetchR11G11B10() unpacks (k_10_11_11/k_11_11_10/
++      // k_2_10_10_10 -- see VertexFormatToVkFormat()'s own switch above,
++      // which already distinguishes exactly these three). This needs no new
++      // data: fetch.attributes.data_format is the real per-attribute Xenos
++      // format, read straight off the vfetch instruction itself.
++      const bool is_packed_normal_like_usage =
++          fetch.attributes.data_format == xenos::VertexFormat::k_10_11_11 ||
++          fetch.attributes.data_format == xenos::VertexFormat::k_11_11_10 ||
++          fetch.attributes.data_format == xenos::VertexFormat::k_2_10_10_10;
++      VkFormat vk_format = is_packed_normal_like_usage
++                                ? VK_FORMAT_R32_UINT
++                                : VertexFormatToVkFormat(fetch.attributes.data_format, fetch.attributes.is_signed,
++                                                          fetch.attributes.is_integer);
++      if (vk_format == VK_FORMAT_UNDEFINED) {
++        any_unmappable_format = true;
++        continue;
++      }
++      VertexAttributeInfo attribute_info;
++      attribute_info.location =
++          real_location != kRenutVertexLocationUnset ? uint32_t(real_location) : next_location;
++      ++next_location;
++      attribute_info.fetch_constant_index = vb.fetch_constant;
++      // offset is in dwords per ParsedVertexFetchInstruction::Attributes
++      // (see PLAN_native_renderer.md's vfetch decode findings) -- convert
++      // to bytes for a real VkVertexInputAttributeDescription.
++      attribute_info.offset_bytes = uint32_t(fetch.attributes.offset) * 4u;
++      attribute_info.format = vk_format;
++      entry.attributes.push_back(attribute_info);
++
++      // Real fix (2026-08-17): the vertex INPUT location no longer encodes
++      // D3D9 usage at all (see vertexLocations's own header comment) -- but
++      // XenosRecomp's compiled HLSL doesn't need it to: tfetchTexcoord()'s
++      // real semanticIndex is baked in as a compile-time literal at the
++      // vfetch call site itself (shader_recompiler.cpp's
++      // `recompile(VertexFetchInstruction)`, reading straight from its own
++      // vertexElements map -- entirely independent of Vulkan locations).
++      // What's still needed HERE is different: g_SwappedTexcoords is a
++      // per-draw runtime mask keyed by that SAME semanticIndex, and this
++      // pipeline-cache code has no other way to learn which raw attribute
++      // is which TexCoord usage now that location can't tell it -- so it's
++      // read from vertexTexCoordSemanticIndex[], captured at build time by
++      // tools/xenos_cache_unpack.cpp's ExtractVertexTexCoordSemanticIndices
++      // the same way vertexLocations[] itself is (see renut_xenos_shader_
++      // cache.h's kRenutTexCoordSemanticUnset comment for the full story).
++      bool is16BitFormat = vk_format == VK_FORMAT_R16G16_SFLOAT || vk_format == VK_FORMAT_R16G16_SINT ||
++                            vk_format == VK_FORMAT_R16G16_UINT || vk_format == VK_FORMAT_R16G16_SNORM ||
++                            vk_format == VK_FORMAT_R16G16_UNORM ||
++                            vk_format == VK_FORMAT_R16G16B16A16_SFLOAT ||
++                            vk_format == VK_FORMAT_R16G16B16A16_SINT ||
++                            vk_format == VK_FORMAT_R16G16B16A16_UINT ||
++                            vk_format == VK_FORMAT_R16G16B16A16_SNORM ||
++                            vk_format == VK_FORMAT_R16G16B16A16_UNORM;
++      if (is16BitFormat) {
++        uint8_t semanticIndex = (raw_attribute_index - 1) < kRenutMaxVertexLocations
++                                     ? vs_entry->vertexTexCoordSemanticIndex[raw_attribute_index - 1]
++                                     : kRenutTexCoordSemanticUnset;
++        if (semanticIndex != kRenutTexCoordSemanticUnset) {
++          entry.swapped_texcoords_mask |= (1u << semanticIndex);
++        }
++      }
++    }
++    ++next_binding;
++  }
++
++  // Real constraint (2026-08-17): a shader's texture/sampler descriptor
++  // index is read at runtime from SharedConstants at byte
++  // `dimension * 64 + fetch_constant * 4` (see SharedConstantsLayout), so
++  // each dimension's index array holds exactly 16 entries. A fetch constant
++  // >= 16 would read into the NEXT dimension's array and sample a
++  // completely unrelated texture. Reject the whole pipeline here (returning
++  // VK_NULL_HANDLE makes the caller fall through to the stock path, which
++  // handles it correctly) rather than at draw time, where an early return
++  // would silently drop the draw instead of falling back.
++  for (const Shader::TextureBinding& tb : pixel_shader->texture_bindings()) {
++    if (tb.fetch_constant >= 16) {
++      REXGPU_WARN(
++          "renut native pipeline: vs_{:016x} ps_{:016x} uses texture fetch constant {} (>= 16, "
++          "not addressable in the shared-constants descriptor-index layout) -- falling back to stock",
++          vs_hash, ps_hash, tb.fetch_constant);
++      entry.available = false;
++      return VK_NULL_HANDLE;
++    }
++  }
++
++  if (entry.attributes.empty()) {
++    REXGPU_WARN(
++        "renut native pipeline: vs_{:016x} ps_{:016x} has {} vertex bindings but zero mappable "
++        "attributes (unmappable format(s): {}) -- skipping",
++        vs_hash, ps_hash, vertex_shader->vertex_bindings().size(), any_unmappable_format);
++    entry.available = false;
++    return VK_NULL_HANDLE;
++  }
++
++  // TEMP DIAGNOSTIC (2026-08-16): once per unique (vs_hash, ps_hash) pair,
++  // dump real per-attribute location/offset/format/binding-count/stride --
++  // isolating which live native shader corrupts geometry, now that
++  // topology/constant-table/bool-constant/vertex-location bugs are all
++  // ruled out or fixed (confirmed via a real A/B test: disabling native
++  // rendering entirely makes the corruption disappear completely, so it's
++  // inside one or more of the currently-live native shaders specifically).
++  // Remove once root-caused.
++  {
++    static std::unordered_set<uint64_t> s_logged_pairs;
++    if (s_logged_pairs.insert(key).second) {
++      std::string diag;
++      for (size_t i = 0; i < entry.attributes.size(); ++i) {
++        const VertexAttributeInfo& a = entry.attributes[i];
++        diag += fmt::format("[loc={} off={} fmt={} binding={}] ", a.location, a.offset_bytes,
++                            int(a.format), a.fetch_constant_index);
++      }
++      std::string strides;
++      for (const Shader::VertexBinding& vb : vertex_shader->vertex_bindings()) {
++        strides += fmt::format("{} ", vb.stride_words * 4u);
++      }
++      REXGPU_WARN("renut native pipeline DIAG: vs_{:016x} ps_{:016x} bindings={} attrs={} strides=[{}] {}",
++                  vs_hash, ps_hash, entry.bindings.size(), entry.attributes.size(), strides, diag);
++    }
++  }
++
++
++  // --- Shader modules from the batch-converted cache ---
++  entry.vertex_module = ui::vulkan::util::CreateShaderModule(
++      vulkan_device, &g_renutXenosSpirvWords[vs_entry->spirvOffset],
++      vs_entry->spirvSize * sizeof(uint32_t));
++  entry.pixel_module = ui::vulkan::util::CreateShaderModule(
++      vulkan_device, &g_renutXenosSpirvWords[ps_entry->spirvOffset],
++      ps_entry->spirvSize * sizeof(uint32_t));
++  if (entry.vertex_module == VK_NULL_HANDLE || entry.pixel_module == VK_NULL_HANDLE) {
++    REXGPU_ERROR("renut native pipeline: vs_{:016x} ps_{:016x} failed to create shader modules", vs_hash,
++                 ps_hash);
++    entry.available = false;
++    return VK_NULL_HANDLE;
++  }
++
++  // --- Pipeline layout: real bindless texture/sampler descriptor sets (0-3)
++  // plus the same 3-uint64 push-constant scheme as Phase 1 (GPU virtual
++  // addresses matching XenosRecomp's generated PushConstants struct) -- one
++  // shared layout for every native pipeline, not per-entry, since all
++  // XenosRecomp-generated shaders declare the identical bindless interface
++  // (see nativevk_xenos_pipeline_cache.h's header comment). ---
++  EnsureBindlessHeapInitialized(command_processor);
++  entry.pipeline_layout = GetOrCreateBindlessPipelineLayout(command_processor);
++  if (entry.pipeline_layout == VK_NULL_HANDLE) {
++    REXGPU_ERROR(
++        "renut native pipeline: vs_{:016x} ps_{:016x} bindless pipeline layout unavailable "
++        "(device feature gap or heap init failure, see earlier log)",
++        vs_hash, ps_hash);
++    entry.available = false;
++    return VK_NULL_HANDLE;
++  }
++
++  // --- Real vertex input state, one binding per fetch constant ---
++  std::vector<VkVertexInputBindingDescription> vertex_bindings_vk;
++  vertex_bindings_vk.reserve(entry.bindings.size());
++  for (const VertexBindingInfo& b : entry.bindings) {
++    VkVertexInputBindingDescription binding_desc;
++    binding_desc.binding = b.binding;
++    // Xenos vertex data for one fetch constant is treated as a flat byte
++    // stream addressed per-attribute by ParsedVertexFetchInstruction's own
++    // offset -- there's no single "stride" field exposed generically here
++    // (VertexBinding::stride_words exists but describes the WHOLE binding,
++    // used below for completeness/documentation, not per-attribute
++    // addressing), so bind with stride 0 (Vulkan treats stride 0 for
++    // VK_VERTEX_INPUT_RATE_VERTEX as "tightly packed" only when there's one
++    // attribute; with multiple attributes sharing a binding, real stride is
++    // required). Use the real per-binding stride from vertex_bindings().
++    binding_desc.stride = 0;  // filled in below once matched back to its VertexBinding
++    binding_desc.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
++    vertex_bindings_vk.push_back(binding_desc);
++  }
++  // Fill in real strides (stride_words * 4) by re-walking vertex_bindings()
++  // in the same order entry.bindings was built, so indices line up.
++  {
++    size_t i = 0;
++    for (const Shader::VertexBinding& vb : vertex_shader->vertex_bindings()) {
++      if (i < vertex_bindings_vk.size()) {
++        vertex_bindings_vk[i].stride = vb.stride_words * 4u;
++      }
++      ++i;
++    }
++  }
++
++  std::vector<VkVertexInputAttributeDescription> vertex_attributes_vk;
++  vertex_attributes_vk.reserve(entry.attributes.size());
++  for (size_t i = 0; i < entry.attributes.size(); ++i) {
++    const VertexAttributeInfo& a = entry.attributes[i];
++    // Map fetch_constant_index -> this pipeline's local binding slot.
++    uint32_t binding_slot = 0;
++    for (const VertexBindingInfo& b : entry.bindings) {
++      if (b.fetch_constant_index == a.fetch_constant_index) {
++        binding_slot = b.binding;
++        break;
++      }
++    }
++    VkVertexInputAttributeDescription attribute_desc;
++    attribute_desc.location = a.location;
++    attribute_desc.binding = binding_slot;
++    attribute_desc.format = a.format;
++    attribute_desc.offset = a.offset_bytes;
++    vertex_attributes_vk.push_back(attribute_desc);
++  }
++
++  VkPipelineVertexInputStateCreateInfo vertex_input_state = {};
++  vertex_input_state.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
++  vertex_input_state.vertexBindingDescriptionCount = uint32_t(vertex_bindings_vk.size());
++  vertex_input_state.pVertexBindingDescriptions = vertex_bindings_vk.data();
++  vertex_input_state.vertexAttributeDescriptionCount = uint32_t(vertex_attributes_vk.size());
++  vertex_input_state.pVertexAttributeDescriptions = vertex_attributes_vk.data();
++
++  VkPipelineInputAssemblyStateCreateInfo input_assembly_state = {};
++  input_assembly_state.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
++  input_assembly_state.topology = vk_topology;
++
++  VkPipelineViewportStateCreateInfo viewport_state = {};
++  viewport_state.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
++  viewport_state.viewportCount = 1;
++  viewport_state.scissorCount = 1;
++
++  VkPipelineRasterizationStateCreateInfo rasterization_state = {};
++  rasterization_state.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
++  rasterization_state.polygonMode = VK_POLYGON_MODE_FILL;
++  // Real per-draw cull mode/winding (2026-08-16 fix) -- see
++  // ComputeRasterAndBlendState's header comment; was hardcoded to
++  // VK_CULL_MODE_NONE for every native pipeline before this.
++  rasterization_state.cullMode = raster_blend_state.cull_mode;
++  rasterization_state.frontFace = raster_blend_state.front_face;
++  rasterization_state.lineWidth = 1.0f;
++
++  // Real bug found+fixed 2026-08-17: this was hardcoded to
++  // VK_SAMPLE_COUNT_1_BIT for every native pipeline regardless of the
++  // guest's real, per-draw MSAA state -- render_pass_key.msaa_samples
++  // (already read from the real RB_SURFACE_INFO register by
++  // render_target_cache.cpp, and already used by this same file below to
++  // pick color/depth VIEW formats) was sitting right here, unused for this.
++  // A pipeline's declared rasterizationSamples must match the actual
++  // sample count of whatever render target it's drawn into -- Vulkan
++  // requires it, and getting it wrong is real, driver-dependent undefined
++  // behavior, not just a soft mismatch. Confirmed real, high-scope
++  // candidate for the reported "entire screen shows striping/interlacing
++  // with any native shader active, disappears completely when disabled"
++  // symptom: multisampled render targets are a normal thing for a 2008-era
++  // 3D game, and a 1x-declared pipeline rasterizing into an actual
++  // 2x/4x-sampled image writes only a subset of the real per-sample data
++  // the later MSAA resolve step reads -- a mechanistically exact match for
++  // a striped-looking image, and shader-content-independent (hits every
++  // native draw against such a target, not specific shaders), matching why
++  // four separate real shader-translation-correctness fixes this session
++  // produced zero visible change. Mirrors the exact same real fallback
++  // render_target_cache.cpp's own image creation uses (2x MSAA attachments
++  // aren't universally supported; the render target cache already silently
++  // promotes 2x to a real 4x image on hardware that can't do 2x) --
++  // querying the SAME real device capability here via the render target
++  // cache's own public accessor, not re-deriving it, so this can never
++  // drift out of sync with what image actually gets created.
++  VkPipelineMultisampleStateCreateInfo multisample_state = {};
++  multisample_state.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
++  if (render_pass_key.msaa_samples == xenos::MsaaSamples::k2X &&
++      render_target_cache && !render_target_cache->msaa_2x_attachments_supported()) {
++    multisample_state.rasterizationSamples = VK_SAMPLE_COUNT_4_BIT;
++  } else {
++    multisample_state.rasterizationSamples =
++        VkSampleCountFlagBits(uint32_t(1) << uint32_t(render_pass_key.msaa_samples));
++  }
++
++  // Real per-draw blend state (2026-08-16 fix) -- see
++  // ComputeRasterAndBlendState's header comment; blendEnable was left at
++  // its VkPipelineColorBlendAttachmentState{} default (false) for every
++  // native pipeline before this, so alpha-blended/additive draws (particle
++  // effects, glow) rendered fully opaque instead.
++  //
++  // Real bug found+fixed (2026-08-17): attachmentCount was hardcoded to 1
++  // regardless of how many color render targets this draw actually uses.
++  // Vulkan requires VkPipelineColorBlendStateCreateInfo::attachmentCount to
++  // exactly match the real number of color attachments (both under dynamic
++  // rendering, matching VkPipelineRenderingCreateInfo::colorAttachmentCount
++  // below, and under a classic VkRenderPass, matching the subpass's own
++  // color attachment count) -- a mismatch is invalid pipeline creation, and
++  // depending on the driver either silently only writes attachment 0 or
++  // produces undefined results for the rest, which for any draw using MRT
++  // (multiple simultaneous render targets -- not unusual: deferred-style
++  // passes, or a color target plus an auxiliary one) means some or all of
++  // its real output silently doesn't land anywhere. Computed from the same
++  // render_pass_key.depth_and_color_used bits the dynamic-rendering block
++  // below already uses for the identical purpose -- one real source of
++  // truth, not two independently-derived counts that could drift apart.
++  uint32_t color_attachment_count = 0;
++  for (uint32_t i = 0; i < xenos::kMaxColorRenderTargets; ++i) {
++    if (render_pass_key.depth_and_color_used & (1 << (1 + i))) {
++      color_attachment_count = i + 1;
++    }
++  }
++  std::array<VkPipelineColorBlendAttachmentState, xenos::kMaxColorRenderTargets>
++      color_blend_attachment_states{};
++  for (uint32_t i = 0; i < color_attachment_count; ++i) {
++    VkPipelineColorBlendAttachmentState& state = color_blend_attachment_states[i];
++    state.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |
++                           VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
++    state.blendEnable = raster_blend_state.blend_enable ? VK_TRUE : VK_FALSE;
++    state.srcColorBlendFactor = raster_blend_state.src_color_factor;
++    state.dstColorBlendFactor = raster_blend_state.dst_color_factor;
++    state.colorBlendOp = raster_blend_state.color_blend_op;
++    state.srcAlphaBlendFactor = raster_blend_state.src_alpha_factor;
++    state.dstAlphaBlendFactor = raster_blend_state.dst_alpha_factor;
++    state.alphaBlendOp = raster_blend_state.alpha_blend_op;
++  }
++  VkPipelineColorBlendStateCreateInfo color_blend_state = {};
++  color_blend_state.sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
++  color_blend_state.attachmentCount = color_attachment_count;
++  color_blend_state.pAttachments = color_blend_attachment_states.data();
++
++  // Real depth/stencil state -- required whenever this draw has a depth
++  // attachment (render_pass_key.depth_and_color_used bit 0), matching the
++  // Vulkan spec requirement that pDepthStencilState be non-null if the
++  // pipeline's render pass (or, under dynamic rendering,
++  // VkPipelineRenderingCreateInfo) uses a depth/stencil attachment.
++  // Real per-draw test/write/compare values (2026-08-16 fix) -- see
++  // RasterAndBlendState's own header comment; was hardcoded to always-on
++  // LESS_OR_EQUAL for every native pipeline before this, regardless of
++  // what the guest's own RB_DEPTHCONTROL register actually asked for.
++  VkPipelineDepthStencilStateCreateInfo depth_stencil_state = {};
++  depth_stencil_state.sType = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
++  if (render_pass_key.depth_and_color_used & 0b1) {
++    depth_stencil_state.depthTestEnable = raster_blend_state.depth_test_enable ? VK_TRUE : VK_FALSE;
++    depth_stencil_state.depthWriteEnable = raster_blend_state.depth_write_enable ? VK_TRUE : VK_FALSE;
++    depth_stencil_state.depthCompareOp = raster_blend_state.depth_compare_op;
++  }
++
++  static const VkDynamicState kDynamicStates[] = {VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR};
++  VkPipelineDynamicStateCreateInfo dynamic_state = {};
++  dynamic_state.sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
++  dynamic_state.dynamicStateCount = uint32_t(rex::countof(kDynamicStates));
++  dynamic_state.pDynamicStates = kDynamicStates;
++
++  // Real bug found+fixed 2026-08-17: XenosRecomp's generated shaders read a
++  // runtime Vulkan specialization constant at constant_id(0)
++  // (shader_common.h: "[[vk::constant_id(0)]] const uint g_SpecConstants = 0;")
++  // to decide real per-shader behavior -- notably SPEC_CONSTANT_R11G11B10_NORMAL,
++  // which gates whether Normal/Tangent/Binormal vertex attributes get decoded
++  // as the packed R11G11B10 hardware format XenosRecomp's own vfetch codegen
++  // otherwise ALWAYS assumes for those usages (shader_recompiler.cpp: any
++  // vfetch instruction whose usage is Normal/Tangent/Binormal unconditionally
++  // emits tfetchR11G11B10(), regardless of the real vertex data's actual
++  // format -- the correction happens entirely via this spec constant at
++  // pipeline-creation time). This code never supplied VkSpecializationInfo at
++  // all -- every native pipeline silently got the Vulkan default (0) for
++  // constant_id(0), meaning SPEC_CONSTANT_R11G11B10_NORMAL was permanently
++  // unset for every native shader regardless of what that shader's own real,
++  // per-shader specConstantsMask (already computed at build time by
++  // XenosRecomp itself, and already present unused in
++  // RenutXenosShaderCacheEntry::specConstantsMask) actually says it needs --
++  // a real, confirmed-plausible cause of the widespread shattered/faceted
++  // normal-lighting corruption seen across native shaders (any shader with a
++  // real R11G11B10-packed normal/tangent/binormal would decode it as if it
++  // were a plain float instead).
++  VkSpecializationMapEntry spec_map_entry = {};
++  spec_map_entry.constantID = 0;
++  spec_map_entry.offset = 0;
++  spec_map_entry.size = sizeof(uint32_t);
++
++  VkSpecializationInfo vs_spec_info = {};
++  vs_spec_info.mapEntryCount = 1;
++  vs_spec_info.pMapEntries = &spec_map_entry;
++  vs_spec_info.dataSize = sizeof(uint32_t);
++  vs_spec_info.pData = &vs_entry->specConstantsMask;
++
++  VkSpecializationInfo ps_spec_info = {};
++  ps_spec_info.mapEntryCount = 1;
++  ps_spec_info.pMapEntries = &spec_map_entry;
++  ps_spec_info.dataSize = sizeof(uint32_t);
++  ps_spec_info.pData = &ps_entry->specConstantsMask;
++
++  VkPipelineShaderStageCreateInfo stages[2];
++  stages[0] = {};
++  stages[0].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
++  stages[0].stage = VK_SHADER_STAGE_VERTEX_BIT;
++  stages[0].module = entry.vertex_module;
++  stages[0].pName = "main";
++  stages[0].pSpecializationInfo = &vs_spec_info;
++  stages[1] = {};
++  stages[1].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
++  stages[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT;
++  stages[1].module = entry.pixel_module;
++  stages[1].pName = "main";
++  stages[1].pSpecializationInfo = &ps_spec_info;
++
++  // Dynamic-rendering fix (2026-08-16): real VkPipelineRenderingCreateInfo,
++  // built from the SAME real RenderPassKey used above for cache validity --
++  // mirrors the stock renderer's own already-working pattern exactly
++  // (pipeline_cache.cpp:3602-3630), just via the real public accessors this
++  // file already has (render_target_cache()'s GetColorVulkanFormat()/
++  // GetDepthVulkanFormat()). Under dynamic rendering there is no
++  // VkFramebuffer/VkRenderPass at all -- the real attachment FORMATS are
++  // the only thing a pipeline needs to be created compatibly.
++  VkPipelineRenderingCreateInfo pipeline_rendering_create_info = {};
++  VkFormat color_attachment_formats[xenos::kMaxColorRenderTargets] = {};
++  if (use_dynamic_rendering) {
++    pipeline_rendering_create_info.sType = VK_STRUCTURE_TYPE_PIPELINE_RENDERING_CREATE_INFO;
++    // Real fix (2026-08-17): reuse the SAME color_attachment_count computed
++    // above for color_blend_state instead of an independently-recomputed
++    // local of the same name -- one real source of truth (see that
++    // computation's own comment for why the two must never drift apart).
++    xenos::ColorRenderTargetFormat color_formats[] = {
++        render_pass_key.color_0_view_format, render_pass_key.color_1_view_format,
++        render_pass_key.color_2_view_format, render_pass_key.color_3_view_format};
++    for (uint32_t i = 0; i < color_attachment_count; ++i) {
++      color_attachment_formats[i] = render_target_cache->GetColorVulkanFormat(color_formats[i]);
++    }
++    pipeline_rendering_create_info.colorAttachmentCount = color_attachment_count;
++    pipeline_rendering_create_info.pColorAttachmentFormats =
++        color_attachment_count ? color_attachment_formats : nullptr;
++    if (render_pass_key.depth_and_color_used & 0b1) {
++      VkFormat depth_format = render_target_cache->GetDepthVulkanFormat(render_pass_key.depth_format);
++      pipeline_rendering_create_info.depthAttachmentFormat = depth_format;
++      pipeline_rendering_create_info.stencilAttachmentFormat = depth_format;
++    }
++  }
++
++  VkGraphicsPipelineCreateInfo pipeline_create_info = {};
++  pipeline_create_info.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
++  pipeline_create_info.pNext = use_dynamic_rendering ? &pipeline_rendering_create_info : nullptr;
++  pipeline_create_info.stageCount = uint32_t(rex::countof(stages));
++  pipeline_create_info.pStages = stages;
++  pipeline_create_info.pVertexInputState = &vertex_input_state;
++  pipeline_create_info.pInputAssemblyState = &input_assembly_state;
++  pipeline_create_info.pViewportState = &viewport_state;
++  pipeline_create_info.pRasterizationState = &rasterization_state;
++  pipeline_create_info.pMultisampleState = &multisample_state;
++  pipeline_create_info.pColorBlendState = &color_blend_state;
++  pipeline_create_info.pDepthStencilState = &depth_stencil_state;
++  pipeline_create_info.pDynamicState = &dynamic_state;
++  pipeline_create_info.layout = entry.pipeline_layout;
++  pipeline_create_info.renderPass = use_dynamic_rendering ? VK_NULL_HANDLE : current_render_pass;
++  pipeline_create_info.subpass = 0;
++  pipeline_create_info.basePipelineIndex = -1;
++
++  VkResult pipeline_result =
++      dfn.vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, 1, &pipeline_create_info, nullptr,
++                                    &entry.pipeline);
++  if (pipeline_result != VK_SUCCESS) {
++    REXGPU_ERROR("renut native pipeline: vs_{:016x} ps_{:016x} vkCreateGraphicsPipelines failed ({})",
++                 vs_hash, ps_hash, int32_t(pipeline_result));
++    entry.available = false;
++    return VK_NULL_HANDLE;
++  }
++
++  entry.available = true;
++  REXGPU_INFO(
++      "renut native pipeline: vs_{:016x} ps_{:016x} created ({} bindings, {} attributes)", vs_hash,
++      ps_hash, entry.bindings.size(), entry.attributes.size());
++
++  if (GetDebugColorizeMode() && !entry.debug_pipeline_attempted) {
++    entry.debug_pipeline_attempted = true;
++    static VkShaderModule s_debug_color_module = VK_NULL_HANDLE;
++    if (s_debug_color_module == VK_NULL_HANDLE) {
++      s_debug_color_module = ui::vulkan::util::CreateShaderModule(
++          vulkan_device, kRenutDebugColorFragSpirv, sizeof(kRenutDebugColorFragSpirv));
++    }
++    if (s_debug_color_module != VK_NULL_HANDLE) {
++      // Stable, distinct color per (vs_hash, ps_hash) pair -- same combine
++      // formula as CombineKey(), just for a display color instead of a map
++      // key. Clamped to [0.25, 1.0] per channel so no pair renders
++      // near-black (indistinguishable from "nothing drawn here").
++      uint64_t color_hash = CombineKey(vs_hash, ps_hash);
++      float debug_color[3] = {
++          0.25f + 0.75f * float((color_hash >> 0) & 0xFF) / 255.0f,
++          0.25f + 0.75f * float((color_hash >> 8) & 0xFF) / 255.0f,
++          0.25f + 0.75f * float((color_hash >> 16) & 0xFF) / 255.0f,
++      };
++      VkSpecializationMapEntry debug_map_entries[3] = {
++          {0, 0 * sizeof(float), sizeof(float)},
++          {1, 1 * sizeof(float), sizeof(float)},
++          {2, 2 * sizeof(float), sizeof(float)},
++      };
++      VkSpecializationInfo debug_spec_info = {};
++      debug_spec_info.mapEntryCount = uint32_t(rex::countof(debug_map_entries));
++      debug_spec_info.pMapEntries = debug_map_entries;
++      debug_spec_info.dataSize = sizeof(debug_color);
++      debug_spec_info.pData = debug_color;
++
++      VkPipelineShaderStageCreateInfo debug_stages[2] = {stages[0], stages[0]};
++      debug_stages[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT;
++      debug_stages[1].module = s_debug_color_module;
++      debug_stages[1].pSpecializationInfo = &debug_spec_info;
++
++      VkGraphicsPipelineCreateInfo debug_pipeline_create_info = pipeline_create_info;
++      debug_pipeline_create_info.pStages = debug_stages;
++
++      VkResult debug_pipeline_result = dfn.vkCreateGraphicsPipelines(
++          device, VK_NULL_HANDLE, 1, &debug_pipeline_create_info, nullptr, &entry.debug_pipeline);
++      if (debug_pipeline_result != VK_SUCCESS) {
++        REXGPU_WARN(
++            "renut native pipeline: vs_{:016x} ps_{:016x} debug-colorize pipeline creation failed "
++            "({}) -- this pair will render normally even in debug-colorize mode",
++            vs_hash, ps_hash, int32_t(debug_pipeline_result));
++        entry.debug_pipeline = VK_NULL_HANDLE;
++      }
++    }
++  }
++
++  if (GetDebugColorizeMode() && entry.debug_pipeline != VK_NULL_HANDLE) {
++    return entry.debug_pipeline;
++  }
++  return entry.pipeline;
++#endif
++}
++
++namespace {
++
++// Combines a real (VkImageView, VkSampler) pair into one identity key for
++// texture2d_slot_map. Both are non-dispatchable handles (opaque uint64_t
++// under the Vulkan handle ABI on the 64-bit-only targets this project
++// builds for), so a simple avalanching combine is a real, collision-safe
++// identity, not a heuristic.
++uint64_t CombineTextureSamplerKey(VkImageView view, VkSampler sampler) {
++  uint64_t v = reinterpret_cast<uint64_t>(view);
++  uint64_t s = reinterpret_cast<uint64_t>(sampler);
++  // splitmix64-style mix so the two handles' low bits (which real driver
++  // allocators tend to cluster) don't cancel out under plain XOR.
++  uint64_t key = v ^ (s + 0x9e3779b97f4a7c15ULL + (v << 6) + (v >> 2));
++  return key;
++}
++
++// Real per-draw resolution of one texture fetch constant to its STABLE,
++// permanently-allocated heap slot (see kBindlessHeapSlotCount's and
++// texture2d_slot_map's comments for why this is no longer the fetch
++// constant register number itself). Returns false if the texture/sampler
++// can't be resolved right now (not resident, format unsupported, etc --
++// texture_cache()'s own real residency machinery already handles the
++// underlying decode/upload) or the slot pool is exhausted. On success,
++// writes the assigned slot to *out_slot.
++bool ResolveTexture2DSlot(VulkanCommandProcessor& command_processor, BindlessHeapState& heap,
++                           uint32_t fetch_constant_index, uint32_t* out_slot) {
++  VulkanTextureCache* texture_cache = command_processor.texture_cache();
++  // false = unsigned view; XenosRecomp's tfetch2D helper has no separate
++  // signed-view parameter (unlike the stock SPIR-V translator's own
++  // per-instruction is_signed tracking), so this always requests the
++  // unsigned view -- a real, known gap for shaders that read a texture as
++  // signed-normalized data, not silently claimed as handled.
++  VkImageView view = texture_cache->GetActiveBindingOrNullImageView(
++      fetch_constant_index, xenos::FetchOpDimension::k2D, /*is_signed=*/false);
++  if (view == VK_NULL_HANDLE) {
++    return false;
++  }
++
++  VulkanShader::SamplerBinding sampler_binding;
++  sampler_binding.fetch_constant = fetch_constant_index;
++  sampler_binding.mag_filter = xenos::TextureFilter::kUseFetchConst;
++  sampler_binding.min_filter = xenos::TextureFilter::kUseFetchConst;
++  sampler_binding.mip_filter = xenos::TextureFilter::kUseFetchConst;
++  sampler_binding.aniso_filter = xenos::AnisoFilter::kUseFetchConst;
++  VulkanTextureCache::SamplerParameters sampler_parameters =
++      texture_cache->GetSamplerParameters(sampler_binding);
++  bool sampler_overflown = false;
++  VkSampler sampler = texture_cache->UseSampler(sampler_parameters, sampler_overflown);
++  if (sampler == VK_NULL_HANDLE) {
++    return false;
++  }
++
++  const uint64_t identity_key = CombineTextureSamplerKey(view, sampler);
++  auto found = heap.texture2d_slot_map.find(identity_key);
++  if (found != heap.texture2d_slot_map.end()) {
++    *out_slot = found->second;
++    return true;  // already has a permanent slot, nothing to write
++  }
++
++  if (heap.next_free_texture2d_slot >= kBindlessHeapSlotCount) {
++    // Pool exhausted (no eviction in this first pass -- see
++    // texture2d_slot_map's comment). Fail the bind rather than silently
++    // reusing/corrupting an existing slot.
++    static std::atomic<bool> warned{false};
++    if (!warned.exchange(true)) {
++      REXGPU_WARN(
++          "renut bindless heap: texture2d slot pool exhausted ({} slots) -- some draws will "
++          "fall back to stock rendering",
++          kBindlessHeapSlotCount);
++    }
++    return false;
++  }
++  const uint32_t slot = heap.next_free_texture2d_slot++;
++  heap.texture2d_slot_map.emplace(identity_key, slot);
++
++  BindlessHeapEntry& entry = heap.texture2d_entries[slot];
++  entry.view = view;
++  entry.sampler = sampler;
++
++  const ui::vulkan::VulkanDevice* vulkan_device = command_processor.GetVulkanDevice();
++  const ui::vulkan::VulkanDevice::Functions& dfn = vulkan_device->functions();
++  VkDevice device = vulkan_device->device();
++
++  VkDescriptorImageInfo image_info = {};
++  image_info.imageView = entry.view;
++  image_info.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
++  VkDescriptorImageInfo sampler_info = {};
++  sampler_info.sampler = entry.sampler;
++
++  VkWriteDescriptorSet writes[2] = {};
++  writes[0].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
++  writes[0].dstSet = heap.texture2d_set;
++  writes[0].dstBinding = 0;
++  writes[0].dstArrayElement = slot;
++  writes[0].descriptorCount = 1;
++  writes[0].descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
++  writes[0].pImageInfo = &image_info;
++  writes[1].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
++  writes[1].dstSet = heap.sampler_set;
++  writes[1].dstBinding = 0;
++  // Sampler heap shares the same slot allocation as its paired texture --
++  // both descriptor indices written into the same draw's SharedConstants
++  // slot value (see IssueNativeDraw's binding loop), so a single shared slot
++  // number is correct here, not a separately-allocated one.
++  writes[1].dstArrayElement = slot;
++  writes[1].descriptorCount = 1;
++  writes[1].descriptorType = VK_DESCRIPTOR_TYPE_SAMPLER;
++  writes[1].pImageInfo = &sampler_info;
++  dfn.vkUpdateDescriptorSets(device, uint32_t(rex::countof(writes)), writes, 0, nullptr);
++
++  *out_slot = slot;
++  return true;
++}
++
++// SharedConstants layout: REAL per-texture descriptor-index fields
++// (g_TextureN_Texture2DDescriptorIndex etc) turned out NOT to be runtime
++// cbuffer reads at all -- verified by compiling a real generated HLSL file
++// through real DXC and disassembling the resulting SPIR-V (`OpAccessChain
++// ... %g_Texture2DDescriptorHeap %uint_0/%uint_1/%uint_2`, literal
++// constants baked in). They only appear as runtime cbuffer members under
++// the file's OTHER, non-compiled `#else` branch -- a dead code path for the
++// __spirv__ target this pipeline actually uses. Confirmed against
++// shader_recompiler.cpp directly: RegisterSet::Sampler always emits
++// `#define {}_TextureNDDescriptorIndex {registerIndex}` under __spirv__,
++// never a cbuffer member. So this heap needs NO texture-index writing into
++// any buffer at all -- see BindTexture2DFixedSlot's header comment for the
++// real, compile-time-fixed slot convention that replaces it.
++//
++// What DOES remain real, runtime cbuffer data (also confirmed via the same
++// compiled-SPIR-V inspection: OpMemberDecorate offsets 256/260/264/272) is
++// DEFINE_SHARED_CONSTANTS()'s own 4 fields -- g_Booleans/g_SwappedTexcoords/
++// g_HalfPixelOffset/g_AlphaThreshold, at a FIXED byte offset of 256
++// (XenosRecomp's macro literally hardcodes packoffset(c16...), not computed
++// per-shader -- see shader_recompiler.cpp lines ~1298-1321: the sampler
++// index-field loop always ends before c16 in every real shader this session
++// captured, real samplers use low single-digit registerIndex values).
++// Matches nativevk_phase1_native_draw.cpp's already-proven field values for
++// the same 4 fields, just at the real, non-zero byte offset a multi-texture
++// shader's SharedConstants buffer actually needs.
++// Real fix (2026-08-17): `booleans` was a single uint32 and the three fields
++// after it sat at bytes 260/264/272. The Xenos boolean constant file is
++// actually 256 bits -- XE_GPU_REG_SHADER_CONSTANT_BOOL_000_031 through
++// _224_255, 8 consecutive dwords -- with vertex-shader booleans at 0-127 and
++// pixel-shader booleans at 128-255. Measured against this game, 1240 of 1531
++// converted pixel shaders branch on booleans in the 129-254 range, which a
++// 32-bit window cannot represent at all: XenosRecomp emitted `1 << 259`-style
++// tests, and a shift past the bit width is undefined in SPIR-V (masked to 5
++// bits on AMD), so those branches silently read unrelated low bits. Widened
++// to the real 8-dword file; the trailing fields moved to 288/292/300 to keep
++// the whole block contiguous. Kept in lockstep with shader_common.h's
++// g_BooleanWord/g_SwappedTexcoords/g_HalfPixelOffset/g_AlphaThreshold macros
++// -- these offsets are a hard ABI contract with the compiled shaders, and a
++// mismatch is invisible to the compiler and catastrophic at runtime.
++//
++// nativevk_phase1_native_draw.cpp keeps its own separate, smaller struct for its
++// own pre-baked SPIR-V and is intentionally untouched by this change.
++// Real fix (2026-08-17): half_pixel_offset replaced with the full
++// ndc_scale/ndc_offset pair -- see shader_common.h's g_NdcScale/g_NdcOffset
++// comment and last_viewport_info()'s comment (command_processor.h) for the
++// full story. Default-constructed to the identity transform (scale=1,
++// offset=0) so any code path that somehow uses this struct without
++// populating it from a real draw's ViewportInfo degrades to a no-op rather
++// than zeroing out every vertex position.
++// ROOT CAUSE FOUND+FIXED (2026-08-17, by diffing against UnleashedRecomp,
++// XenosRecomp's own reference consumer): this space was NOT "reserved" --
++// it holds the real, RUNTIME-READ texture/sampler descriptor indices, and
++// leaving it zeroed made every native shader sample heap slot 0.
++//
++// This file previously asserted (in a comment claiming DXC/SPIR-V
++// verification) that `g_TextureN_Texture2DDescriptorIndex` is a
++// compile-time #define equal to the fetch constant, so nothing needed
++// writing here. That is WRONG, and a SECOND, related mistake (the
++// bindless-heap race, see kBindlessHeapSlotCount's comment) followed from
++// assuming the heap SLOT itself could just be the fetch constant register
++// number too -- it can't, since a shared register is reused by many
++// different real textures across a frame's draws. shader_recompiler.cpp:
++// 1272-1277 emits, for the __spirv__ path actually compiled:
++//   #define {name}_Texture{dim}DescriptorIndex \
++//       vk::RawBufferLoad<uint>(g_PushConstants.SharedConstants + j*64 + registerIndex*4)
++//   #define {name}_SamplerDescriptorIndex \
++//       vk::RawBufferLoad<uint>(g_PushConstants.SharedConstants + 3*64 + registerIndex*4)
++// i.e. a real per-draw buffer READ at a fixed byte offset, exactly like
++// UnleashedRecomp's own SharedConstants struct (texture2DIndices[16],
++// texture3DIndices[16], textureCubeIndices[16], samplerIndices[16], then
++// booleans) -- 16 uint32 per dimension, 64 bytes each, 256 bytes total.
++// With this left as zeroed padding, EVERY tfetch2D() in EVERY native pixel
++// shader resolved to descriptor index 0 for both texture and sampler:
++// every shader sampled whatever texture happened to occupy heap slot 0
++// that draw. That is a mechanically exact match for the reported symptoms
++// (wrong/《stretched》-looking textures everywhere, flickering as slot 0's
++// occupant changes between draws) and explains why none of the
++// vertex-side/constant-side fixes moved the needle.
++//
++// NOTE the hard 16-entry limit per dimension: registerIndex*4 must stay
++// within its own 64-byte array, so a fetch constant >= 16 would alias into
++// the next dimension's array. That bound is baked into the compiled
++// shaders, so it is enforced at the binding site rather than worked around.
++struct SharedConstantsLayout {
++  uint32_t texture2d_indices[16] = {};
++  uint32_t texture3d_indices[16] = {};
++  uint32_t texturecube_indices[16] = {};
++  uint32_t sampler_indices[16] = {};
++  uint32_t booleans[8] = {};
++  uint32_t swapped_texcoords = 0;
++  float ndc_scale[3] = {1.0f, 1.0f, 1.0f};
++  float ndc_offset[3] = {0.0f, 0.0f, 0.0f};
++  float alpha_threshold = 0.5f;
++  uint32_t alpha_test_enable = 0;
++};
++static_assert(sizeof(SharedConstantsLayout) == 324, "must match SharedConstants cbuffer layout");
++// Descriptor-index array offsets are a hard ABI contract with the compiled
++// shaders (shader_recompiler.cpp's `j * 64 + registerIndex * 4` formula).
++static_assert(offsetof(SharedConstantsLayout, texture2d_indices) == 0, "Texture2D indices at byte 0");
++static_assert(offsetof(SharedConstantsLayout, texture3d_indices) == 64, "Texture3D indices at byte 64");
++static_assert(offsetof(SharedConstantsLayout, texturecube_indices) == 128, "TextureCube indices at byte 128");
++static_assert(offsetof(SharedConstantsLayout, sampler_indices) == 192, "Sampler indices at byte 192");
++static_assert(offsetof(SharedConstantsLayout, booleans) == 256, "g_BooleanWord(0) must be at byte 256");
++static_assert(offsetof(SharedConstantsLayout, swapped_texcoords) == 288, "g_SwappedTexcoords must be at byte 288");
++static_assert(offsetof(SharedConstantsLayout, ndc_scale) == 292, "g_NdcScale must be at byte 292");
++static_assert(offsetof(SharedConstantsLayout, ndc_offset) == 304, "g_NdcOffset must be at byte 304");
++static_assert(offsetof(SharedConstantsLayout, alpha_threshold) == 316, "g_AlphaThreshold must be at byte 316");
++static_assert(offsetof(SharedConstantsLayout, alpha_test_enable) == 320, "g_AlphaTestEnable must be at byte 320");
++
++}  // namespace
++
++void IssueNativeDraw(VulkanCommandProcessor& command_processor, VkPipeline pipeline,
++                      Shader* vertex_shader, Shader* pixel_shader,
++                      const PrimitiveProcessor::ProcessingResult& primitive_processing_result,
++                      VkBuffer index_buffer, VkDeviceSize index_buffer_offset,
++                      VkIndexType index_type) {
++#if NATIVEVK_HAVE_XENOS_SHADER_CACHE
++  if (pipeline == VK_NULL_HANDLE) {
++    return;
++  }
++  const uint32_t vertex_count = primitive_processing_result.host_draw_vertex_count;
++  State& state = GetState();
++  const uint64_t key = CombineKey(vertex_shader->ucode_data_hash(), 0);
++  // Re-find by scanning for the matching pipeline handle rather than
++  // recomputing the ps-inclusive key here (caller already resolved that in
++  // GetOrCreatePipeline) -- cheap linear scan over a few dozen entries.
++  // Real bug found+fixed (2026-08-17): this scan only ever matched
++  // kv.second.pipeline, but GetOrCreatePipeline() returns
++  // kv.second.debug_pipeline instead whenever debug-colorize mode is on
++  // (see SetDebugColorizeMode's header comment). The caller
++  // (command_processor.cpp) passes that exact return value straight into
++  // `pipeline` here -- so with debug mode on, `found` was ALWAYS null,
++  // this function ALWAYS returned before issuing any real draw command,
++  // and the caller (which unconditionally treats a non-null
++  // GetOrCreatePipeline() result as "handled", see its own comment) never
++  // fell back to stock rendering either. Net effect, confirmed by the
++  // exact symptom reported: EVERY draw whose pipeline was ever built while
++  // debug mode was on rendered NOTHING AT ALL, permanently, for the rest
++  // of the session (not just its first frame -- GetOrCreatePipeline()
++  // keeps returning the same debug_pipeline handle on every subsequent
++  // call too) -- silently missing geometry, not colorization, and the
++  // native draw counter staying exactly 0 forever since this early return
++  // sits before `++state.draw_count;`. Match either handle.
++  PipelineEntry* found = nullptr;
++  for (auto& kv : state.pipelines) {
++    if (kv.second.pipeline == pipeline || kv.second.debug_pipeline == pipeline) {
++      found = &kv.second;
++      break;
++    }
++  }
++  if (!found) {
++    return;
++  }
++
++  BindlessHeapState& heap = GetHeapState();
++  if (!heap.available) {
++    return;
++  }
++
++  // Real fix (2026-08-17): reclaim constants_pool's completed pages once
++  // per frame, matching the stock renderer's own uniform_buffer_pool_
++  // cadence (command_processor.cpp's BeginSubmission) -- see
++  // BindlessHeapState::last_reclaimed_frame's own comment for the full
++  // story. Gated on frame number so this doesn't do a linked-list walk on
++  // every single draw, only once when a new frame starts.
++  const uint64_t current_frame = command_processor.GetCurrentFrame();
++  if (heap.last_reclaimed_frame != current_frame) {
++    heap.constants_pool->Reclaim(command_processor.GetCompletedFrame());
++    heap.last_reclaimed_frame = current_frame;
++  }
++
++  uint64_t start_ns = Now();
++
++  command_processor.BindExternalGraphicsPipeline(pipeline);
++
++  // Real per-draw texture/sampler binding: walk the PIXEL shader's own real
++  // texture_bindings() (fetch_constant -> real ALU register, already-
++  // structured data from AnalyzeUcode() -- see tools/ucode_analyze.cpp's
++  // identical use of this same API), resolve each fetch constant's real
++  // texture/sampler to its STABLE, permanently-allocated heap slot (see
++  // ResolveTexture2DSlot's and kBindlessHeapSlotCount's comments -- this is
++  // no longer the fetch constant register number), and write that assigned
++  // slot into THIS draw's own SharedConstants buffer. Skip the draw entirely
++  // when any required texture isn't ready or the slot pool is exhausted,
++  // matching the stock renderer's own real fallback behavior, rather than
++  // drawing with a stale/wrong descriptor.
++  SharedConstantsLayout shared_constants;
++  for (const Shader::TextureBinding& tb : pixel_shader->texture_bindings()) {
++    // See SharedConstantsLayout's comment: the compiled shader reads its
++    // descriptor index from texture2d_indices[registerIndex] /
++    // sampler_indices[registerIndex], and build_synthetic_container.py sets
++    // each sampler ConstantInfo's registerIndex equal to the real Xenos
++    // fetch constant, so registerIndex == tb.fetch_constant here -- only the
++    // ARRAY POSITION, not the value stored there. Anything >= 16 cannot be
++    // addressed without aliasing into the next dimension's array (the byte
++    // offsets are baked into the shader), so fall back to the stock path for
++    // that draw rather than sampling a wrong texture.
++    // NOTE: rejected at pipeline-creation time instead of here. Returning
++    // early from IssueNativeDraw does NOT fall back to stock -- the caller
++    // (command_processor.cpp) treats a non-null GetOrCreatePipeline()
++    // result as "this draw is handled" and never reaches the stock path,
++    // so an early return here silently DROPS the draw. (Measured: only 1
++    // fetch in 1 of 1537 real pixel shaders is affected, but this exact
++    // trap already caused a real invisible-geometry bug in the
++    // debug-colorize path earlier today.)
++    if (tb.fetch_constant >= 16) {
++      continue;
++    }
++    uint32_t slot = 0;
++    if (!ResolveTexture2DSlot(command_processor, heap, tb.fetch_constant, &slot)) {
++      return;
++    }
++    shared_constants.texture2d_indices[tb.fetch_constant] = slot;
++    shared_constants.sampler_indices[tb.fetch_constant] = slot;
++  }
++
++  // Real per-draw VertexShaderConstants/PixelShaderConstants upload: dense
++  // c0-c255 float4 arrays, matching XenosRecomp's g_VertexShaderConstants[256]
++  // / g_PixelShaderConstants[256] layout exactly (confirmed via direct HLSL
++  // inspection -- a flat array, not the stock renderer's per-shader-usage-
++  // bitmap-packed layout, so the whole real register range is copied
++  // unconditionally rather than reusing the stock renderer's own constant
++  // population function, which is genuinely incompatible here -- see
++  // nativevk_xenos_pipeline_cache.h's header comment on this).
++  const RegisterFile& regs = *command_processor.register_file();
++  constexpr size_t kFloatConstantsBytes = 256 * 4 * sizeof(float);
++
++  // TEMP DIAG (2026-08-17): investigating why vs_78963937a7788928 (a boot
++  // video full-screen quad -- raw position passthrough, no transform
++  // matrix) renders as a black screen when native but not when stock.
++  // IssueNativeDraw never reads PA_CL_CLIP_CNTL.clip_disable at all, but
++  // the stock renderer (draw.cpp's GetHostViewportInfo) handles
++  // clip_disable draws via a COMPLETELY different math path (a huge host
++  // viewport plus its own NDC remap), which this raw XenosRecomp-compiled
++  // passthrough shader has no knowledge of and cannot replicate -- a
++  // plausible real cause for a full-screen quad rendering in the wrong
++  // space entirely (i.e. nothing visible). Logging real register state
++  // once per unique shader hash to confirm or rule this out before
++  // attempting a fix, rather than guessing.
++  if (vertex_shader->ucode_data_hash() == 0x78963937a7788928ull) {
++    static std::unordered_set<uint64_t> loggedDiagKeys;
++    if (loggedDiagKeys.insert(vertex_shader->ucode_data_hash()).second) {
++      auto pa_cl_clip_cntl = regs.Get<reg::PA_CL_CLIP_CNTL>();
++      auto pa_su_vtx_cntl = regs.Get<reg::PA_SU_VTX_CNTL>();
++      auto pa_su_sc_mode_cntl = regs.Get<reg::PA_SU_SC_MODE_CNTL>();
++      REXGPU_WARN(
++          "renut native DIAG vs_78963937a7788928: clip_disable={} pix_center={} cull_front={} "
++          "cull_back={} face={} vport_x_scale={:.4f} vport_y_scale={:.4f} vport_x_offset={:.4f} "
++          "vport_y_offset={:.4f}",
++          uint32_t(pa_cl_clip_cntl.clip_disable), uint32_t(pa_su_vtx_cntl.pix_center),
++          uint32_t(pa_su_sc_mode_cntl.cull_front), uint32_t(pa_su_sc_mode_cntl.cull_back),
++          uint32_t(pa_su_sc_mode_cntl.face), regs.Get<float>(XE_GPU_REG_PA_CL_VPORT_XSCALE),
++          regs.Get<float>(XE_GPU_REG_PA_CL_VPORT_YSCALE),
++          regs.Get<float>(XE_GPU_REG_PA_CL_VPORT_XOFFSET),
++          regs.Get<float>(XE_GPU_REG_PA_CL_VPORT_YOFFSET));
++    }
++  }
++
++  // Real bug found+fixed 2026-08-17: shared_constants was declared above
++  // with its in-class defaults (all zero/placeholder) and NEVER written
++  // before being shipped to the GPU -- every native draw was supplying
++  // g_Booleans=0, g_SwappedTexcoords=0, g_AlphaThreshold=0.5 (a constant,
++  // not the guest's real per-draw value) regardless of real game state.
++  // g_Booleans=0 means every shader's boolean-constant-gated branch always
++  // took its "false" path; g_SwappedTexcoords=0 means every 16-bit-packed
++  // TEXCOORD attribute got read with the wrong byte order. Both are
++  // consistent with (not proven sole cause of) the widespread native-shader
++  // visual corruption this was investigating.
++  //   - g_Booleans: real register is a raw dword, first 32 of the GPU's 128
++  //     real boolean constants (see XE_GPU_REG_SHADER_CONSTANT_BOOL_000_031;
++  //     XenosRecomp's own g_Booleans field is a single uint32, i.e. only the
++  //     first 32 bools are representable here -- a real, separate XenosRecomp
++  //     limitation, not something this fix can widen).
++  //   - g_SwappedTexcoords: computed once per pipeline at creation time from
++  //     each vertex attribute's real format (16-bit-per-channel formats need
++  //     the correction) -- see PipelineEntry::swapped_texcoords_mask's own
++  //     comment.
++  //   - g_AlphaThreshold: the guest's real per-draw alpha-test reference
++  //     register, already a normalized float (RB_ALPHA_REF is `kFloat` in
++  //     register_table.inc) -- no unit conversion needed.
++  //   - g_NdcScale/g_NdcOffset (real fix, 2026-08-17, supersedes the old
++  //     "g_HalfPixelOffset intentionally left at zero" note below): the
++  //     stock renderer's ndc_scale/ndc_offset ISN'T just the half-pixel
++  //     offset, it's the entire guest-clip-space-to-host-viewport transform
++  //     every stock vertex shader applies unconditionally
++  //     (spirv_translator.cpp) -- viewport scale/offset, window offset,
++  //     half-pixel offset, D3D-vs-GL clip convention, reverse-Z, and the
++  //     whole clip-disabled/screen-space-quad case. Native shaders had zero
++  //     equivalent, which is confirmed to produce exactly the "large,
++  //     wrongly-positioned, cleanly-edged geometry" symptom for any
++  //     clip-disabled draw (full-screen quads: UI, video, post-process).
++  //     Read from command_processor.last_viewport_info(), which IssueDraw
++  //     already computes via the SAME draw_util::GetHostViewportInfo() call
++  //     the stock path uses, once per draw, before the native/stock branch
++  //     -- not re-derived here, so this can never drift out of sync with
++  //     what the stock path itself would have used for this exact draw.
++  // Real fix (2026-08-17): was uploading only the first dword, i.e. booleans
++  // 0-31, so every pixel-shader boolean (which live at 128-255 on this
++  // hardware) was never sent to the GPU at all -- the shader read whatever
++  // happened to be in the vertex-shader boolean bits instead. All 8 dwords of
++  // the real boolean register file are contiguous in the register file, so
++  // this is a single copy. See SharedConstantsLayout's comment for the full
++  // mechanism.
++  static_assert(XE_GPU_REG_SHADER_CONSTANT_BOOL_224_255 - XE_GPU_REG_SHADER_CONSTANT_BOOL_000_031 == 7,
++                "boolean constant registers must be 8 contiguous dwords");
++  for (size_t i = 0; i < 8; ++i) {
++    shared_constants.booleans[i] = regs[XE_GPU_REG_SHADER_CONSTANT_BOOL_000_031 + uint32_t(i)];
++  }
++  shared_constants.swapped_texcoords = found->swapped_texcoords_mask;
++  shared_constants.alpha_threshold = regs.Get<float>(XE_GPU_REG_RB_ALPHA_REF);
++  // Real fix (2026-08-17): real per-draw alpha-test enable, matching the
++  // same register the stock renderer reads (draw_util::DoesCoverageDependOnAlpha)
++  // -- see g_AlphaTestEnable's own comment (shader_common.h) for why this
++  // must be dynamic rather than baked at shader-conversion time.
++  //
++  // Real bug found+fixed (2026-08-17, same day): the first version of this
++  // fix gated purely on RB_COLORCONTROL.alpha_test_enable, but XenosRecomp's
++  // compiled `clip(oC0.w - g_AlphaThreshold)` hardcodes exactly ONE
++  // comparator -- discard when oC0.w < threshold, i.e. GEQUAL-keep
++  // semantics -- with no way to express the other 7 D3DCMP_* functions.
++  // Games routinely leave the fixed-function alpha-test UNIT enabled while
++  // setting ALPHAFUNC=ALWAYS as a real, common "no-op" idiom (equivalent to
++  // disabled) -- gating on enable alone made every such draw wrongly
++  // discard pixels via GEQUAL logic instead of discarding nothing,
++  // producing exactly the reported "enabling native rendering makes
++  // geometry disappear" symptom, and explains why it looked near-universal
++  // rather than shader-specific. Only apply when the real compare function
++  // is ALSO exactly what the compiled clip() implements.
++  auto rb_colorcontrol = regs.Get<reg::RB_COLORCONTROL>();
++  shared_constants.alpha_test_enable =
++      (rb_colorcontrol.alpha_test_enable &&
++       rb_colorcontrol.alpha_func == xenos::CompareFunction::kGreaterEqual)
++          ? 1u
++          : 0u;
++  {
++    const draw_util::ViewportInfo& viewport_info = command_processor.last_viewport_info();
++    for (size_t i = 0; i < 3; ++i) {
++      shared_constants.ndc_scale[i] = viewport_info.ndc_scale[i];
++      shared_constants.ndc_offset[i] = viewport_info.ndc_offset[i];
++    }
++  }
++
++  // Real "represent each shader on screen" feature (2026-08-17, user-
++  // requested): best-effort on-screen label position, gated behind the
++  // panel's toggle so this costs nothing when the feature's off (the
++  // common case). HEURISTIC, not a verified-correct decode -- still
++  // assumes this shader's transform matrix lives at constant registers
++  // c0-c3 (the D3D9 HLSL compiler's default top-down allocation order
++  // almost always puts the first-declared matrix there).
++  //
++  // Real fix (2026-08-17, "labels stick to the player/camera, not the
++  // object" bug report): the original version of this evaluated the
++  // matrix at a fixed, assumed LOCAL-space origin (0,0,0,1) for every
++  // draw. That only yields a per-object world position if c0-c3 holds a
++  // real World*View*Projection matrix that changes per draw. The reported
++  // symptom -- every label landing near the SAME on-screen spot, tracking
++  // the player/camera instead of individual objects -- means that's not
++  // what's happening: c0-c3 is far more likely just a View/ViewProjection
++  // matrix shared by the whole frame, with no per-object translation
++  // baked in, so every "at origin" evaluation collapsed to roughly the
++  // same point (wherever the camera itself is looking). Fixed by reading
++  // this draw's REAL first vertex position (Vulkan attribute location 0,
++  // i.e. Position -- see XenosRecomp's USAGE_LOCATIONS table) straight out
++  // of guest memory instead of assuming the origin, so the transform now
++  // varies per-draw even if c0-c3 turns out to only be View/ViewProjection
++  // (still an open unknown -- see
++  // renut_native_shader_investigation_2026_08_17.md -- just no longer
++  // masked by a degenerate always-zero input).
++  if (GetShowNativeShaderLabels()) {
++    const VertexAttributeInfo* position_attr = nullptr;
++    for (const VertexAttributeInfo& attr : found->attributes) {
++      if (attr.location == 0) {
++        position_attr = &attr;
++        break;
++      }
++    }
++    // Only 32-bit-float position formats are decoded here -- the common
++    // case. Packed/half-float positions are skipped rather than risk
++    // plotting garbage from a format this code doesn't interpret.
++    if (position_attr != nullptr && (position_attr->format == VK_FORMAT_R32G32B32_SFLOAT ||
++                                      position_attr->format == VK_FORMAT_R32G32B32A32_SFLOAT)) {
++      xenos::xe_gpu_vertex_fetch_t vfetch_constant =
++          regs.GetVertexFetch(position_attr->fetch_constant_index);
++      const uint32_t guest_address =
++          (uint32_t(vfetch_constant.address) << 2) + position_attr->offset_bytes;
++      // Real guest memory is big-endian (see rex::memory::Memory::
++      // TranslatePhysical's own doc comment) -- load_and_swap matches this
++      // codebase's existing convention for reading it on the CPU (see
++      // command_processor.cpp/pipeline_cache.cpp's own rex::byte_swap
++      // uses). SharedMemory::memory() is protected, so go through
++      // Runtime::instance()->memory() instead (same real rex::memory::Memory
++      // singleton -- see include/rex/runtime.h -- just via a public accessor).
++      const uint8_t* raw = Runtime::instance()->memory()->TranslatePhysical<const uint8_t*>(
++          guest_address);
++      const float local_pos[3] = {
++          rex::memory::load_and_swap<float>(raw + 0),
++          rex::memory::load_and_swap<float>(raw + 4),
++          rex::memory::load_and_swap<float>(raw + 8),
++      };
++
++      // Real fix (2026-08-17): was a hardcoded c0 guess; now a live,
++      // panel-adjustable base register (see GetNativeShaderLabelMatrixRegister's
++      // own header comment for why -- two static guesses in a row were both
++      // wrong, so this is now a calibration knob instead of a third guess).
++      const uint32_t assumed_matrix_register = GetNativeShaderLabelMatrixRegister();
++      const uint32_t base = XE_GPU_REG_SHADER_CONSTANT_000_X + assumed_matrix_register * 4;
++      auto matrix_row_component = [&](uint32_t row, uint32_t component) {
++        return regs.Get<float>(base + row * 4 + component);
++      };
++      // clip = (local.x, local.y, local.z, 1) * M, M's rows stored as
++      // c0..c3 (confirmed convention: an assumed-zero local vector used to
++      // collapse to exactly row 3, i.e. c3, before this fix).
++      float clip_x = 0.0f, clip_y = 0.0f, clip_w = 0.0f;
++      for (uint32_t row = 0; row < 3; ++row) {
++        clip_x += local_pos[row] * matrix_row_component(row, 0);
++        clip_y += local_pos[row] * matrix_row_component(row, 1);
++        clip_w += local_pos[row] * matrix_row_component(row, 3);
++      }
++      clip_x += matrix_row_component(3, 0);
++      clip_y += matrix_row_component(3, 1);
++      clip_w += matrix_row_component(3, 3);
++
++      // w<=0 means behind the camera (or this register block genuinely
++      // isn't a projection matrix for this shader) -- skip rather than
++      // plot garbage.
++      if (clip_w > 0.0001f) {
++        DebugLabelEntry entry;
++        entry.vs_hash = vertex_shader->ucode_data_hash();
++        entry.ps_hash = pixel_shader->ucode_data_hash();
++        entry.ndc_x = clip_x / clip_w;
++        entry.ndc_y = clip_y / clip_w;
++        std::lock_guard<std::mutex> lock(DebugLabelMutex());
++        DebugLabelPositions()[CombineKey(entry.vs_hash, entry.ps_hash)] = entry;
++      }
++    }
++  }
++
++  const ui::vulkan::VulkanDevice* vulkan_device = command_processor.GetVulkanDevice();
++  const ui::vulkan::VulkanDevice::Functions& dfn = vulkan_device->functions();
++  VkDevice device = vulkan_device->device();
++  // Real Vulkan device requirement, not optional -- matches the stock
++  // renderer's own uniform-buffer suballocation alignment
++  // (command_processor.cpp's uniform_buffer_alignment), needed because these
++  // buffers are bound as VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT (BDA reads don't
++  // require it, but this pool's usage flags declare uniform-buffer usage
++  // too, so the device's real minimum applies).
++  const size_t uniform_buffer_alignment =
++      size_t(vulkan_device->properties().minUniformBufferOffsetAlignment);
++
++  VkBuffer vs_constants_buffer = VK_NULL_HANDLE, ps_constants_buffer = VK_NULL_HANDLE,
++           shared_constants_buffer = VK_NULL_HANDLE;
++  VkDeviceSize vs_constants_offset = 0, ps_constants_offset = 0, shared_constants_offset = 0;
++  uint8_t* vs_mapping = heap.constants_pool->Request(
++      command_processor.GetCurrentSubmission(), kFloatConstantsBytes, uniform_buffer_alignment,
++      vs_constants_buffer, vs_constants_offset);
++  uint8_t* ps_mapping = heap.constants_pool->Request(
++      command_processor.GetCurrentSubmission(), kFloatConstantsBytes, uniform_buffer_alignment,
++      ps_constants_buffer, ps_constants_offset);
++  uint8_t* shared_mapping = heap.constants_pool->Request(
++      command_processor.GetCurrentSubmission(), sizeof(SharedConstantsLayout),
++      uniform_buffer_alignment, shared_constants_buffer, shared_constants_offset);
++
++  uint64_t push_constants[3] = {0, 0, 0};
++  if (vs_mapping) {
++    std::memcpy(vs_mapping, &regs[XE_GPU_REG_SHADER_CONSTANT_000_X], kFloatConstantsBytes);
++    VkBufferDeviceAddressInfo address_info = {};
++    address_info.sType = VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO;
++    address_info.buffer = vs_constants_buffer;
++    push_constants[0] = dfn.vkGetBufferDeviceAddress(device, &address_info) + vs_constants_offset;
++  }
++  if (ps_mapping) {
++    std::memcpy(ps_mapping, &regs[XE_GPU_REG_SHADER_CONSTANT_256_X], kFloatConstantsBytes);
++    VkBufferDeviceAddressInfo address_info = {};
++    address_info.sType = VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO;
++    address_info.buffer = ps_constants_buffer;
++    push_constants[1] = dfn.vkGetBufferDeviceAddress(device, &address_info) + ps_constants_offset;
++  }
++  if (shared_mapping) {
++    std::memcpy(shared_mapping, &shared_constants, sizeof(SharedConstantsLayout));
++    VkBufferDeviceAddressInfo address_info = {};
++    address_info.sType = VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO;
++    address_info.buffer = shared_constants_buffer;
++    push_constants[2] =
++        dfn.vkGetBufferDeviceAddress(device, &address_info) + shared_constants_offset;
++  }
++  heap.constants_pool->FlushWrites();
++
++  DeferredCommandBuffer& cmd = command_processor.deferred_command_buffer();
++  cmd.CmdVkPushConstants(found->pipeline_layout, VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT,
++                        0, sizeof(push_constants), push_constants);
++
++  // Bind the 4 bindless descriptor sets (0-3) -- one shared heap for every
++  // native pipeline, real texture/sampler data already written above.
++  VkDescriptorSet bindless_sets[4] = {heap.texture2d_set, heap.texture3d_set,
++                                      heap.texturecube_set, heap.sampler_set};
++  cmd.CmdVkBindDescriptorSets(VK_PIPELINE_BIND_POINT_GRAPHICS, found->pipeline_layout, 0,
++                             uint32_t(rex::countof(bindless_sets)), bindless_sets, 0, nullptr);
++
++  // Real vertex buffer binding: shared_memory_->buffer() IS a real VkBuffer
++  // already containing live guest memory (see PLAN_native_renderer.md's
++  // finding that stock renut has zero vkCmdBindVertexBuffers calls and
++  // instead fetches in-shader via SSBO -- native pipelines need the real
++  // fixed-function binding XenosRecomp's HLSL expects, into the SAME
++  // memory, at the byte offset the fetch constant's own address already
++  // gives). By this point in IssueDraw, the caller's earlier vfetch-
++  // residency loop has already called RequestRange/RequestRanges for every
++  // fetch constant this vertex shader references, so the bytes are resident.
++  // (regs already declared above, for the constant-buffer upload.)
++  VulkanSharedMemory* shared_memory = command_processor.shared_memory();
++  std::vector<VkBuffer> vertex_buffers;
++  std::vector<VkDeviceSize> vertex_offsets;
++  vertex_buffers.reserve(found->bindings.size());
++  vertex_offsets.reserve(found->bindings.size());
++  for (const VertexBindingInfo& b : found->bindings) {
++    xenos::xe_gpu_vertex_fetch_t vfetch_constant = regs.GetVertexFetch(b.fetch_constant_index);
++    vertex_buffers.push_back(shared_memory->buffer());
++    vertex_offsets.push_back(VkDeviceSize(vfetch_constant.address) << 2);
++  }
++  if (!vertex_buffers.empty()) {
++    cmd.CmdVkBindVertexBuffers(0, uint32_t(vertex_buffers.size()), vertex_buffers.data(),
++                              vertex_offsets.data());
++  }
++
++  if (index_buffer == VK_NULL_HANDLE) {
++    cmd.CmdVkDraw(vertex_count, 1, 0, 0);
++  } else {
++    cmd.CmdVkBindIndexBuffer(index_buffer, index_buffer_offset, index_type);
++    cmd.CmdVkDrawIndexed(vertex_count, 1, 0, 0, 0);
++  }
++
++  ++state.draw_count;
++  state.total_ns += Now() - start_ns;
++#else
++  (void)command_processor;
++  (void)pipeline;
++  (void)vertex_shader;
++  (void)vertex_count;
++#endif
++}
++
++uint64_t TakeDrawCount() {
++  State& state = GetState();
++  uint64_t count = state.draw_count;
++  state.draw_count = 0;
++  return count;
++}
++
++uint64_t PeekLastFrameDrawCount() {
++  // Real bug found+fixed (2026-08-17): this used to read a snapshot taken
++  // inside TakeDrawCount(), which is ONLY called from RenutWriteTraceRow's
++  // fprintf argument list (command_processor.cpp) -- i.e. only when the CSV
++  // trace file is actually open and being written to. Confirmed via the
++  // real trace CSVs on disk: none were freshly written during an entire
++  // play session, meaning TakeDrawCount() was never once called, so the
++  // snapshot stayed frozen at its initial 0 forever regardless of how many
++  // native draws actually happened -- exactly the "stuck at 0" the user
++  // reported. state.draw_count itself IS live-incremented unconditionally
++  // by every real IssueNativeDraw() call (see the `++state.draw_count;`
++  // right after the real CmdVkDraw/CmdVkDrawIndexed call), so read it
++  // directly instead. This makes the panel's number a running total since
++  // boot (or since the last real TakeDrawCount() call, if the trace writer
++  // ever does run) rather than a clean per-frame count, but "is this
++  // growing at all, and roughly how fast" answers the question that
++  // mattered here -- a real total beats a value that never updates.
++  return GetState().draw_count;
++}
++
++uint64_t TakeTotalNs() {
++  State& state = GetState();
++  uint64_t ns = state.total_ns;
++  state.total_ns = 0;
++  return ns;
++}
++
++}  // namespace rex::graphics::vulkan::nativevk_pipeline
+diff --git a/src/graphics/vulkan/nativevk_xenos_pipeline_cache.h b/src/graphics/vulkan/nativevk_xenos_pipeline_cache.h
+new file mode 100644
+index 0000000..b53a6dd
+--- /dev/null
++++ b/src/graphics/vulkan/nativevk_xenos_pipeline_cache.h
+@@ -0,0 +1,247 @@
++#pragma once
++// Native-renderer "convert the important/common shaders" effort (see
++// PLAN_native_renderer.md). Generalizes Phase 1's single hardcoded
++// vs_67021cae68a26b46+ps_12c73f3eb45dad49 pipeline (nativevk_phase1_native_draw)
++// into a real cache keyed by (vertex hash, pixel hash), backed by
++// renut_xenos_shader_cache.h's batch-converted SPIR-V (see
++// tools/xenos_batch_convert.py + tools/xenos_cache_unpack.cpp), so any
++// SUCCESSFULLY-CONVERTED shader pair gets a real native pipeline on demand,
++// not just the one Phase 1 hand-picked.
++//
++// Deliberately a new file/namespace rather than editing
++// nativevk_phase1_native_draw.cpp in place -- that file's single hardcoded quad
++// draw stays as-is (a known-working, minimal reference/fallback), and this
++// is additive: IssueDraw tries this generalized cache FIRST, falling back to
++// Phase 1's single-target path, then to the normal Xenos-translated draw.
++
++#include <cstdint>
++#include <vector>
++
++#include <volk.h>
++
++#include <rex/graphics/primitive_processor.h>
++#include <rex/graphics/vulkan/command_processor.h>
++#include <rex/graphics/xenos.h>
++
++namespace rex::graphics::vulkan::nativevk_pipeline {
++
++// True if BOTH shaders in this draw have compiled SPIR-V available in the
++// batch shader cache (renut_xenos_shader_cache.h) -- i.e. this pair is a
++// real candidate for native substitution, not just one side of it. Cheap
++// hash-table lookups only; does not build anything.
++bool HasNativePipeline(uint64_t vertex_shader_ucode_hash, uint64_t pixel_shader_ucode_hash);
++
++// Lazily builds (once per (vertex_hash, pixel_hash, render_pass, primitive
++// topology) tuple, cached thereafter) a real VkPipeline for this shader
++// pair: real compiled SPIR-V from the batch cache, real per-element vertex
++// input derived from the vertex shader's OWN decoded vfetch instructions
++// (Shader::vertex_bindings(), populated by the SDK's existing
++// AnalyzeUcode() -- already called for any shader that has ever been used
++// for a real draw, see pipeline_cache.cpp), not a fabricated hardcoded
++// buffer. Returns VK_NULL_HANDLE if creation failed (logged once per
++// shader pair) or the device lacks bufferDeviceAddress.
++//
++// host_primitive_type (2026-08-16 fix): the pipeline's input assembly
++// topology was hardcoded to VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST regardless
++// of what the guest actually drew -- correct only for kTriangleList itself,
++// wrong (garbled/misconnected geometry, confirmed via real in-game visual
++// corruption) for kTriangleStrip/kLineList/etc, and structurally impossible
++// to get right at all for kRectangleList/kQuadList without a geometry
++// shader (which this native path does not have). Returns VK_NULL_HANDLE
++// for any primitive type this path can't correctly draw, so the caller
++// falls back to the normal Xenos-translated draw instead of silently
++// rendering it wrong.
++VkPipeline GetOrCreatePipeline(VulkanCommandProcessor& command_processor,
++                                Shader* vertex_shader, Shader* pixel_shader,
++                                xenos::PrimitiveType host_primitive_type);
++
++// Issues the native draw: binds the pipeline via BindExternalGraphicsPipeline
++// (the same proven seam Phase 1 uses), binds shared_memory_->buffer() at the
++// REAL guest vertex-fetch-constant byte offsets for each vertex binding
++// (Xenos vfetch instructions address SharedMemory directly -- see
++// PLAN_native_renderer.md's "no vkCmdBindVertexBuffers in stock renut"
++// finding; native pipelines DO need a real fixed-function binding, unlike
++// the stock in-shader SSBO fetch, so this binds the SAME memory stock renut
++// already made resident via RequestRange/RequestRanges earlier in IssueDraw,
++// just via a real Vulkan vertex-input binding instead of an SSBO load), and
++// issues the same draw call the guest asked for (vertex count/instance count
++// from the caller, matching what the normal Xenos-translated path would have
++// issued).
++// pixel_shader is needed (new, was previously only vertex_shader) for real
++// texture-binding resolution -- see the bindless-heap follow-up below: the
++// pixel shader's own texture_bindings() (fetch_constant -> heap slot) must
++// be walked to know which real textures this draw needs bound.
++//
++// index_buffer (2026-08-16 fix): the caller's own draw (the normal
++// Xenos-translated path, right below this call in command_processor.cpp)
++// picks between CmdVkDraw and CmdVkDrawIndexed depending on whether this
++// draw uses a real index buffer -- this native path was unconditionally
++// calling CmdVkDraw and silently ignoring any real index buffer, which for
++// indexed geometry reads the raw sequential vertex stream instead of
++// following the real index order/dedup, producing garbled/streaked
++// geometry. index_buffer is null (VK_NULL_HANDLE) for non-indexed draws;
++// the caller resolves it exactly the same way the stock path does
++// (guest DMA scratch buffer / host-converted / host-builtin, see
++// command_processor.cpp's IssueDraw) since that resolution needs locals
++// only in scope there.
++void IssueNativeDraw(VulkanCommandProcessor& command_processor, VkPipeline pipeline,
++                      Shader* vertex_shader, Shader* pixel_shader,
++                      const PrimitiveProcessor::ProcessingResult& primitive_processing_result,
++                      VkBuffer index_buffer, VkDeviceSize index_buffer_offset,
++                      VkIndexType index_type);
++
++// Trace-CSV plumbing, same take-and-reset pattern as Phase 1's
++// TakeDrawCount()/TakeTotalNs().
++uint64_t TakeDrawCount();
++uint64_t TakeTotalNs();
++// Non-destructive: total native draws since boot (or since the last real
++// TakeDrawCount() call, if the CSV trace writer is active -- it usually
++// isn't). NOT a per-frame count: TakeDrawCount() is the only thing that ever
++// resets the underlying counter, and it's only reachable from the trace
++// writer's own fprintf call, which confirmed-real testing showed does not
++// run in ordinary play. Safe to read from the debug panel at any time.
++uint64_t PeekLastFrameDrawCount();
++
++// Bindless texture/sampler heap follow-up (see PLAN_native_renderer.md):
++// XenosRecomp-generated shaders expect a real bindless descriptor scheme
++// this SDK never had (confirmed via direct codebase search: zero
++// UPDATE_AFTER_BIND/PARTIALLY_BOUND/bindless usage anywhere in
++// src/graphics/vulkan or include/rex/graphics/vulkan before this) -- fixed-
++// size 32-slot Texture2D/Texture3D/TextureCube/Sampler arrays at sets 0-3
++// (DXC's default HLSL space->Vulkan set mapping, confirmed via XenosRecomp's
++// own dxc_compiler.cpp: no -fvk-bind-* overrides). Must be created once,
++// lazily, on first native draw that needs it (matching GetOrCreatePipeline's
++// own lazy-init pattern).
++//
++// Constant buffers (VertexShaderConstants/PixelShaderConstants/
++// SharedConstants) do NOT need a descriptor set at all -- confirmed by
++// reading nativevk_phase1_native_draw.cpp's already-proven, already-shipped
++// mechanism: they're plain VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT buffers,
++// addressed by raw GPU pointer via vkGetBufferDeviceAddress and passed
++// through the SAME 3-uint64 push-constant range GetOrCreatePipeline already
++// creates (currently zeroed -- see IssueNativeDraw). This file generalizes
++// that one-shader-pair mechanism to any shader, it does not replace it.
++void EnsureBindlessHeapInitialized(VulkanCommandProcessor& command_processor);
++
++// Real pipeline layout for a native pipeline: adds the bindless texture/
++// sampler descriptor sets (0-3) alongside the existing 3-uint64 push-
++// constant range (unchanged -- see above, constants stay push-constant-
++// addressed, not descriptor-set-bound).
++VkPipelineLayout GetOrCreateBindlessPipelineLayout(VulkanCommandProcessor& command_processor);
++
++// Real-time native-shader debug panel support (2026-08-16): every shader
++// pair HasNativePipeline() has ever seen (both sides genuinely converted,
++// so a real candidate for substitution -- a few dozen at most, not every
++// pair the game ever draws) is recorded with a live on/off toggle. The
++// panel (renut_shader_debug_panel.cpp) reads a snapshot via
++// GetDebugShaderPairs() and flips pairs via SetDebugShaderPairEnabled(), so
++// the user can disable all, then re-enable one at a time in-game with no
++// rebuild/relaunch, to bisect which converted shader(s) cause visible
++// corruption.
++struct DebugShaderPairInfo {
++  uint64_t vs_hash;
++  uint64_t ps_hash;
++  bool enabled;
++  // True if this pair started disabled because it was listed in
++  // marked_bad_shaders.txt when first seen this run (see
++  // RecordAndCheckPairEnabled()), not because of a live manual toggle.
++  bool marked_bad;
++  // Real "hard to find again" fix (2026-08-17, user-requested): the panel
++  // used to identify every pair only by its two 16-hex-digit hashes, which
++  // is unreadable enough that re-locating a specific pair after toggling it
++  // was impractical with hundreds of live pairs. A small, stable, 1-based
++  // sequence number assigned the moment a pair is first recorded (see
++  // RecordAndCheckPairEnabled()) -- stable for the life of the process,
++  // NOT re-sorted/re-numbered as pairs get toggled or re-ordered on screen.
++  uint32_t display_id;
++};
++
++// Snapshot (copy, not a live reference) of every recorded pair, in first-
++// seen order.
++std::vector<DebugShaderPairInfo> GetDebugShaderPairs();
++
++// Flips one pair's live enabled state. No-op if the pair hasn't been
++// recorded yet (i.e. was never seen in HasNativePipeline()).
++void SetDebugShaderPairEnabled(uint64_t vs_hash, uint64_t ps_hash, bool enabled);
++
++// Convenience for the panel's "Enable All" / "Disable All" buttons.
++void SetAllDebugShaderPairsEnabled(bool enabled);
++
++// Convenience for the panel's "Enable All Bad" / "Disable All Bad" buttons
++// (2026-08-17, user-requested): flips only the pairs with marked_bad set
++// (i.e. listed in marked_bad_shaders.txt), leaving every other pair's live
++// enabled state untouched -- lets the user quickly re-test "does turning
++// all known-bad shaders back on reproduce the corruption" without having to
++// click every marked pair individually.
++void SetMarkedBadShaderPairsEnabled(bool enabled);
++
++// Lazily creates and registers the real ImGui debug panel (see
++// renut_shader_debug_panel.cpp), once per process. Safe to call every
++// frame (no-ops after the first call), matching this file's
++// EnsureBindlessHeapInitialized pattern.
++void EnsureDebugPanelInitialized();
++
++// Real "represent each shader on screen" feature (2026-08-17, user-
++// requested): a best-effort floating "#<display_id>" label the panel draws
++// above wherever a native pair last drew. Position is a HEURISTIC, not a
++// verified-correct per-shader decode -- see IssueNativeDraw's own comment
++// (nativevk_pipeline_cache.cpp) for exactly what it assumes and why it
++// won't be right for every shader. ndc_x/ndc_y are normalized device
++// coordinates (-1..1, not yet converted to screen pixels); the panel does
++// that conversion itself since it already has ImGuiIO::DisplaySize.
++struct DebugShaderLabel {
++  uint64_t vs_hash;
++  uint64_t ps_hash;
++  float ndc_x;
++  float ndc_y;
++};
++
++// Snapshot of the most recent on-screen position recorded for every native
++// pair that has drawn at least once since labels were last enabled. Empty
++// (cheap) whenever GetShowNativeShaderLabels() is false, since
++// IssueNativeDraw skips recording entirely in that case.
++std::vector<DebugShaderLabel> GetDebugShaderLabels();
++
++// Panel-controlled on/off switch for the label-recording work above --
++// off by default so IssueNativeDraw's per-draw cost stays zero unless the
++// user actually opts in from the panel.
++void SetShowNativeShaderLabels(bool show);
++bool GetShowNativeShaderLabels();
++
++// Real fix (2026-08-17, user-reported: labels cluster above the player
++// instead of at each object): two static guesses (assumed local-space
++// origin, then real vertex data) both put the "WorldViewProjection at
++// c0-c3" assumption at fault -- that register block is very likely NOT a
++// per-object matrix for this game's shaders. Rather than keep guessing
++// blindly, the base register is now a LIVE, panel-adjustable value: drag
++// it in-game while looking at a specific object and watch its label move,
++// instead of waiting on a full rebuild per guess. Not expected to be the
++// same correct value for every shader (different shaders may lay out
++// their constants differently) -- this is a calibration aid, not a
++// verified-correct per-shader decode.
++void SetNativeShaderLabelMatrixRegister(uint32_t base_register);
++uint32_t GetNativeShaderLabelMatrixRegister();
++
++// Debugging feature (2026-08-17, user-requested): user reported that after
++// several real, verified shader-translation fixes (positional vertex
++// locations, boolean-constant width, vfetch-order/location alignment), the
++// on-screen corruption looked visually unchanged, to the point of doubting
++// whether ANY native shader renders correctly. Before committing to a full
++// rewrite on that belief, this gives a way to SEE the answer directly rather
++// than argue from a handful of screenshots: when on, GetOrCreatePipeline()
++// builds (and IssueNativeDraw uses) an alternate pipeline that keeps the
++// REAL, potentially-still-broken vertex shader module untouched but swaps in
++// a trivial fragment shader (nativevk_debug_color_spirv.h, hand-compiled via
++// glslangValidator, no descriptors/textures/interpolants read at all) that
++// just outputs one flat, stable color baked per (vs_hash, ps_hash) pair via
++// specialization constants. One screenshot with this on shows, unambiguously:
++// (1) how much of the visible scene is actually drawn by a native pipeline
++// at all (colored) vs falling back to the stock/original renderer (looks
++// normal), and (2) whether the native-colored geometry is well-formed
++// (matches real object silhouettes) or exploded/distorted (confirms a
++// vertex-stage, not fragment-stage, bug) -- separates "is it really most
++// shaders, or just a visually-dominant few" from subjective impression.
++void SetDebugColorizeMode(bool enabled);
++bool GetDebugColorizeMode();
++
++}  // namespace rex::graphics::vulkan::nativevk_pipeline
+diff --git a/src/ui/vulkan/vulkan_device.cpp b/src/ui/vulkan/vulkan_device.cpp
+index fc31478..285172f 100644
+--- a/src/ui/vulkan/vulkan_device.cpp
++++ b/src/ui/vulkan/vulkan_device.cpp
+@@ -648,6 +648,26 @@ std::unique_ptr<VulkanDevice> VulkanDevice::CreateIfSupported(
+       XE_UI_VULKAN_FEATURE_2(features_1_2, samplerMirrorClampToEdge);
+       XE_UI_VULKAN_FEATURE_2(features_1_2, uniformBufferStandardLayout);
+       XE_UI_VULKAN_FEATURE_2(features_1_2, scalarBlockLayout);
++      // Native-renderer Phase 1 (see PLAN_native_renderer.md): optional, not
++      // required for stock GPU emulation, so this does not gate device
++      // creation if unsupported -- only renut's native draw path needs it,
++      // and it checks device->properties().bufferDeviceAddress before use.
++      XE_UI_VULKAN_FEATURE_2(features_1_2, bufferDeviceAddress);
++      // Native-renderer "convert the important/common shaders": bindless
++      // descriptor array support for XenosRecomp-generated shaders (see
++      // device.h's comment on these same fields for the full rationale).
++      // Same optional/checked-before-use pattern as bufferDeviceAddress.
++      XE_UI_VULKAN_FEATURE_2(features_1_2, descriptorIndexing);
++      XE_UI_VULKAN_FEATURE_2(features_1_2, runtimeDescriptorArray);
++      XE_UI_VULKAN_FEATURE_2(features_1_2, shaderSampledImageArrayNonUniformIndexing);
++      XE_UI_VULKAN_FEATURE_2(features_1_2, descriptorBindingPartiallyBound);
++      XE_UI_VULKAN_FEATURE_2(features_1_2, descriptorBindingVariableDescriptorCount);
++      // CreateBindlessSetLayout() (nativevk_pipeline_cache.cpp) uses
++      // VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT for both its sampled-image
++      // (texture2d/3d/cube) and sampler bindings -- both require their own
++      // device feature bit, distinct from descriptorBindingPartiallyBound.
++      XE_UI_VULKAN_FEATURE_2(features_1_2, descriptorBindingSampledImageUpdateAfterBind);
++      XE_UI_VULKAN_FEATURE_2(features_1_2, descriptorBindingUpdateUnusedWhilePending);
+     }
+   } else {
+     if (ext_1_2_KHR_sampler_mirror_clamp_to_edge) {
+@@ -659,6 +679,9 @@ std::unique_ptr<VulkanDevice> VulkanDevice::CreateIfSupported(
+     if (with_gpu_emulation) {
+       XE_UI_VULKAN_FEATURE_2(features_1_3, shaderDemoteToHelperInvocation);
+       XE_UI_VULKAN_FEATURE_2(features_1_3, dynamicRendering);
++      // Promoted to 1.3 core, so no feature bit to enable - the commands are
++      // simply available on a 1.3+ device.
++      device->properties_.extendedDynamicState = true;
+     }
+   } else {
+     if (ext_1_3_KHR_dynamic_rendering) {
+@@ -772,6 +795,7 @@ std::unique_ptr<VulkanDevice> VulkanDevice::CreateIfSupported(
+   }
+   if (properties.apiVersion >= VK_MAKE_API_VERSION(0, 1, 3, 0)) {
+ #include <rex/ui/vulkan/functions/device_1_3_khr_dynamic_rendering.inc>
++#include <rex/ui/vulkan/functions/device_1_3_ext_extended_dynamic_state.inc>
+ #include <rex/ui/vulkan/functions/device_1_3_khr_maintenance4.inc>
+   }
+ #undef XE_UI_VULKAN_FUNCTION_PROMOTED
+@@ -800,6 +824,40 @@ std::unique_ptr<VulkanDevice> VulkanDevice::CreateIfSupported(
+   if (device->extensions_.ext_KHR_swapchain) {
+ #include <rex/ui/vulkan/functions/device_khr_swapchain.inc>
+   }
++  // Native-renderer Phase 1 (see PLAN_native_renderer.md): optional, does not
++  // affect functions_loaded/device creation success if the function pointer
++  // turns out to be unavailable despite the feature bit being set -- callers
++  // must check device->properties().bufferDeviceAddress before use, not just
++  // assume this pointer is non-null.
++  if (device->properties_.bufferDeviceAddress) {
++    // Only reached when apiVersion >= 1.2 (see the feature-enable guard
++    // above), so bufferDeviceAddress is always the PROMOTED/core feature
++    // here, never the standalone extension -- must query the CORE name
++    // ("vkGetBufferDeviceAddress"), not the legacy "...KHR" extension name.
++    // Bug found during Phase 1 bring-up (2026-08-17): this block originally
++    // copied the non-promoted/legacy-name macro pattern by mistake, which
++    // queries the wrong proc name and was the root cause of a black-screen
++    // regression -- confirmed via bisection, not assumed.
++    bool buffer_device_address_functions_loaded = true;
++#undef XE_UI_VULKAN_FUNCTION_PROMOTED
++#define XE_UI_VULKAN_FUNCTION_PROMOTED(extension_name, core_name)                             \
++    buffer_device_address_functions_loaded &=                                                  \
++        (dfn.core_name = PFN_##core_name(                                                       \
++             ifn.vkGetDeviceProcAddr(device->device_, #core_name))) != nullptr;
++#include <rex/ui/vulkan/functions/device_1_2_khr_buffer_device_address.inc>
++#undef XE_UI_VULKAN_FUNCTION_PROMOTED
++#define XE_UI_VULKAN_FUNCTION_PROMOTED(extension_name, core_name) \
++  functions_loaded &= (dfn.core_name = PFN_##core_name(           \
++                           ifn.vkGetDeviceProcAddr(device->device_, #extension_name))) != nullptr;
++    if (!buffer_device_address_functions_loaded) {
++      REXLOG_WARN(
++          "Vulkan device '{}' advertised bufferDeviceAddress but "
++          "vkGetBufferDeviceAddress could not be loaded; native-renderer "
++          "Phase 1 draws will be skipped",
++          properties.deviceName);
++      device->properties_.bufferDeviceAddress = false;
++    }
++  }
+ #undef XE_UI_VULKAN_FUNCTION_PROMOTED
+ 
+ #undef XE_UI_VULKAN_FUNCTION
+diff --git a/src/ui/vulkan/vulkan_upload_buffer_pool.cpp b/src/ui/vulkan/vulkan_upload_buffer_pool.cpp
+index 771019a..771fad2 100644
+--- a/src/ui/vulkan/vulkan_upload_buffer_pool.cpp
++++ b/src/ui/vulkan/vulkan_upload_buffer_pool.cpp
+@@ -131,6 +131,20 @@ GraphicsUploadBufferPool::Page* VulkanUploadBufferPool::CreatePageImplementation
+   memory_allocate_info.pNext = nullptr;
+   memory_allocate_info.allocationSize = allocation_size_;
+   memory_allocate_info.memoryTypeIndex = memory_type_;
++  // Required whenever the buffer was created with
++  // VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT (native-renderer bindless
++  // constant buffers, see nativevk_pipeline_cache.cpp's constants_pool) --
++  // VUID-vkBindBufferMemory-bufferDeviceAddress-03339 otherwise.
++  VkMemoryAllocateFlagsInfo memory_allocate_flags_info;
++  if (usage_ & VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT) {
++    memory_allocate_info_last->pNext = &memory_allocate_flags_info;
++    memory_allocate_info_last =
++        reinterpret_cast<VkMemoryAllocateInfo*>(&memory_allocate_flags_info);
++    memory_allocate_flags_info.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_FLAGS_INFO;
++    memory_allocate_flags_info.pNext = nullptr;
++    memory_allocate_flags_info.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
++    memory_allocate_flags_info.deviceMask = 0;
++  }
+   VkMemoryDedicatedAllocateInfo memory_dedicated_allocate_info;
+   if (vulkan_device_->extensions().ext_1_1_KHR_dedicated_allocation) {
+     memory_allocate_info_last->pNext = &memory_dedicated_allocate_info;

--- a/cmake/patches/rexglue_sdk_native_renderer.patch
+++ b/cmake/patches/rexglue_sdk_native_renderer.patch
@@ -1,3 +1,17 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 09ac897..7215a4b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -139,7 +139,8 @@ add_compile_definitions(REXGLUE_BUILD_CONFIG="$<CONFIG>")
+ include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/rex_version.cmake)
+ rex_resolve_version(REXGLUE_FULL_VERSION
+     FLOOR_MAJOR ${PROJECT_VERSION_MAJOR}
+-    FLOOR_MINOR ${PROJECT_VERSION_MINOR})
++    FLOOR_MINOR ${PROJECT_VERSION_MINOR}
++    SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+ 
+ # Strip the -id trailer (if any) for the numeric-only version.
+ string(REGEX REPLACE "-.*$" "" REXGLUE_NUMERIC_VERSION "${REXGLUE_FULL_VERSION}")
 diff --git a/include/rex/graphics/nativevk/command_processor.h b/include/rex/graphics/nativevk/command_processor.h
 new file mode 100644
 index 0000000..3469994

--- a/cmake/patches/xenosrecomp_native_renderer.patch
+++ b/cmake/patches/xenosrecomp_native_renderer.patch
@@ -1,0 +1,490 @@
+diff --git a/XenosRecomp/main.cpp b/XenosRecomp/main.cpp
+index d015145..5095081 100644
+--- a/XenosRecomp/main.cpp
++++ b/XenosRecomp/main.cpp
+@@ -115,7 +115,7 @@ int main(int argc, char** argv)
+ 
+         std::atomic<uint32_t> progress = 0;
+ 
+-        std::for_each(std::execution::par_unseq, shaders.begin(), shaders.end(), [&](auto& hashShaderPair)
++        std::for_each(std::execution::seq, shaders.begin(), shaders.end(), [&](auto& hashShaderPair)
+             {
+                 auto& shader = hashShaderPair.second;
+ 
+@@ -123,21 +123,61 @@ int main(int argc, char** argv)
+                 recompiler = {};
+                 recompiler.recompile(shader.data, include);
+ 
++                if (recompiler.hadError)
++                {
++                    fmt::println("Skipping shader {:X}: {}.", hashShaderPair.first, recompiler.hadErrorReason);
++                    return;
++                }
++
+                 shader.specConstantsMask = recompiler.specConstantsMask;
+ 
+                 thread_local DxcCompiler dxcCompiler;
+ 
+ #ifdef XENOS_RECOMP_DXIL
+                 shader.dxil = dxcCompiler.compile(recompiler.out, recompiler.isPixelShader, recompiler.specConstantsMask != 0, false);
+-                assert(shader.dxil != nullptr);
+-                assert(*(reinterpret_cast<uint32_t *>(shader.dxil->GetBufferPointer()) + 1) != 0 && "DXIL was not signed properly!");
++                if (shader.dxil == nullptr)
++                {
++                    fmt::println("Skipping shader {:X}: DXIL compile failed.", hashShaderPair.first);
++                    return;
++                }
++                if (*(reinterpret_cast<uint32_t *>(shader.dxil->GetBufferPointer()) + 1) == 0)
++                {
++                    fmt::println("Skipping shader {:X}: DXIL was not signed properly.", hashShaderPair.first);
++                    shader.dxil->Release();
++                    shader.dxil = nullptr;
++                    return;
++                }
+ #endif
+ 
+                 IDxcBlob* spirv = dxcCompiler.compile(recompiler.out, recompiler.isPixelShader, false, true);
+-                assert(spirv != nullptr);
++                if (spirv == nullptr)
++                {
++                    fmt::println("Skipping shader {:X}: SPIR-V compile failed.", hashShaderPair.first);
++#ifdef XENOS_RECOMP_DXIL
++                    if (shader.dxil != nullptr)
++                    {
++                        shader.dxil->Release();
++                        shader.dxil = nullptr;
++                    }
++#endif
++                    return;
++                }
+ 
+                 bool result = smolv::Encode(spirv->GetBufferPointer(), spirv->GetBufferSize(), shader.spirv, smolv::kEncodeFlagStripDebugInfo);
+-                assert(result);
++                if (!result)
++                {
++                    fmt::println("Skipping shader {:X}: smolv::Encode failed.", hashShaderPair.first);
++                    shader.spirv.clear();
++                    spirv->Release();
++#ifdef XENOS_RECOMP_DXIL
++                    if (shader.dxil != nullptr)
++                    {
++                        shader.dxil->Release();
++                        shader.dxil = nullptr;
++                    }
++#endif
++                    return;
++                }
+ 
+                 spirv->Release();
+ 
+@@ -157,6 +197,12 @@ int main(int argc, char** argv)
+ 
+         for (auto& [hash, shader] : shaders)
+         {
++            // A shader whose compile failed has an empty spirv vector (see
++            // the graceful-skip changes above) instead of crashing --
++            // must not emit a broken/empty cache entry for it.
++            if (shader.spirv.empty())
++                continue;
++
+             f.println("\t{{ 0x{:X}, {}, {}, {}, {}, {} }},",
+                 hash, dxil.size(), (shader.dxil != nullptr) ? shader.dxil->GetBufferSize() : 0, spirv.size(), shader.spirv.size(), shader.specConstantsMask);
+ 
+diff --git a/XenosRecomp/shader_common.h b/XenosRecomp/shader_common.h
+index 1c74034..b9028d6 100644
+--- a/XenosRecomp/shader_common.h
++++ b/XenosRecomp/shader_common.h
+@@ -26,10 +26,22 @@ struct PushConstants
+ 
+ [[vk::push_constant]] ConstantBuffer<PushConstants> g_PushConstants;
+ 
+-#define g_Booleans                 vk::RawBufferLoad<uint>(g_PushConstants.SharedConstants + 256)
+-#define g_SwappedTexcoords         vk::RawBufferLoad<uint>(g_PushConstants.SharedConstants + 260)
+-#define g_HalfPixelOffset          vk::RawBufferLoad<float2>(g_PushConstants.SharedConstants + 264)
+-#define g_AlphaThreshold           vk::RawBufferLoad<float>(g_PushConstants.SharedConstants + 272)
++// Real fix (2026-08-17): the Xenos boolean constant file is 256 bits, not 32
++// (XE_GPU_REG_SHADER_CONSTANT_BOOL_000_031 .. _224_255 = 8 dwords), with
++// vertex-shader booleans at 0-127 and pixel-shader booleans at 128-255.
++// Upstream modelled the whole file as a single uint with 16 bools per stage
++// and a +16 pixel offset, which cannot represent anything past bool 31 --
++// measured against this game, 1240 of 1531 converted pixel shaders branch on
++// booleans in the 129-254 range, so upstream emitted `1 << 259`-style shifts.
++// A shift >= the bit width is undefined in SPIR-V and is masked to 5 bits on
++// AMD, so those tests silently read unrelated low bits instead. Widened to the
++// real 8-dword file and indexed by the raw hardware bool address, which also
++// removes the need for upstream issue #17's "subtract 128 for pixel shaders"
++// workaround -- absolute addressing is correct for both stages by construction.
++#define g_BooleanWord(i)           vk::RawBufferLoad<uint>(g_PushConstants.SharedConstants + 256 + (i) * 4)
++#define g_SwappedTexcoords         vk::RawBufferLoad<uint>(g_PushConstants.SharedConstants + 288)
++#define g_HalfPixelOffset          vk::RawBufferLoad<float2>(g_PushConstants.SharedConstants + 292)
++#define g_AlphaThreshold           vk::RawBufferLoad<float>(g_PushConstants.SharedConstants + 300)
+ 
+ [[vk::constant_id(0)]] const uint g_SpecConstants = 0;
+ 
+@@ -37,11 +49,15 @@ struct PushConstants
+ 
+ #else
+ 
++// Mirrors the SPIR-V layout above: 8 boolean dwords occupy c16-c17 (bytes
++// 256-287), so the remaining shared fields start at c18 (byte 288).
+ #define DEFINE_SHARED_CONSTANTS() \
+-    uint g_Booleans : packoffset(c16.x); \
+-    uint g_SwappedTexcoords : packoffset(c16.y); \
+-    float2 g_HalfPixelOffset : packoffset(c16.z); \
+-    float g_AlphaThreshold : packoffset(c17.x);
++    uint4 g_BooleanWords[2] : packoffset(c16); \
++    uint g_SwappedTexcoords : packoffset(c18.x); \
++    float2 g_HalfPixelOffset : packoffset(c18.y); \
++    float g_AlphaThreshold : packoffset(c18.w);
++
++#define g_BooleanWord(i) g_BooleanWords[(i) / 4][(i) % 4]
+ 
+ uint g_SpecConstants();
+ 
+diff --git a/XenosRecomp/shader_recompiler.cpp b/XenosRecomp/shader_recompiler.cpp
+index 698a418..08837fa 100644
+--- a/XenosRecomp/shader_recompiler.cpp
++++ b/XenosRecomp/shader_recompiler.cpp
+@@ -74,6 +74,22 @@ struct DeclUsageLocation
+     uint32_t location;
+ };
+ 
++// Ceiling for positional vertex-input location assignment (see the long
++// comment at the [[vk::location]] emission site). Vulkan's guaranteed minimum
++// for maxVertexInputAttributes is 16, but real desktop drivers expose more --
++// 32 on the AMD/RADV target this was measured against, and the largest real
++// shader in this game needs 28. Shaders above this bail out gracefully rather
++// than emitting a pipeline the device cannot create; the host falls back to
++// the stock renderer for them. Raise only in step with a real device limit
++// check on the host side.
++static constexpr uint32_t maxVertexInputAttributes = 32;
++
++// SUPERSEDED (2026-08-17) but deliberately retained as documentation of what
++// upstream does: vertex input locations are no longer looked up here, they are
++// assigned positionally. See the [[vk::location]] emission site for the full
++// rationale and the two measured bugs this table caused for this game.
++// Referenced by nothing; kept so the diff against upstream stays legible.
++[[maybe_unused]]
+ // NOTE: These are specialized Vulkan locations for Unleashed Recompiled. Change as necessary. Likely not going to work with other games.
+ static constexpr DeclUsageLocation USAGE_LOCATIONS[] =
+ {
+@@ -115,7 +131,35 @@ static constexpr std::pair<DeclUsage, size_t> INTERPOLATORS[] =
+     { DeclUsage::TexCoord, 14 },
+     { DeclUsage::TexCoord, 15 },
+     { DeclUsage::Color, 0 },
+-    { DeclUsage::Color, 1 }
++    { DeclUsage::Color, 1 },
++    // Real fix (2026-08-17): upstream declared only TEXCOORD0-15 + COLOR0-1
++    // here, so a container declaring an interpolator with any other usage
++    // emitted a reference to a parameter that was never declared -- e.g.
++    // `oNormal0` / `iBinormal0` -- and failed to compile. 13 real shaders in
++    // this game hit that (10 vertex, 5 pixel, overlapping pairs).
++    //
++    // The entries below are measurement-driven, not guessed: they are exactly
++    // the non-TEXCOORD/COLOR interpolator usages observed across this game's
++    // captured shaders. Both stages declare this same fixed list in the same
++    // order, so any vertex shader still links against any pixel shader and
++    // DXC assigns matching locations on both sides.
++    //
++    // Bounds: 23 float4 varyings = 92 components, within the 128-component
++    // maxVertexOutputComponents / maxFragmentInputComponents floor.
++    //
++    // The principled fix is to drop usage names here entirely and link
++    // interpolators positionally by register index, exactly as the hardware
++    // does (see the vertex-input [[vk::location]] comment for the same
++    // argument). That is deliberately NOT done in this change: unlike the
++    // vertex-input case -- where a table miss was a hard compile failure, so
++    // switching could only help -- changing interpolator naming alters code
++    // generation for the 280 vertex / 1531 pixel shaders that already convert
++    // and render. It needs its own validated change, not a drive-by.
++    { DeclUsage::Normal, 0 },
++    { DeclUsage::Normal, 1 },
++    { DeclUsage::Normal, 2 },
++    { DeclUsage::Tangent, 0 },
++    { DeclUsage::Binormal, 0 }
+ };
+ 
+ static constexpr std::string_view TEXTURE_DIMENSIONS[] = 
+@@ -586,19 +630,44 @@ void ShaderRecompiler::recompile(const AluInstruction& instr)
+             {
+             case ExportRegister::PSColor0:
+                 exportRegister = "oC0";
+-                break;        
++                break;
+             case ExportRegister::PSColor1:
+                 exportRegister = "oC1";
+-                break;        
++                break;
+             case ExportRegister::PSColor2:
+                 exportRegister = "oC2";
+-                break;            
++                break;
+             case ExportRegister::PSColor3:
+                 exportRegister = "oC3";
+-                break;           
++                break;
+             case ExportRegister::PSDepth:
+                 exportRegister = "oDepth";
+                 break;
++            // Real fix (2026-08-17): ExportAddress/ExportData0-4 are Xenos
++            // memory-export (memexport) registers -- this recompiler has no
++            // codegen for them at all (confirmed against XenosRecomp's own
++            // upstream README, which lists "Memory export" as an explicitly
++            // unimplemented feature). Previously these writes silently fell
++            // through the switch as a no-op, so a memexport shader
++            // "compiled" while its real output (GPU-side skinning/particle/
++            // procedural data written to memory for a later pass to read)
++            // was completely discarded -- confirmed real: a game shader
++            // this project measured as memexport-using (vs_fccbd68e...,
++            // eM0 writer) was one of the shaders causing visible geometry
++            // corruption when run through the native pipeline. Bail out
++            // gracefully (matches hadError's own vertex-element-collision
++            // handling) instead of shipping a shader with silently-dropped
++            // output -- the caller falls back to the already-correct
++            // stock/translated renderer for these.
++            case ExportRegister::ExportAddress:
++            case ExportRegister::ExportData0:
++            case ExportRegister::ExportData1:
++            case ExportRegister::ExportData2:
++            case ExportRegister::ExportData3:
++            case ExportRegister::ExportData4:
++                hadError = true;
++                hadErrorReason = "memory export (eA/eM) is not supported by this recompiler";
++                return;
+             }
+         }
+         else
+@@ -623,10 +692,37 @@ void ShaderRecompiler::recompile(const AluInstruction& instr)
+ 
+                 break;
+ 
++            // Real fix (2026-08-17): see the identical case in the pixel-
++            // shader switch above for the full rationale -- memexport
++            // (ExportAddress/ExportData0-4) has no codegen in this
++            // recompiler at all, so these writes must bail out rather than
++            // silently vanish. This is the vertex-shader side, and matches
++            // this project's own measured data: every confirmed memexport
++            // shader captured from the real game so far has been a vertex
++            // shader (0 pixel shaders).
++            case ExportRegister::ExportAddress:
++            case ExportRegister::ExportData0:
++            case ExportRegister::ExportData1:
++            case ExportRegister::ExportData2:
++            case ExportRegister::ExportData3:
++            case ExportRegister::ExportData4:
++                hadError = true;
++                hadErrorReason = "memory export (eA/eM) is not supported by this recompiler";
++                return;
++
+             default:
+             {
+                 auto findResult = interpolators.find(instr.vectorDest);
+-                assert(findResult != interpolators.end());
++                if (findResult == interpolators.end())
++                {
++                    // Real defensive fallback (not just an assert-removal):
++                    // a container whose declared interpolator usage doesn't
++                    // cover every register this shader's own ALU code
++                    // writes to would otherwise hit undefined behavior here
++                    // (dereferencing map::end()) instead of a clean skip.
++                    exportRegister = "";
++                    break;
++                }
+                 exportRegister = findResult->second;
+                 break;
+             }
+@@ -1253,8 +1349,16 @@ void ShaderRecompiler::recompile(const uint8_t* shaderData, const std::string_vi
+ 
+         if (constantInfo->registerSet == RegisterSet::Bool)
+         {
++            // Real fix (2026-08-17, see shader_common.h's g_BooleanWord
++            // comment): was `(1 << registerIndex + (isPixelShader ? 16 : 0))`,
++            // which can only address 32 booleans and silently produced
++            // undefined out-of-range shifts for the 129-254 range this game
++            // actually uses. Now selects the real dword + bit out of the full
++            // 256-bit hardware boolean file. Emitted as a 0/1 value so the
++            // existing `(NAME) != 0` use sites keep working unchanged.
+             const char* constantName = reinterpret_cast<const char*>(constantTableData + constantInfo->name);
+-            println("\t#define {} (1 << {})", constantName, constantInfo->registerIndex + (isPixelShader ? 16 : 0));
++            uint32_t boolIndex = constantInfo->registerIndex;
++            println("\t#define {} ((g_BooleanWord({}) >> {}) & 1u)", constantName, boolIndex / 32, boolIndex % 32);
+             boolConstants.emplace(constantInfo->registerIndex, constantName);
+         }
+     }
+@@ -1302,6 +1406,7 @@ void ShaderRecompiler::recompile(const uint8_t* shaderData, const std::string_vi
+     else
+     {
+         auto vertexShader = reinterpret_cast<const VertexShader*>(shader);
++        bool seenUsageSemantics[256] = {};
+         for (uint32_t i = 0; i < vertexShader->vertexElementCount; i++)
+         {
+             union
+@@ -1312,6 +1417,23 @@ void ShaderRecompiler::recompile(const uint8_t* shaderData, const std::string_vi
+ 
+             value = vertexShader->vertexElementsAndInterpolators[vertexShader->field18 + i];
+ 
++            // Real fix (2026-08-17, see hadError's own header comment): two
++            // vertex elements sharing the same (usage, usageIndex) would
++            // otherwise both become a parameter named `i{usage}{usageIndex}`
++            // -- a real, confirmed-in-the-wild collision (a real captured
++            // game shader with 6 vfetch attributes, 5 of which decode to
++            // Position/0) that "compiles" but silently aliases/shadows real
++            // vertex data instead of erroring. Bail out gracefully instead
++            // of emitting HLSL that's structurally wrong.
++            uint32_t usageSemantic = (uint32_t(vertexElement.usage) << 4) | uint32_t(vertexElement.usageIndex);
++            if (seenUsageSemantics[usageSemantic])
++            {
++                hadError = true;
++                hadErrorReason = "duplicate vertex element usage/usageIndex (would produce colliding, identically-named HLSL parameters)";
++                return;
++            }
++            seenUsageSemantics[usageSemantic] = true;
++
+             const char* usageType = USAGE_TYPES[uint32_t(vertexElement.usage)];
+ 
+         #ifdef UNLEASHED_RECOMP
+@@ -1324,14 +1446,50 @@ void ShaderRecompiler::recompile(const uint8_t* shaderData, const std::string_vi
+ 
+             out += '\t';
+ 
+-            for (auto& usageLocation : USAGE_LOCATIONS)
++            // Real fix (2026-08-17): locations are now assigned POSITIONALLY
++            // -- location i for the i-th vertex element of this shader --
++            // instead of being looked up in USAGE_LOCATIONS.
++            //
++            // USAGE_LOCATIONS is upstream's own Unleashed-specific table and
++            // says so in its comment ("Likely not going to work with other
++            // games"). Two measured, real failures came from it here:
++            //
++            // 1. A table MISS emitted the parameter with no [[vk::location]]
++            //    at all, and DXC rejects PARTIAL explicit location assignment
++            //    outright -- killing the whole shader. This was 198 of 236
++            //    failing vertex shaders (84%), all of them needing only
++            //    POSITION2..12 / TEXCOORD8..12, which the table omits.
++            // 2. The table maps both (Position,1) and (TexCoord,7) to
++            //    location 15, so any shader using both silently aliases two
++            //    attributes onto one location. Not currently hit by any
++            //    converting shader (verified: 0 of 280), but it becomes a live
++            //    corruption source the moment the table is widened.
++            //
++            // Positional assignment is also the structurally correct model:
++            // Xenos vertex shaders pull their own data via vfetch, whose
++            // instruction encoding carries stride/offset/format directly, so
++            // the D3D9 usage semantic is a host-side fiction that never
++            // reaches the hardware. Routing vertex data through usage names
++            // converts a problem the microcode states outright (which element)
++            // into one that must be guessed (which semantic) -- and for this
++            // game those names ARE guesses: 0 of those 198 shaders have a real
++            // captured vertex declaration. Assigning by index makes a wrong
++            // NAME stop being a wrong BINDING.
++            //
++            // The host must derive its VkVertexInputAttributeDescription
++            // locations the same way -- see xenos_cache_unpack.cpp's
++            // ExtractVertexLocations(), which uses this identical ordering.
++            //
++            // Upstream's README recommends exactly this: "A generic solution
++            // would assign unique locations per vertex shader and dynamically
++            // create vertex declarations at runtime."
++            if (i >= maxVertexInputAttributes)
+             {
+-                if (usageLocation.usage == vertexElement.usage && usageLocation.usageIndex == vertexElement.usageIndex)
+-                {
+-                    print("[[vk::location({})]] ", usageLocation.location);
+-                    break;
+-                }
++                hadError = true;
++                hadErrorReason = "more vertex elements than Vulkan guarantees input locations";
++                return;
+             }
++            print("[[vk::location({})]] ", i);
+ 
+             println("in {0} i{1}{2} : {3}{2},", usageType, USAGE_VARIABLES[uint32_t(vertexElement.usage)],
+                 uint32_t(vertexElement.usageIndex), USAGE_SEMANTICS[uint32_t(vertexElement.usage)]);
+@@ -1418,7 +1576,24 @@ void ShaderRecompiler::recompile(const uint8_t* shaderData, const std::string_vi
+         out += "\n";
+     }
+ 
+-    bool printedRegisters[32]{};
++    // Real fix (2026-08-17): was 32. Xenos ALU source operands mask to six
++    // bits (see the `reg &= 0x3F` in this file's operand decoder), so the
++    // architectural register file is r0-r63. Declaring only r0-r31 meant any
++    // shader touching a higher register emitted an undeclared identifier.
++    //
++    // Measured: 15 real shaders hit this, all via r63 specifically, which is
++    // ExportRegister::VSPointSizeEdgeFlagKillVertex -- the vertex export
++    // switch has no case for it, so it falls through to the interpolator
++    // lookup, misses, and the generated code writes to r63 as a plain
++    // register. Point size has no meaning for the triangle draws this game
++    // uses and upstream lists it as unimplemented, so discarding the value
++    // into a now-declared dead local is correct here; DXC removes it. The
++    // important part is that it is discarded DELIBERATELY rather than by
++    // colliding with an undeclared name.
++    //
++    // Unused registers cost nothing: DXC eliminates the ones never read.
++    static constexpr size_t kNumRegisters = 64;
++    bool printedRegisters[kNumRegisters]{};
+ 
+     uint32_t interpolatorCount = (shader->interpolatorInfo >> 5) & 0x1F;
+ 
+@@ -1457,7 +1632,7 @@ void ShaderRecompiler::recompile(const uint8_t* shaderData, const std::string_vi
+         out += "\n";
+     }
+ 
+-    for (size_t i = 0; i < 32; i++)
++    for (size_t i = 0; i < kNumRegisters; i++)
+     {
+         if (!printedRegisters[i])
+         {
+@@ -1694,11 +1869,23 @@ void ShaderRecompiler::recompile(const uint8_t* shaderData, const std::string_vi
+                     }
+                     else
+                     {
+-                        auto findResult = boolConstants.find(cfInstr.condJmp.boolAddress);
+-                        if (findResult != boolConstants.end())
+-                            println("if ((g_Booleans & {}) {}= 0)", findResult->second, cfInstr.condJmp.condition ^ simpleControlFlow ? "!" : "=");
+-                        else
+-                            println("if (b{} {}= 0)", uint32_t(cfInstr.condJmp.boolAddress), cfInstr.condJmp.condition ^ simpleControlFlow ? "!" : "=");
++                        // Real fix (2026-08-17): index the real 256-bit
++                        // boolean file by the instruction's own absolute
++                        // boolAddress rather than looking up a name from the
++                        // constant table. Two real bugs go away at once:
++                        // (1) a container whose constant table does not name
++                        // this boolean used to emit a bare `b<N>` identifier
++                        // that was never declared -- a hard compile failure;
++                        // (2) upstream issue #17 ("pixel shader boolean
++                        // constants require 128 to be subtracted from
++                        // boolAddress") only exists because the old scheme
++                        // packed the two stages into one 32-bit word. The
++                        // hardware address is already absolute across both
++                        // stages, so using it directly is correct for vertex
++                        // and pixel shaders with no per-stage adjustment.
++                        uint32_t boolAddress = cfInstr.condJmp.boolAddress;
++                        println("if (((g_BooleanWord({}) >> {}) & 1u) {}= 0)", boolAddress / 32, boolAddress % 32,
++                            cfInstr.condJmp.condition ^ simpleControlFlow ? "!" : "=");
+                     }
+ 
+                     if (simpleControlFlow)
+diff --git a/XenosRecomp/shader_recompiler.h b/XenosRecomp/shader_recompiler.h
+index b2e317d..2364c0f 100644
+--- a/XenosRecomp/shader_recompiler.h
++++ b/XenosRecomp/shader_recompiler.h
+@@ -34,6 +34,19 @@ struct ShaderRecompiler : StringBuffer
+     std::unordered_map<uint32_t, uint32_t> ifEndLabels;
+     uint32_t specConstantsMask = 0;
+ 
++    // Real fix (2026-08-17): set when this shader's real vertex-element
++    // table can't be safely translated -- specifically when two elements
++    // share the same (usage, usageIndex) pair (XenosRecomp's own param
++    // generation loop names/decorates parameters purely by that pair, so a
++    // collision produces two identically-named `in float4 iPosition0`
++    // parameters, one of which silently shadows/aliases the other's real
++    // vertex data at a shared, ambiguous Vulkan location -- confirmed via a
++    // real captured game shader that compiled "successfully" but rendered
++    // corrupted geometry in-game). main.cpp checks this after recompile()
++    // and skips the shader gracefully instead of shipping a broken one.
++    bool hadError = false;
++    const char* hadErrorReason = "";
++
+ #ifdef UNLEASHED_RECOMP
+     bool hasMtxProjection = false;
+     bool hasMtxPrevInvViewProjection = false;

--- a/cmake/rexglue_xenosrecomp.cmake
+++ b/cmake/rexglue_xenosrecomp.cmake
@@ -9,14 +9,14 @@
 #     combined, real, compiled (SPIR-V) shader cache .cpp, for the
 #     "convert all the important shaders" effort. See tools/xenos_batch_convert.py
 #     for why this isn't just XenosRecomp's own directory-scan mode: 26/748
-#     real Banjo shaders segfault it outright (confirmed 2026-08-17), and its
+#     real Banjo shaders segfault it outright, and its
 #     directory driver has no per-shader crash recovery -- the batch script
 #     isolates each shader in its own subprocess so one crasher doesn't take
 #     down the whole cache.
 
 include(FetchContent)
 
-# Real, unpatched upstream bugs (confirmed 2026-08-16, see
+# Real, unpatched upstream bugs (confirmed see
 # renut_shader_conversion_blockers.md memory + cmake/patches/xenosrecomp_native_renderer.patch's
 # own header comment). Two real, independent fixes bundled in one patch:
 #
@@ -28,8 +28,8 @@ include(FetchContent)
 # means we learn NOTHING about why it failed -- just "crash", no stderr, no shader hash in the
 # message. This patch turns every one of those into a graceful, logged skip (shader hash + real
 # reason printed, shader simply omitted from the output cache) instead of a silent segfault --
-# real robustness fix, not upstream-reported (checked: zero related issues/PRs in
-# hedge-dev/XenosRecomp as of 2026-08-16).
+# not upstream-reported (checked: zero related issues/PRs in
+# hedge-dev/XenosRecomp).
 #
 # 2. XenosRecomp's combined multi-shader pass (main.cpp, std::execution::par_unseq over all
 # shaders) has a REAL, confirmed, deterministic concurrency bug: shaders that convert
@@ -49,7 +49,7 @@ include(FetchContent)
 # `git apply` on the second+ configure since the patch no longer applies cleanly to already-
 # patched source -- only apply when it actually still needs it.
 #
-# REAL BUG FOUND AND FIXED (2026-08-16): PATCH_COMMAND is executed directly via
+# REAL BUG FOUND AND FIXED: PATCH_COMMAND is executed directly via
 # execute_process, NOT through a shell -- so a bare command string containing
 # shell operators (&&, ||, 2>/dev/null) does NOT do conditional/redirection
 # logic. Every token, including "&&", "||", "git", "apply", etc., gets passed
@@ -59,7 +59,7 @@ include(FetchContent)
 # routing the whole idempotent-apply logic through `sh -c` so the shell
 # operators are interpreted as intended.
 #
-# 2026-08-17: xenosrecomp_native_renderer.patch SUPERSEDES the old
+# xenosrecomp_native_renderer.patch SUPERSEDES the old
 # xenosrecomp_graceful_skip.patch (deleted) -- it is that same patch's full
 # content PLUS this session's native-renderer fixes (256-bit boolean-constant
 # file instead of 1 dword; positional [[vk::location]] instead of the
@@ -67,7 +67,7 @@ include(FetchContent)
 # Normal/Tangent/Binormal; ALU register file 32 -> 64), captured via `git diff`
 # against the pristine FetchContent checkout and verified with `git apply
 # --check` against a fresh clone of the same upstream commit. See
-# docs/ai/history.md's "DONE (2026-08-17)" section for the full rationale and
+# docs/ai/history.md's "DONE" section for the full rationale and
 # measured before/after shader-conversion yield. Kept as ONE combined patch
 # file (not two applied in sequence) since PATCH_COMMAND's idempotent
 # check-then-apply logic only handles a single patch cleanly.
@@ -98,7 +98,7 @@ if(NOT TARGET xenos_cache_unpack)
     target_include_directories(xenos_cache_unpack PRIVATE
         "${CMAKE_SOURCE_DIR}/src"
         "${xenosrecomp_SOURCE_DIR}/thirdparty/smol-v/source"
-        # Real hash-remap fix (2026-08-16, see xenos_cache_unpack.cpp's
+        # Real hash-remap fix (see xenos_cache_unpack.cpp's
         # BuildHashRemap()): xxHash is header-only (XXH_INLINE_ALL), no new
         # link target needed -- reuses the same real xxHash copy XenosRecomp
         # itself was already fetched with, no separate dependency to manage.
@@ -148,7 +148,7 @@ endfunction()
 # renut_synthesize_constant_tables(SHADER_DUMP_DIR <dir> REXSDK_DIR <dir>
 #                                   OUTPUT_DIR <dir>)
 #
-# Real fix (2026-08-16): most captured Banjo-Kazooie shaders have
+# most captured Banjo-Kazooie shaders have
 # constantTableOffset == 0 in their real container header -- the game's
 # build stripped the D3DX9 constant-reflection table XenosRecomp needs (see
 # XenosRecomp's own README: "If this data is missing, the recompiler will
@@ -247,7 +247,7 @@ endfunction()
 # renut_synthesize_containers_from_ucode(UCODE_DIR <dir> REXSDK_DIR <dir>
 #                                         OUTPUT_DIR <dir>)
 #
-# Real fix (2026-08-16): this game's MOST-USED shaders never call D3D9's
+# this game's MOST-USED shaders never call D3D9's
 # CreateVertexShader/CreatePixelShader at all -- they're loaded directly
 # into GPU sequencer memory via IM_LOAD/IM_LOAD_IMMEDIATE PM4 packets
 # (confirmed via direct source investigation and cross-referenced against
@@ -274,7 +274,7 @@ endfunction()
 # regardless of origin, so both sources merge into one real, combined
 # shader pool for the batch converter below to process together.
 #
-# Real follow-up finding (2026-08-16, same session): 1590/2143 shaders from
+# Real follow-up finding (same session): 1590/2143 shaders from
 # this path DID convert and DID render natively in-game (confirmed via
 # real `native pipeline: ... created` log lines, 148 distinct pairs) --
 # but with real, visible geometry corruption, because real D3D9 vertex-
@@ -338,7 +338,7 @@ function(renut_synthesize_containers_from_ucode)
     set(_stamp "${ARG_OUTPUT_DIR}/.ucode_synthesized_stamp")
 
     file(GLOB _ucode_files "${ARG_UCODE_DIR}/*.ucode")
-    # Real bug found+fixed 2026-08-17: build_synthetic_container.py reads
+    # build_synthetic_container.py reads
     # real captured vertex-declaration usage from
     # <ucode_dir>/../shaders_vertdecl/vs_<hash>.vertdecl.txt when present
     # (see its own --vertdecl-dir default), but this DEPENDS list never
@@ -356,7 +356,7 @@ function(renut_synthesize_containers_from_ucode)
                 "${ARG_UCODE_DIR}"
                 "${ARG_OUTPUT_DIR}"
                 $<TARGET_FILE:ucode_analyze>
-                # TEMP (2026-08-16): --reject-heuristic disabled to isolate
+                # TEMP: --reject-heuristic disabled to isolate
                 # the remaining live-native-shader corruption bug (confirmed
                 # NOT the location bug, NOT native/stock mixing -- see
                 # memory). RE-ENABLE once the real cause is found+fixed or
@@ -401,7 +401,7 @@ function(renut_xenos_shader_batch target_name)
     set(_common_header "${xenosrecomp_SOURCE_DIR}/XenosRecomp/shader_common.h")
     set(_batch_script "${CMAKE_SOURCE_DIR}/tools/xenos_batch_convert.py")
 
-    # Real hash-remap fix (2026-08-16): XenosRecomp's own cache-entry hash
+    # Real hash-remap fix: XenosRecomp's own cache-entry hash
     # is NOT the same value the Vulkan pipeline cache looks shaders up by at
     # runtime -- see xenos_cache_unpack.cpp's BuildHashRemap() for the full
     # explanation. This file carries the real data stage 2 needs to fix it.
@@ -428,7 +428,7 @@ function(renut_xenos_shader_batch target_name)
     # Also produces _remap_file (see above) as a second real output.
     set(_compressed_cache "${ARG_OUTPUT}.compressed.cpp")
 
-    # Real bug found+fixed 2026-08-16: DEPENDS never listed the actual
+    # DEPENDS never listed the actual
     # shader dump directory's CONTENTS, only the tool/header/script -- so
     # ninja had no way to know new/changed .bin files should trigger a
     # rebuild, and correctly (from its own point of view) reported "no work

--- a/cmake/rexglue_xenosrecomp.cmake
+++ b/cmake/rexglue_xenosrecomp.cmake
@@ -1,0 +1,473 @@
+# rexglue_xenosrecomp.cmake — build-time Xenos shader microcode -> HLSL/SPIR-V
+# for the native-renderer effort (see docs/ai/research.md Phase 0 item 3/4
+# and Phase 1).
+#
+# Fetches hedge-dev/XenosRecomp as a host tool. Two entry points:
+#   - renut_xenos_shader(): single named shader -> plain HLSL text, for
+#     hand-inspection/Phase-1-style one-off integration.
+#   - renut_xenos_shader_batch(): a whole guest shader dump directory -> one
+#     combined, real, compiled (SPIR-V) shader cache .cpp, for the
+#     "convert all the important shaders" effort. See tools/xenos_batch_convert.py
+#     for why this isn't just XenosRecomp's own directory-scan mode: 26/748
+#     real Banjo shaders segfault it outright (confirmed 2026-08-17), and its
+#     directory driver has no per-shader crash recovery -- the batch script
+#     isolates each shader in its own subprocess so one crasher doesn't take
+#     down the whole cache.
+
+include(FetchContent)
+
+# Real, unpatched upstream bugs (confirmed 2026-08-16, see
+# renut_shader_conversion_blockers.md memory + cmake/patches/xenosrecomp_native_renderer.patch's
+# own header comment). Two real, independent fixes bundled in one patch:
+#
+# 1. XenosRecomp's main.cpp guards every DXC compile result with a bare
+# assert() and no null-check, so ANY failed HLSL compile (missing interpolator semantic, DXC
+# rejecting the generated code, etc -- any reason at all) segfaults the whole XenosRecomp process
+# instead of skipping that one shader. Our own batch driver (tools/xenos_batch_convert.py) already
+# isolates each shader in its own subprocess specifically to survive this, but a crash there still
+# means we learn NOTHING about why it failed -- just "crash", no stderr, no shader hash in the
+# message. This patch turns every one of those into a graceful, logged skip (shader hash + real
+# reason printed, shader simply omitted from the output cache) instead of a silent segfault --
+# real robustness fix, not upstream-reported (checked: zero related issues/PRs in
+# hedge-dev/XenosRecomp as of 2026-08-16).
+#
+# 2. XenosRecomp's combined multi-shader pass (main.cpp, std::execution::par_unseq over all
+# shaders) has a REAL, confirmed, deterministic concurrency bug: shaders that convert
+# successfully in isolation can silently fail (with fix 1 above, gracefully -- without it,
+# crash) when compiled in parallel alongside hundreds of others. Confirmed via direct
+# bisection: the exact same shader set run under std::execution::seq instead converts 100%
+# successfully (0 failures across 2135 real shaders, ~50s total), while par_unseq
+# deterministically drops the same ~450 shaders on every repeated run with identical input --
+# ruling out a resource-exhaustion fluke or true data race, and pointing at real DXC-internal
+# or thread_local state that isn't safe across concurrent DxcCompiler instances despite each
+# thread owning its own. Not root-caused further (DXC's own internals, out of scope to debug
+# here) -- switched to std::execution::seq instead, a real, verified, safe fix: one-time
+# build-step cost, not a hot path, and 50s for ~2100 shaders is a fully acceptable trade for
+# 100% correctness over a silent ~20% loss.
+# git apply --check first (idempotent): a fresh clone needs the patch; an already-configured
+# build tree (FetchContent skips re-cloning if the source dir already exists) would fail a bare
+# `git apply` on the second+ configure since the patch no longer applies cleanly to already-
+# patched source -- only apply when it actually still needs it.
+#
+# REAL BUG FOUND AND FIXED (2026-08-16): PATCH_COMMAND is executed directly via
+# execute_process, NOT through a shell -- so a bare command string containing
+# shell operators (&&, ||, 2>/dev/null) does NOT do conditional/redirection
+# logic. Every token, including "&&", "||", "git", "apply", etc., gets passed
+# as a literal argv entry to the FIRST command (git), which git then rejects
+# or silently misinterprets -- so the patch was NEVER actually applied by this
+# line despite `git apply --check` succeeding when run by hand. Fixed by
+# routing the whole idempotent-apply logic through `sh -c` so the shell
+# operators are interpreted as intended.
+#
+# 2026-08-17: xenosrecomp_native_renderer.patch SUPERSEDES the old
+# xenosrecomp_graceful_skip.patch (deleted) -- it is that same patch's full
+# content PLUS this session's native-renderer fixes (256-bit boolean-constant
+# file instead of 1 dword; positional [[vk::location]] instead of the
+# Unleashed-specific USAGE_LOCATIONS table; INTERPOLATORS extended with
+# Normal/Tangent/Binormal; ALU register file 32 -> 64), captured via `git diff`
+# against the pristine FetchContent checkout and verified with `git apply
+# --check` against a fresh clone of the same upstream commit. See
+# docs/ai/history.md's "DONE (2026-08-17)" section for the full rationale and
+# measured before/after shader-conversion yield. Kept as ONE combined patch
+# file (not two applied in sequence) since PATCH_COMMAND's idempotent
+# check-then-apply logic only handles a single patch cleanly.
+FetchContent_Declare(
+    xenosrecomp
+    GIT_REPOSITORY https://github.com/hedge-dev/XenosRecomp.git
+    GIT_TAG main
+    GIT_SUBMODULES_RECURSE ON
+    PATCH_COMMAND sh -c "git apply --check '${CMAKE_CURRENT_LIST_DIR}/patches/xenosrecomp_native_renderer.patch' 2>/dev/null && git apply '${CMAKE_CURRENT_LIST_DIR}/patches/xenosrecomp_native_renderer.patch' || true"
+)
+FetchContent_MakeAvailable(xenosrecomp)
+
+# xenos_cache_unpack: decompresses XenosRecomp's own generated shader-cache
+# .cpp (ZSTD-compressed, smol-v-encoded SPIR-V) into plain uint32_t SPIR-V
+# words at BUILD TIME, so rexgpu-renut (a separate CMake build from reNut's
+# own executable, the only place these FetchContent-provided zstd/smol-v
+# targets exist) never needs to link zstd or smol-v itself. See
+# tools/xenos_cache_unpack.cpp for the full rationale.
+if(NOT TARGET xenos_cache_unpack)
+    # smol-v has no CMake target of its own -- XenosRecomp's own build
+    # compiles smolv.cpp directly into its executable's sources (see
+    # XenosRecomp/CMakeLists.txt's SMOLV_SOURCE_DIR use), so this does the
+    # same rather than inventing a target that doesn't exist upstream.
+    add_executable(xenos_cache_unpack
+        "${CMAKE_SOURCE_DIR}/tools/xenos_cache_unpack.cpp"
+        "${xenosrecomp_SOURCE_DIR}/thirdparty/smol-v/source/smolv.cpp"
+    )
+    target_include_directories(xenos_cache_unpack PRIVATE
+        "${CMAKE_SOURCE_DIR}/src"
+        "${xenosrecomp_SOURCE_DIR}/thirdparty/smol-v/source"
+        # Real hash-remap fix (2026-08-16, see xenos_cache_unpack.cpp's
+        # BuildHashRemap()): xxHash is header-only (XXH_INLINE_ALL), no new
+        # link target needed -- reuses the same real xxHash copy XenosRecomp
+        # itself was already fetched with, no separate dependency to manage.
+        "${xenosrecomp_SOURCE_DIR}/thirdparty/xxHash"
+    )
+    target_link_libraries(xenos_cache_unpack PRIVATE libzstd_static)
+endif()
+
+# renut_xenos_shader(<target> INPUT <shader.bin> OUTPUT <shader.hlsl>)
+#
+# Wires a custom command that runs XenosRecomp in single-file mode against
+# INPUT (one shader's .bin dump, e.g. from shader_dump.cpp's
+# `dump_guest_shaders` capture) and produces OUTPUT as plain HLSL text (NOT a
+# compiled shader-cache .cpp — this is source for inspection/Phase-1 hand
+# integration, not something to add to <target>'s sources directly). No-ops
+# (with a status message, not an error) if INPUT does not exist at configure
+# time, since the guest shader dump this depends on is opt-in runtime capture,
+# never checked into the repo.
+function(renut_xenos_shader target_name)
+    cmake_parse_arguments(ARG "" "INPUT;OUTPUT" "" ${ARGN})
+
+    if(NOT EXISTS "${ARG_INPUT}")
+        message(STATUS
+            "renut_xenos_shader: '${ARG_INPUT}' not found, skipping "
+            "(run with -Ddump_guest_shaders=true once to produce a shader "
+            "dump, then reconfigure).")
+        return()
+    endif()
+
+    set(_common_header "${xenosrecomp_SOURCE_DIR}/XenosRecomp/shader_common.h")
+
+    add_custom_command(
+        OUTPUT "${ARG_OUTPUT}"
+        COMMAND $<TARGET_FILE:XenosRecomp>
+                "${ARG_INPUT}"
+                "${ARG_OUTPUT}"
+                "${_common_header}"
+        DEPENDS XenosRecomp "${_common_header}" "${ARG_INPUT}"
+        COMMENT "Recompiling guest shader ${ARG_INPUT} via XenosRecomp"
+        VERBATIM
+    )
+
+    add_custom_target(${target_name}_xenos_shader DEPENDS "${ARG_OUTPUT}")
+    add_dependencies(${target_name} ${target_name}_xenos_shader)
+endfunction()
+
+# renut_synthesize_constant_tables(SHADER_DUMP_DIR <dir> REXSDK_DIR <dir>
+#                                   OUTPUT_DIR <dir>)
+#
+# Real fix (2026-08-16): most captured Banjo-Kazooie shaders have
+# constantTableOffset == 0 in their real container header -- the game's
+# build stripped the D3DX9 constant-reflection table XenosRecomp needs (see
+# XenosRecomp's own README: "If this data is missing, the recompiler will
+# not function"), NOT a capture bug on reNut's side (confirmed via direct
+# comparison against XenosRecomp's own shader_recompiler.cpp, which asserts
+# constantTableOffset != NULL and reads real D3DXSHADER_CONSTANTTABLE data
+# from it). tools/xenos_synthesize_constant_table.py fixes this by
+# synthesizing a real, valid constant table from what the SDK's OWN
+# Shader::AnalyzeUcode already knows about each shader (which float4
+# registers and samplers it actually reads) -- verified end-to-end to raise
+# real XenosRecomp conversion success from 36/253 to 101/253 real captured
+# shaders. Two real SDK-side bugs had to be fixed to make AnalyzeUcode
+# itself trustworthy first (see rexglue-sdk-src's translator.cpp/
+# translator_disasm.cpp changes, same date): a control-flow-bound
+# computation that silently produced empty analysis for shaders with
+# zero-count trailing exec instructions, and a debug-disassembly crash on
+# vertex formats outside this codebase's currently-modeled xenos::VertexFormat
+# enum.
+#
+# Builds tools/ucode_analyze.cpp as a real CMake executable (same real SDK
+# source list as tools/build_ucode_analyze.sh, kept in sync manually -- see
+# that script's own comment on how the list was derived) linked against
+# REXSDK_DIR, then runs the synthesis script against a COPY of
+# SHADER_DUMP_DIR under OUTPUT_DIR (never mutates the real capture in
+# place) every configure. No-ops if SHADER_DUMP_DIR doesn't exist yet,
+# matching renut_xenos_shader_batch()'s own behavior.
+function(renut_synthesize_constant_tables)
+    cmake_parse_arguments(ARG "" "SHADER_DUMP_DIR;REXSDK_DIR;OUTPUT_DIR" "" ${ARGN})
+
+    if(NOT EXISTS "${ARG_SHADER_DUMP_DIR}")
+        message(STATUS
+            "renut_synthesize_constant_tables: '${ARG_SHADER_DUMP_DIR}' not "
+            "found, skipping.")
+        return()
+    endif()
+
+    find_package(Python3 COMPONENTS Interpreter REQUIRED)
+
+    if(NOT TARGET ucode_analyze)
+        set(_sdk "${ARG_REXSDK_DIR}")
+        add_executable(ucode_analyze
+            "${CMAKE_SOURCE_DIR}/tools/ucode_analyze.cpp"
+            "${_sdk}/src/graphics/pipeline/shader/shader.cpp"
+            "${_sdk}/src/graphics/pipeline/shader/translator.cpp"
+            "${_sdk}/src/graphics/pipeline/shader/translator_disasm.cpp"
+            "${_sdk}/src/graphics/format/ucode.cpp"
+            "${_sdk}/src/core/string_buffer.cpp"
+            "${_sdk}/src/core/logging.cpp"
+            "${_sdk}/src/core/cvar.cpp"
+            "${_sdk}/src/core/memory.cpp"
+            "${_sdk}/src/core/filesystem_posix.cpp"
+            "${_sdk}/src/core/platform/env_posix.cpp"
+            "${_sdk}/src/core/utf8.cpp"
+            "${_sdk}/thirdparty/fmt/src/format.cc"
+            "${_sdk}/thirdparty/fmt/src/os.cc"
+        )
+        target_include_directories(ucode_analyze PRIVATE
+            "${_sdk}/include" "${_sdk}"
+            "${_sdk}/thirdparty/spdlog/include" "${_sdk}/thirdparty/fmt/include"
+            "${_sdk}/thirdparty/simde" "${_sdk}/thirdparty/tomlplusplus/include"
+            "${_sdk}/thirdparty/cli11/include" "${_sdk}/thirdparty/xxHash"
+            "${_sdk}/thirdparty/renderdoc" "${_sdk}/thirdparty/utfcpp/source"
+        )
+        target_compile_definitions(ucode_analyze PRIVATE SPDLOG_FMT_EXTERNAL)
+        target_compile_options(ucode_analyze PRIVATE -mssse3)
+    endif()
+
+    set(_synth_script "${CMAKE_SOURCE_DIR}/tools/xenos_synthesize_constant_table.py")
+    set(_synth_manifest "${ARG_OUTPUT_DIR}/synthesize_constant_tables_manifest.txt")
+    set(_stamp "${ARG_OUTPUT_DIR}/.synthesized_stamp")
+
+    # Real copy-then-patch, not in-place: OUTPUT_DIR is a build-tree scratch
+    # location the batch converter below reads from, so the user's actual
+    # captured shaders/ (which may be reused across many rebuilds/games)
+    # never gets mutated. glob_recurse rather than a fixed file list since
+    # the real shader count varies run to run as more play sessions add
+    # captures.
+    file(GLOB _dump_files "${ARG_SHADER_DUMP_DIR}/*")
+    add_custom_command(
+        OUTPUT "${_stamp}"
+        COMMAND ${CMAKE_COMMAND} -E rm -rf "${ARG_OUTPUT_DIR}"
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${ARG_OUTPUT_DIR}"
+        COMMAND ${CMAKE_COMMAND} -E copy_directory "${ARG_SHADER_DUMP_DIR}" "${ARG_OUTPUT_DIR}"
+        COMMAND ${Python3_EXECUTABLE} "${_synth_script}"
+                $<TARGET_FILE:ucode_analyze>
+                "${ARG_OUTPUT_DIR}"
+                "${_synth_manifest}"
+        COMMAND ${CMAKE_COMMAND} -E touch "${_stamp}"
+        DEPENDS ucode_analyze "${_synth_script}" ${_dump_files}
+        COMMENT "Synthesizing missing constant tables for real captured shaders in ${ARG_SHADER_DUMP_DIR}"
+        VERBATIM
+    )
+    add_custom_target(renut_synthesize_constant_tables_target DEPENDS "${_stamp}")
+endfunction()
+
+# renut_synthesize_containers_from_ucode(UCODE_DIR <dir> REXSDK_DIR <dir>
+#                                         OUTPUT_DIR <dir>)
+#
+# Real fix (2026-08-16): this game's MOST-USED shaders never call D3D9's
+# CreateVertexShader/CreatePixelShader at all -- they're loaded directly
+# into GPU sequencer memory via IM_LOAD/IM_LOAD_IMMEDIATE PM4 packets
+# (confirmed via direct source investigation and cross-referenced against
+# real capture data: 0% overlap between shader_dump.cpp's D3D9-hook
+# captures and real `renut color draw pair` live draw identities, across
+# 1471 distinct real drawn shader hashes). shader_dump.cpp's hook
+# structurally can never see these, regardless of capture timing/coverage.
+#
+# Real, raw microcode for these IS available via the separate
+# renut_dump_ucode_hash cvar (shaders_ucode_hash/<vs|ps>_<hash>.ucode,
+# keyed by the real runtime ucode_data_hash()), just missing the
+# ShaderContainer metadata (constantTableOffset, vertex elements,
+# interpolators) XenosRecomp needs. tools/build_synthetic_container.py
+# (existing tool, generalized this session to include real float/sampler/
+# bool constant tables -- previously left them empty, causing 100% failure)
+# rebuilds a full, real container per .ucode file using the SDK's own
+# Shader::AnalyzeUcode(). Verified end-to-end: 1492/1884 real captured
+# shaders from this path convert successfully (vs ~12 before the constant-
+# table fix), a MUCH larger and more relevant pool than the D3D9-hook
+# capture's 101/253 -- these are the game's actual most-drawn shaders.
+#
+# Writes into OUTPUT_DIR, same directory renut_synthesize_constant_tables()
+# uses -- xenos_batch_convert.py scans generically for *.bin containers
+# regardless of origin, so both sources merge into one real, combined
+# shader pool for the batch converter below to process together.
+#
+# Real follow-up finding (2026-08-16, same session): 1590/2143 shaders from
+# this path DID convert and DID render natively in-game (confirmed via
+# real `native pipeline: ... created` log lines, 148 distinct pairs) --
+# but with real, visible geometry corruption, because real D3D9 vertex-
+# declaration capture is ALSO unavailable for these shaders (same IM_LOAD
+# root cause -- SetVertexShader/SetVertexDeclaration never fire either),
+# so every vertex shader here falls back to build_synthetic_container.py's
+# POSITION-first/TEXCOORD-follows heuristic, which is only verified
+# correct for the one shader it was originally built against. Passing
+# --reject-heuristic below trades shader-count for correctness: only
+# vertex shaders whose semantics didn't need guessing (currently: none
+# have a real captured declaration, so in practice this means "only
+# non-vertex-shader-having pixel shaders, plus any vertex shader trivial
+# enough to need zero non-position attributes" survive) go into the real
+# cache. Revisit if/when real vertex-declaration capture becomes possible
+# for these shaders (would need a different mechanism entirely, not a fix
+# to the existing SetVertexDeclaration hook -- see this session's own
+# finding that hook structurally cannot see these shaders either).
+function(renut_synthesize_containers_from_ucode)
+    cmake_parse_arguments(ARG "" "UCODE_DIR;REXSDK_DIR;OUTPUT_DIR" "" ${ARGN})
+
+    if(NOT EXISTS "${ARG_UCODE_DIR}")
+        message(STATUS
+            "renut_synthesize_containers_from_ucode: '${ARG_UCODE_DIR}' not "
+            "found, skipping (run with -Drenut_dump_ucode_hash=true and play "
+            "for a while, then reconfigure).")
+        return()
+    endif()
+
+    find_package(Python3 COMPONENTS Interpreter REQUIRED)
+
+    if(NOT TARGET ucode_analyze)
+        set(_sdk "${ARG_REXSDK_DIR}")
+        add_executable(ucode_analyze
+            "${CMAKE_SOURCE_DIR}/tools/ucode_analyze.cpp"
+            "${_sdk}/src/graphics/pipeline/shader/shader.cpp"
+            "${_sdk}/src/graphics/pipeline/shader/translator.cpp"
+            "${_sdk}/src/graphics/pipeline/shader/translator_disasm.cpp"
+            "${_sdk}/src/graphics/format/ucode.cpp"
+            "${_sdk}/src/core/string_buffer.cpp"
+            "${_sdk}/src/core/logging.cpp"
+            "${_sdk}/src/core/cvar.cpp"
+            "${_sdk}/src/core/memory.cpp"
+            "${_sdk}/src/core/filesystem_posix.cpp"
+            "${_sdk}/src/core/platform/env_posix.cpp"
+            "${_sdk}/src/core/utf8.cpp"
+            "${_sdk}/thirdparty/fmt/src/format.cc"
+            "${_sdk}/thirdparty/fmt/src/os.cc"
+        )
+        target_include_directories(ucode_analyze PRIVATE
+            "${_sdk}/include" "${_sdk}"
+            "${_sdk}/thirdparty/spdlog/include" "${_sdk}/thirdparty/fmt/include"
+            "${_sdk}/thirdparty/simde" "${_sdk}/thirdparty/tomlplusplus/include"
+            "${_sdk}/thirdparty/cli11/include" "${_sdk}/thirdparty/xxHash"
+            "${_sdk}/thirdparty/renderdoc" "${_sdk}/thirdparty/utfcpp/source"
+        )
+        target_compile_definitions(ucode_analyze PRIVATE SPDLOG_FMT_EXTERNAL)
+        target_compile_options(ucode_analyze PRIVATE -mssse3)
+    endif()
+
+    set(_batch_script "${CMAKE_SOURCE_DIR}/tools/batch_build_synthetic_containers.py")
+    set(_stamp "${ARG_OUTPUT_DIR}/.ucode_synthesized_stamp")
+
+    file(GLOB _ucode_files "${ARG_UCODE_DIR}/*.ucode")
+    # Real bug found+fixed 2026-08-17: build_synthetic_container.py reads
+    # real captured vertex-declaration usage from
+    # <ucode_dir>/../shaders_vertdecl/vs_<hash>.vertdecl.txt when present
+    # (see its own --vertdecl-dir default), but this DEPENDS list never
+    # included those files -- so after fixing the capture hook and
+    # recapturing real .vertdecl.txt data by playing, a rebuild would keep
+    # using the STALE synthesized containers (heuristic-only) because
+    # CMake had no reason to think anything changed. Glob them in so new/
+    # changed real captures actually trigger a re-synthesis.
+    get_filename_component(_vertdecl_dir "${ARG_UCODE_DIR}/../shaders_vertdecl" ABSOLUTE)
+    file(GLOB _vertdecl_files "${_vertdecl_dir}/*.vertdecl.txt")
+    add_custom_command(
+        OUTPUT "${_stamp}"
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${ARG_OUTPUT_DIR}"
+        COMMAND ${Python3_EXECUTABLE} "${_batch_script}"
+                "${ARG_UCODE_DIR}"
+                "${ARG_OUTPUT_DIR}"
+                $<TARGET_FILE:ucode_analyze>
+                # TEMP (2026-08-16): --reject-heuristic disabled to isolate
+                # the remaining live-native-shader corruption bug (confirmed
+                # NOT the location bug, NOT native/stock mixing -- see
+                # memory). RE-ENABLE once the real cause is found+fixed or
+                # this investigation is done for the session.
+        COMMAND ${CMAKE_COMMAND} -E touch "${_stamp}"
+        DEPENDS ucode_analyze "${_batch_script}"
+                "${CMAKE_SOURCE_DIR}/tools/build_synthetic_container.py" ${_ucode_files} ${_vertdecl_files}
+        COMMENT "Synthesizing full shader containers from real ucode-only captures in ${ARG_UCODE_DIR}"
+        VERBATIM
+    )
+    add_custom_target(renut_synthesize_containers_from_ucode_target DEPENDS "${_stamp}")
+endfunction()
+
+# renut_xenos_shader_batch(<target> SHADER_DUMP_DIR <dir> OUTPUT <cache.cpp>
+#                           [MANIFEST <manifest.txt>])
+#
+# Converts every real guest shader in SHADER_DUMP_DIR (reNut's
+# `dump_guest_shaders` output) to compiled SPIR-V via XenosRecomp, using
+# tools/xenos_batch_convert.py to isolate each shader in its own subprocess
+# so crashing shaders are skipped instead of aborting the whole run. OUTPUT
+# is XenosRecomp's own generated shader-cache C++ (ShaderCacheEntry table +
+# compressed SPIR-V blob) built from only the shaders that converted
+# successfully -- add it to <target>'s sources yourself if/when a consumer
+# for the combined cache exists; this function only produces the file.
+#
+# No-ops (status message, not an error) if SHADER_DUMP_DIR does not exist at
+# configure time, matching renut_xenos_shader()'s behavior -- the shader dump
+# is opt-in runtime capture, never checked into the repo.
+function(renut_xenos_shader_batch target_name)
+    cmake_parse_arguments(ARG "" "SHADER_DUMP_DIR;OUTPUT;MANIFEST" "" ${ARGN})
+
+    if(NOT EXISTS "${ARG_SHADER_DUMP_DIR}")
+        message(STATUS
+            "renut_xenos_shader_batch: '${ARG_SHADER_DUMP_DIR}' not found, "
+            "skipping (run with -Ddump_guest_shaders=true and play for a "
+            "while to produce a real shader dump, then reconfigure).")
+        return()
+    endif()
+
+    find_package(Python3 COMPONENTS Interpreter REQUIRED)
+
+    set(_common_header "${xenosrecomp_SOURCE_DIR}/XenosRecomp/shader_common.h")
+    set(_batch_script "${CMAKE_SOURCE_DIR}/tools/xenos_batch_convert.py")
+
+    # Real hash-remap fix (2026-08-16): XenosRecomp's own cache-entry hash
+    # is NOT the same value the Vulkan pipeline cache looks shaders up by at
+    # runtime -- see xenos_cache_unpack.cpp's BuildHashRemap() for the full
+    # explanation. This file carries the real data stage 2 needs to fix it.
+    # Always requested (not optional) since the fix is meaningless without
+    # it -- a missing MANIFEST is fine (it's diagnostic-only), a missing
+    # remap file means every entry silently keeps the wrong hash again.
+    set(_remap_file "${ARG_OUTPUT}.hashremap.bin")
+
+    # xenos_batch_convert.py's remap file is always its LAST positional
+    # argument (see its own usage docstring); MANIFEST must always be given
+    # a real value here (even if the caller didn't request one) so an empty
+    # ARG_MANIFEST can't shift the remap file into the manifest's slot --
+    # CMake command lists silently drop empty-string list elements, which
+    # would otherwise be a real, easy-to-hit positional-argument bug.
+    set(_manifest_arg "${ARG_OUTPUT}.manifest.txt")
+    if(ARG_MANIFEST)
+        set(_manifest_arg "${ARG_MANIFEST}")
+    endif()
+
+    # Stage 1: xenos_batch_convert.py produces XenosRecomp's OWN generated
+    # cache format (ShaderCacheEntry table + ZSTD-compressed smol-v SPIR-V) —
+    # written to a scratch file, not ARG_OUTPUT directly, since stage 2
+    # rewrites it into the plain/decompressed form ARG_OUTPUT actually is.
+    # Also produces _remap_file (see above) as a second real output.
+    set(_compressed_cache "${ARG_OUTPUT}.compressed.cpp")
+
+    # Real bug found+fixed 2026-08-16: DEPENDS never listed the actual
+    # shader dump directory's CONTENTS, only the tool/header/script -- so
+    # ninja had no way to know new/changed .bin files should trigger a
+    # rebuild, and correctly (from its own point of view) reported "no work
+    # to do" even after the synthesis steps above populated
+    # SHADER_DUMP_DIR with 1000+ new real containers. Real symptom: two full
+    # reconfigures in a row both produced this, since nothing about
+    # XenosRecomp/common_header/batch_script itself had changed -- only the
+    # shader files had. glob_recurse (not a fixed list) since the real
+    # shader count varies build to build as more captures/synthesis runs
+    # add files.
+    file(GLOB_RECURSE _shader_dump_files "${ARG_SHADER_DUMP_DIR}/*")
+
+    add_custom_command(
+        OUTPUT "${_compressed_cache}" "${_remap_file}"
+        COMMAND ${Python3_EXECUTABLE} "${_batch_script}"
+                $<TARGET_FILE:XenosRecomp>
+                "${ARG_SHADER_DUMP_DIR}"
+                "${_common_header}"
+                "${_compressed_cache}"
+                "${_manifest_arg}"
+                "${_remap_file}"
+        DEPENDS XenosRecomp "${_common_header}" "${_batch_script}" ${_shader_dump_files}
+        COMMENT "Batch-converting guest shaders in ${ARG_SHADER_DUMP_DIR} via XenosRecomp (crash-isolated per shader)"
+        VERBATIM
+    )
+
+    # Stage 2: xenos_cache_unpack decompresses the stage-1 output into plain
+    # uint32_t SPIR-V words, so <target> (rexgpu-renut, a separate CMake
+    # build with no zstd/smol-v of its own) can consume ARG_OUTPUT directly.
+    # Also applies the real hash remap (_remap_file) so entries are keyed by
+    # the hash the runtime actually looks native pipelines up by.
+    add_custom_command(
+        OUTPUT "${ARG_OUTPUT}"
+        COMMAND $<TARGET_FILE:xenos_cache_unpack> "${_compressed_cache}" "${ARG_OUTPUT}" "${_remap_file}"
+        DEPENDS xenos_cache_unpack "${_compressed_cache}" "${_remap_file}"
+        COMMENT "Decompressing native-renderer shader cache -> ${ARG_OUTPUT}"
+        VERBATIM
+    )
+
+    add_custom_target(${target_name}_xenos_shader_batch DEPENDS "${ARG_OUTPUT}")
+    add_dependencies(${target_name} ${target_name}_xenos_shader_batch)
+endfunction()

--- a/cmake/rexglue_xenosrecomp.cmake
+++ b/cmake/rexglue_xenosrecomp.cmake
@@ -49,15 +49,14 @@ include(FetchContent)
 # `git apply` on the second+ configure since the patch no longer applies cleanly to already-
 # patched source -- only apply when it actually still needs it.
 #
-# REAL BUG FOUND AND FIXED: PATCH_COMMAND is executed directly via
-# execute_process, NOT through a shell -- so a bare command string containing
-# shell operators (&&, ||, 2>/dev/null) does NOT do conditional/redirection
-# logic. Every token, including "&&", "||", "git", "apply", etc., gets passed
-# as a literal argv entry to the FIRST command (git), which git then rejects
-# or silently misinterprets -- so the patch was NEVER actually applied by this
-# line despite `git apply --check` succeeding when run by hand. Fixed by
-# routing the whole idempotent-apply logic through `sh -c` so the shell
-# operators are interpreted as intended.
+# PATCH_COMMAND is executed directly via execute_process, NOT through a
+# shell -- a bare command string containing shell operators (&&, ||,
+# 2>/dev/null) does NOT do conditional/redirection logic; every token gets
+# passed as a literal argv entry to the first command instead. The
+# idempotent check-then-apply logic lives in apply_xenosrecomp_patch.cmake
+# (a portable CMake script, not `sh -c ...`) so it works the same on Windows
+# as everywhere else -- `sh` is not on PATH by default there, which broke
+# the whole FetchContent populate step.
 #
 # xenosrecomp_native_renderer.patch SUPERSEDES the old
 # xenosrecomp_graceful_skip.patch (deleted) -- it is that same patch's full
@@ -76,7 +75,9 @@ FetchContent_Declare(
     GIT_REPOSITORY https://github.com/hedge-dev/XenosRecomp.git
     GIT_TAG main
     GIT_SUBMODULES_RECURSE ON
-    PATCH_COMMAND sh -c "git apply --check '${CMAKE_CURRENT_LIST_DIR}/patches/xenosrecomp_native_renderer.patch' 2>/dev/null && git apply '${CMAKE_CURRENT_LIST_DIR}/patches/xenosrecomp_native_renderer.patch' || true"
+    PATCH_COMMAND ${CMAKE_COMMAND}
+        "-DPATCH_FILE=${CMAKE_CURRENT_LIST_DIR}/patches/xenosrecomp_native_renderer.patch"
+        -P "${CMAKE_CURRENT_LIST_DIR}/apply_xenosrecomp_patch.cmake"
 )
 FetchContent_MakeAvailable(xenosrecomp)
 

--- a/config/renut_funcs.toml
+++ b/config/renut_funcs.toml
@@ -32297,3 +32297,55 @@ longjmp_address = 0x82BB59B0
 0x8224339c = {}
 0x823edf0c = {}
 0x823edf40 = {}
+
+# ---------------------------------------------------------------------------
+# CRT functions. These are ordinary recompiled guest functions -- they are
+# NOT mapped through [rexcrt] (see the note in renut_config.toml), so the
+# original PPC code is kept and used. Declared here so they still get real
+# names; override individually with REX_HOOK if you want native versions.
+# ---------------------------------------------------------------------------
+0x821e7f10 = {name = "rex_strncpy"}  # strncpy
+0x821f4bc0 = {name = "rex_strcpy_s"}  # strcpy_s
+0x8223f478 = {name = "rex_RtlAllocateHeap"}  # RtlAllocateHeap
+0x8223fd48 = {name = "rex_RtlFreeHeap"}  # RtlFreeHeap
+0x82240200 = {name = "rex_RtlSizeHeap"}  # RtlSizeHeap
+0x8224b658 = {name = "rex_XMemSet"}  # XMemSet
+0x82257b18 = {name = "rex_XMemSet128"}  # XMemSet128
+0x82261560 = {name = "rex_wcscmp"}  # wcscmp
+0x822a2930 = {name = "rex_XMemCpy"}  # XMemCpy
+0x82714358 = {name = "rex_CloseHandle"}  # CloseHandle
+0x827152e8 = {name = "rex_FindFirstFileA"}  # FindFirstFileA
+0x82715378 = {name = "rex_CreateFileA"}  # CreateFileA
+0x82715570 = {name = "rex_SetFilePointer"}  # SetFilePointer
+0x827156e0 = {name = "rex_ReadFile"}  # ReadFile
+0x82715868 = {name = "rex_FindNextFileA"}  # FindNextFileA
+0x82715a20 = {name = "rex_GetFileSize"}  # GetFileSize
+0x82715bf0 = {name = "rex_GetDiskFreeSpaceExA"}  # GetDiskFreeSpaceExA
+0x82715da8 = {name = "rex_SetEndOfFile"}  # SetEndOfFile
+0x82715e50 = {name = "rex_WriteFile"}  # WriteFile
+0x82715ff8 = {name = "rex_GetFileAttributesA"}  # GetFileAttributesA
+0x82717428 = {name = "rex_RtlReAllocateHeap"}  # RtlReAllocateHeap
+0x827182b0 = {name = "rex_CompareFileTime"}  # CompareFileTime
+0x827190f8 = {name = "rex_GetFileSizeEx"}  # GetFileSizeEx
+0x82bb0dc0 = {name = "rex_strchr"}  # strchr
+0x82bb0e00 = {name = "rex_memcpy_s"}  # memcpy_s
+0x82bb0ed8 = {name = "rex_memmove_s"}  # memmove_s
+0x82bb12d0 = {name = "rex_strncmp"}  # strncmp
+0x82bb1798 = {name = "rex_wcslen"}  # wcslen
+0x82bb1d20 = {name = "rex_memchr"}  # memchr
+0x82bb1d60 = {name = "rex_strstr"}  # strstr
+0x82bb2c70 = {name = "rex_memmove"}  # memmove
+0x82bb3508 = {name = "rex_wcsstr"}  # wcsstr
+0x82bb3960 = {name = "rex_wcsncmp"}  # wcsncmp
+0x82bb4028 = {name = "rex_wcschr"}  # wcschr
+0x82bb4068 = {name = "rex_wcsncpy"}  # wcsncpy
+0x82bb4510 = {name = "rex_memcpy"}  # memcpy
+0x82bb4a40 = {name = "rex_memset"}  # memset
+0x82bb61c0 = {name = "rex_strrchr"}  # strrchr
+0x82bcd0c8 = {name = "rex_DeleteFileA"}  # DeleteFileA
+0x82bcd260 = {name = "rex_lstrcmpiA"}  # lstrcmpiA
+0x82bcd2f0 = {name = "rex_lstrlenA"}  # lstrlenA
+0x82bcd3a8 = {name = "rex_GetFileAttributesExA"}  # GetFileAttributesExA
+0x82bcd9e0 = {name = "rex_FlushFileBuffers"}  # FlushFileBuffers
+0x82bcda20 = {name = "rex_CreateDirectoryA"}  # CreateDirectoryA
+0x82bcdd68 = {name = "rex_SetFileAttributesA"}  # SetFileAttributesA

--- a/config/renut_hooks.toml
+++ b/config/renut_hooks.toml
@@ -137,12 +137,12 @@ registers = []
 after_instruction = false
 jump_address_on_true = 0x8222BD64
 
-# Real fix (2026-08-17): same handle-vs-real-pointer correlation as
+# Same handle-vs-pointer correlation as
 # dumpVertexDeclaration_hook/dumpVertexDeclarationCreated_hook, but for
 # vertex shaders -- sub_8264E8B0 (this same address) allocates a handle
 # object and returns it in r3; SetVertexShader (0x8222A0A8) receives that
-# handle, not the raw blob pointer. Capture the real pointer here (entry)
-# and pair it with the handle at the function's real return point below.
+# handle, not the raw blob pointer. Capture the pointer here (entry)
+# and pair it with the handle at the function's return point below.
 [[midasm_hook]]
 address = 0x8264E8B0
 name = "dumpVertexShaderCreate_hook"
@@ -285,13 +285,13 @@ name = "dumpVertexDeclaration_hook"
 registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10"]
 after_instruction = false
 
-# Real fix (2026-08-17): sub_8264EA90's real return point (confirmed via
-# recompiled-code inspection -- both its success and failure paths converge
-# here, at "addi r1,r1,112", with r3 already holding the just-allocated
-# vertex-declaration handle, or 0 on failure). Needed to correlate the
-# elements-array pointer captured at entry (dumpVertexDeclaration_hook,
-# above) with the handle SetVertexDeclaration (0x82205700) later receives --
-# see g_declHandleToElements in shader_dump.cpp for the full story.
+# sub_8264EA90's return point (confirmed via recompiled-code inspection --
+# both its success and failure paths converge here, at "addi r1,r1,112",
+# with r3 already holding the just-allocated vertex-declaration handle, or
+# 0 on failure). Needed to correlate the elements-array pointer captured at
+# entry (dumpVertexDeclaration_hook, above) with the handle
+# SetVertexDeclaration (0x82205700) later receives -- see
+# g_declHandleToElements in shader_dump.cpp for the full story.
 [[midasm_hook]]
 address = 0x8264EAFC
 name = "dumpVertexDeclarationCreated_hook"

--- a/config/renut_hooks.toml
+++ b/config/renut_hooks.toml
@@ -137,10 +137,15 @@ registers = []
 after_instruction = false
 jump_address_on_true = 0x8222BD64
 
-
+# Real fix (2026-08-17): same handle-vs-real-pointer correlation as
+# dumpVertexDeclaration_hook/dumpVertexDeclarationCreated_hook, but for
+# vertex shaders -- sub_8264E8B0 (this same address) allocates a handle
+# object and returns it in r3; SetVertexShader (0x8222A0A8) receives that
+# handle, not the raw blob pointer. Capture the real pointer here (entry)
+# and pair it with the handle at the function's real return point below.
 [[midasm_hook]]
 address = 0x8264E8B0
-name = "dumpVertexShader_hook"
+name = "dumpVertexShaderCreate_hook"
 registers = ["r3"]
 after_instruction = false
 
@@ -203,7 +208,7 @@ name = "BanjoActorOverride"
 registers = ["r3", "r5"]
 after_instruction = true
 jump_address_on_false = 0x8251CABC
- 
+
 [[midasm_hook]]
 address = 0x8246e7a8
 name = "klungoConstruct_hook"
@@ -257,4 +262,118 @@ after_instruction = true
 address = 0x8255ed1c
 name = "Max_Acquired_Parts_Access_hook_3"
 registers = ["r9"]
+after_instruction = true
+
+# --- Merged from reNut linux-work (native-renderer/shader-capture hooks) ---
+
+[[midasm_hook]]
+address = 0x82230848
+name = "disable_tessellated_draw"
+registers = []
+after_instruction = false
+jump_address_on_true = 0x82230E10
+
+[[midasm_hook]]
+address = 0x8264E998
+name = "dumpVertexShaderCreated_hook"
+registers = ["r3"]
+after_instruction = false
+
+[[midasm_hook]]
+address = 0x8264EA90
+name = "dumpVertexDeclaration_hook"
+registers = ["r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10"]
+after_instruction = false
+
+# Real fix (2026-08-17): sub_8264EA90's real return point (confirmed via
+# recompiled-code inspection -- both its success and failure paths converge
+# here, at "addi r1,r1,112", with r3 already holding the just-allocated
+# vertex-declaration handle, or 0 on failure). Needed to correlate the
+# elements-array pointer captured at entry (dumpVertexDeclaration_hook,
+# above) with the handle SetVertexDeclaration (0x82205700) later receives --
+# see g_declHandleToElements in shader_dump.cpp for the full story.
+[[midasm_hook]]
+address = 0x8264EAFC
+name = "dumpVertexDeclarationCreated_hook"
+registers = ["r3"]
+after_instruction = false
+
+[[midasm_hook]]
+address = 0x8222A0A8
+name = "dumpVertexShaderSet_hook"
+registers = ["r3", "r4"]
+after_instruction = false
+
+[[midasm_hook]]
+address = 0x82205700
+name = "dumpVertexDeclarationSet_hook"
+registers = ["r3", "r4"]
+after_instruction = false
+
+[[midasm_hook]]
+address = 0x822469D0
+name = "gameActivityAnimationStream"
+registers = ["r3", "r4", "r5"]
+after_instruction = false
+
+[[midasm_hook]]
+address = 0x82246AA0
+name = "gameActivityAnimationStreamEnd"
+registers = ["r3", "r4", "r5"]
+after_instruction = false
+
+[[midasm_hook]]
+address = 0x82B0E5B0
+name = "gameActivityBodyBlend"
+registers = ["r3", "r4", "r5"]
+after_instruction = false
+
+[[midasm_hook]]
+address = 0x82B0E634
+name = "gameActivityBodyBlendEnd"
+registers = ["r3", "r4", "r5"]
+after_instruction = false
+
+[[midasm_hook]]
+address = 0x823CCE78
+name = "gameActivityActorScript"
+registers = ["r3", "r4", "r5"]
+after_instruction = false
+
+[[midasm_hook]]
+address = 0x823CD3FC
+name = "gameActivityActorScriptEnd"
+registers = ["r3", "r4", "r5"]
+after_instruction = false
+
+[[midasm_hook]]
+address = 0x8226CD88
+name = "gameActivityActorGeneration"
+registers = ["r3", "r4", "r5"]
+after_instruction = false
+
+[[midasm_hook]]
+address = 0x8226CEC4
+name = "gameActivityActorGenerationEnd"
+registers = ["r3", "r4", "r5"]
+after_instruction = false
+
+[[midasm_hook]]
+address = 0x82222250
+name = "appMainDrawStart"
+after_instruction = false
+
+[[midasm_hook]]
+address = 0x82222250
+name = "appMainDrawend"
+after_instruction = true
+
+[[midasm_hook]]
+address = 0x8220F210
+name = "appMainTickPreDrawStart"
+after_instruction = false
+
+[[midasm_hook]]
+address = 0x8220F210
+name = "appMainTickPreDrawend"
 after_instruction = true

--- a/config/renut_hooks.toml
+++ b/config/renut_hooks.toml
@@ -310,6 +310,44 @@ name = "dumpVertexDeclarationSet_hook"
 registers = ["r3", "r4"]
 after_instruction = false
 
+# Phase 0 of the SDK-independent native renderer rewrite (see
+# docs/ai/archive/native-renderer-rewrite-plan.md and nativevk_phase0.cpp):
+# read-only draw-count validation on the four real D3D9 draw entry points
+# (config/renut_gpu_funcs.toml). No register values needed, just call counts.
+[[midasm_hook]]
+address = 0x8222C7A0
+name = "phase0DrawVertices_hook"
+registers = []
+after_instruction = false
+
+[[midasm_hook]]
+address = 0x826567C8
+name = "phase0DrawIndexedVertices_hook"
+registers = []
+after_instruction = false
+
+[[midasm_hook]]
+address = 0x8222E520
+name = "phase0DrawVerticesUP_hook"
+registers = []
+after_instruction = false
+
+[[midasm_hook]]
+address = 0x82656728
+name = "phase0DrawIndexedVerticesUP_hook"
+registers = []
+after_instruction = false
+
+# Second, independent hook at the SAME address as dumpVertexShaderSet_hook
+# above -- deliberately not reusing that one, since it's gated behind the
+# unrelated renut_dump_vertex_decl cvar (see nativevk_phase0.cpp's own
+# comment on phase0SetVertexShader_hook for why).
+[[midasm_hook]]
+address = 0x8222A0A8
+name = "phase0SetVertexShader_hook"
+registers = ["r3", "r4"]
+after_instruction = false
+
 [[midasm_hook]]
 address = 0x822469D0
 name = "gameActivityAnimationStream"

--- a/docs/ai/MIGRATION.md
+++ b/docs/ai/MIGRATION.md
@@ -1,0 +1,126 @@
+# Migrating a project onto `Renderer`
+
+> **Scope**: for anyone (human or AI) bringing an existing, independently-developed
+> fork/branch into `masterspike52/reNut:Renderer`. Read this before starting a
+> migration; read [`START_HERE.md`](START_HERE.md) first if you haven't already — the
+> rules there apply here too, this file is the added process for combining two
+> divergent histories cleanly. This describes the actual process used to bring
+> `linux-work`'s native-renderer work onto `Renderer` (see `history.md`'s "opened a real
+> PR branch" entry) — it's a proven process, not a theoretical one.
+
+## Step 0: check whether you even share git history with the target branch
+
+Before anything else:
+
+```sh
+git fetch <upstream-remote>
+git merge-base <your-branch> <upstream-remote>/Renderer
+```
+
+If this prints a commit, you have real shared ancestry and a normal `git merge` or PR
+compare will produce a sane, reviewable diff — proceed with a standard merge/rebase.
+
+**If it prints nothing, stop.** Your branch has zero shared history with the target,
+even if the content overlaps heavily by file name. This happens when a project's local
+checkout was `git init`'d fresh at some point instead of cloned from upstream — it's not
+obvious from `git log` alone unless you specifically check ancestry, and it means a
+GitHub PR from that branch would not show a normal diff; it would look like you're
+replacing almost everything, even files that are byte-identical. This exact situation is
+why this file exists — `linux-work` had this problem, confirmed via this same check.
+
+**The fix**: build a new branch on the target's real tip, and manually port your work
+onto it file-by-file (Step 2 below), rather than trying to merge/rebase the disconnected
+history. Do not force-push your old branch's history onto the new one, and do not use
+`git merge --allow-unrelated-histories` — it does not solve the reviewability problem,
+it just produces a merge commit with the same wall-of-diff issue.
+
+## Step 1: never bring SDK/vendor source with you
+
+If your project's changes touch an external SDK checkout (as this project's native
+renderer did, until the rewrite described in `archive/native-renderer-rewrite-plan.md`),
+**do not commit that SDK's source into your branch, and do not add new files inside its
+checkout either** — see `nativevk.md`'s hard rule and the plan doc for why "my files
+live outside the SDK's own source" is not sufficient on its own if the *code* still
+depends on the SDK's internals to function. The target for any rendering work is zero
+dependency on rexglue-sdk's own pipeline: hook the game's calls directly, own the
+resource/rendering code in this repo.
+
+If your project genuinely needs an SDK-side change, capture it as a minimal, documented
+patch (same mechanism as `cmake/patches/rexglue_sdk_native_renderer.patch`) — never as
+committed source — and keep it as small as the `nativevk.md` hard rule describes.
+
+## Step 2: bring your branch over in two passes, not one bulk merge
+
+**Pass 1 — files that only exist on your side.** These merge with zero conflict by
+construction:
+
+```sh
+git checkout -b my-migration <upstream-remote>/Renderer
+comm -23 <(git ls-tree -r --name-only your-branch | sort) \
+         <(git ls-tree -r --name-only <upstream-remote>/Renderer | sort) \
+         > /tmp/new_files.txt
+git checkout your-branch -- $(cat /tmp/new_files.txt)
+git commit -m "Bring over <project>-only files with no overlap on Renderer"
+```
+
+**Pass 2 — files that exist on both sides.** Do not bulk-overwrite these — `Renderer`
+carries other collaborators' independent work in them. For each overlapping file:
+
+```sh
+diff <(git show <upstream-remote>/Renderer:path/to/file) <(git show your-branch:path/to/file)
+```
+
+Then classify it:
+- **Identical** — nothing to do.
+- **Trivial** (whitespace/newline-only) — leave as `Renderer`'s version.
+- **One side is a strict superset/bugfix of the other** — verify by reading every
+  removed line and confirming it's stale, not a dropped capability, then take that
+  side wholesale.
+- **Both sides added independent, real content** (the common case: two people each
+  added their own cvar, hook, function, `#ifdef` branch) — hand-merge. Keep both
+  additions; do not let one side's change silently delete the other's.
+- **Real conflict** (same address/name/key used for two different things) — resolve
+  by understanding what each side actually needs, the same way this project's hooks.toml
+  merge resolved a duplicate hook address by checking which piece of code the new file
+  actually called into (see `history.md`).
+
+This is real, careful, file-by-file work — there is no shortcut that doesn't risk
+silently deleting someone else's contribution. Budget time for it accordingly.
+
+## Step 3: verify before calling it done
+
+- Rebuild everything your changes touch; deploy build artifacts and `md5sum`-verify
+  copies match, per `START_HERE.md` rule 4.
+- Confirm braces/structure are intact on any file you hand-edited (a quick
+  `s.count('{') == s.count('}')` check catches most mechanical mistakes).
+- Playtest, don't just compile — a clean build is not the same as a correct migration.
+- If you touched a generated patch file (Step 1's SDK-patch mechanism), regenerate it
+  from a clean diff of the actual external checkout, and sanity-check its line count and
+  content before committing — don't assume the checkout only has your intended changes
+  in it. It may have unrelated, unverified work sitting in it from other investigation;
+  regenerating blindly would ship that too.
+
+## Step 4: clean up before opening the PR
+
+- Strip development-log-style comments (dates, "user-requested", "this session",
+  references to your own local planning docs that won't exist for the reviewer) down to
+  just the technical reasoning. A comment referencing a date or a conversation reads as
+  noise to someone who wasn't there.
+- Fix any dangling references to files that didn't come over with you (local-only
+  planning docs, session-specific notes).
+- Write the PR description in two clearly separated sections: what works immediately
+  after merging with no extra setup, and what's not ready / still needs work. Don't let
+  scaffolding read as a finished feature — say plainly if something is in-progress.
+- Double-check the PR's base branch is actually `Renderer`, not `main` or another
+  default — GitHub does not always guess correctly, especially across forks.
+
+## Common mistakes this process exists to prevent
+
+- Opening a PR from a branch with no shared history and being surprised by a
+  50,000-line diff instead of the few thousand lines you actually changed.
+- Silently deleting another contributor's cvar/hook/fix because a bulk file overwrite
+  looked like the fast path.
+- Shipping an SDK-checkout patch that includes unrelated, unverified experimentation
+  because it was sitting uncommitted in that checkout when the patch was regenerated.
+- A PR description that reads like the whole feature works, when large parts of it are
+  scaffolding that needs a separate manual setup step (or doesn't work at all yet).

--- a/docs/ai/START_HERE.md
+++ b/docs/ai/START_HERE.md
@@ -82,6 +82,10 @@ current-but-temporary, not the end state.
 - [`nativevk.md`](nativevk.md) — the native renderer / rexglue-sdk boundary: setup,
   the hard rule in full, how to keep the patch current. Read before touching the
   renderer or the SDK checkout.
+- [`MIGRATION.md`](MIGRATION.md) — the process for bringing an independently-developed
+  branch/fork onto `Renderer`: checking git ancestry first, never bringing SDK source
+  along, reconciling overlapping files without clobbering other people's work, and
+  cleanup before opening a PR. Read before migrating any project onto this branch.
 - [`research.md`](research.md) — narrative background: what the project is, current
   architecture, how comparable projects (UnleashedRecomp, DPRecomp, Xenia) solve the
   same problems. Read for context, or to explain the project to someone new.

--- a/docs/ai/START_HERE.md
+++ b/docs/ai/START_HERE.md
@@ -13,6 +13,21 @@ recompilation ships and is stable. GPU has two interchangeable plugins: `rexgpu-
 (experimental, statically-compiled pipelines, in progress). If you need more than that,
 go to [`research.md`](research.md).
 
+**Planned architecture change (decided, not yet started):** `rexgpu-nativevk` as
+described above and in `nativevk.md` is going away. It still substitutes pipelines
+from inside rexglue-sdk's own draw call (`VulkanCommandProcessor::IssueDraw`), which
+means it still depends on the SDK's GPU-emulation stack (texture cache, render-target
+cache, shared memory, primitive processor) to get there, even though its own source
+lives outside the SDK checkout. The decided direction is a full replacement:
+UnleashedRecomp-style, hooking the game's D3D9 calls directly at their guest addresses
+and implementing Vulkan rendering entirely independently, with zero dependency on
+rexglue-sdk's rendering pipeline at all. See
+[`archive/native-renderer-rewrite-plan.md`](archive/native-renderer-rewrite-plan.md)
+for the real plan (existing groundwork already found: every D3D9 entry point needed
+already has a known guest address, and `render_hooks_stub.cpp` has a matching orphaned
+stub scaffold). Until that lands, treat everything below about `rexgpu-nativevk` as
+current-but-temporary, not the end state.
+
 ## Hard rules
 
 1. **rexglue-sdk lives outside this repo and should almost never need real edits.**

--- a/docs/ai/START_HERE.md
+++ b/docs/ai/START_HERE.md
@@ -1,0 +1,81 @@
+# Start here
+
+You're an AI working on reNut. Read this file in full before doing anything else — it's
+short on purpose. It tells you the rules, then where to go for the rest.
+
+## What reNut is, in one paragraph
+
+reNut is a native Linux/Windows port of *Banjo-Kazooie: Nuts & Bolts* (Xbox 360), built
+on **rexglue** (a static-recompilation SDK) plus this repo's own game-specific fixes,
+tooling, and a from-scratch native GPU renderer effort (`rexgpu-nativevk`). CPU
+recompilation ships and is stable. GPU has two interchangeable plugins: `rexgpu-xenos`
+(stock, runtime-translated, the correct reference baseline) and `rexgpu-nativevk`
+(experimental, statically-compiled pipelines, in progress). If you need more than that,
+go to [`research.md`](research.md).
+
+## Hard rules
+
+1. **rexglue-sdk lives outside this repo and should almost never need real edits.**
+   The SDK is a separate external checkout (`REXSDK_DIR`); reNut's git history contains
+   *zero* SDK source files, ever — only a generated patch that captures what little the
+   SDK genuinely needs changed. Before editing anything under `rexglue-sdk-src/`, read
+   [`nativevk.md`](nativevk.md)'s hard-rule section and look for a hook-based alternative
+   first. If an SDK edit really is unavoidable, keep it minimal, document why inline at
+   the call site, and regenerate+commit the patch in the same commit as the reNut-side
+   change that depends on it.
+
+2. **Never commit SDK source, generated build output, or game assets.** Check
+   `.gitignore` before adding new generated/external paths. When staging with a broad
+   `git add`, review `git status` output before committing — this project has previously
+   had large personal reference material (Xbox 360 SDK docs) sitting untracked in the
+   repo root; that kind of thing gets moved to `reNut-build-scratch/` (a sibling
+   directory, outside the repo), not committed.
+
+3. **Verify claims against the real tree/binary, not memory or assumption.** This
+   project's history ([`history.md`](history.md)) has multiple entries where a plausible-
+   sounding claim turned out wrong on direct inspection (grep, `nm -D`, binary hash
+   comparison, actual playtesting) — always prefer that over restating something
+   remembered from an earlier session or a doc that might be stale.
+
+4. **After any change to the nativevk/xenos plugins**: rebuild both
+   (`ninja rexgpu-nativevk rexgpu-xenos`), copy the built `.so` files from the SDK
+   checkout's `out/linux-amd64/` into the game's build dir, `md5sum` both copies to
+   confirm they match, and sanity-load each with
+   `python3 -c "import ctypes; ctypes.CDLL(path)"` before considering the change done.
+   Rebuilding `renut` itself is a separate step only needed when reNut's own sources
+   changed.
+
+5. **When something looks broken, find the real root cause before patching around it.**
+   Several fixes in `history.md` trace back to a wrong assumption stated confidently
+   before being checked. If you're not sure, say so and check, rather than guess.
+
+6. **If a fix reaches a live, confirmed-broken state and the root cause isn't found
+   quickly, revert cleanly rather than keep patching forward.** See
+   [`archive/deferred-vfetch-flush.md`](archive/deferred-vfetch-flush.md) for a real
+   example of this rule being followed correctly.
+
+7. **Division of labor**: the AI fixes/edits/builds; the user plays the actual game to
+   verify. Don't claim a rendering/gameplay fix "works" without the user having tested
+   it in-game — a clean compile is not the same as a correct fix.
+
+8. **Destructive git operations need explicit confirmation** — force-push, reset --hard,
+   amending someone else's commit, discarding uncommitted work. Run `git status` first.
+   Only commit when asked to.
+
+## Where the rest of the documentation lives
+
+- [`nativevk.md`](nativevk.md) — the native renderer / rexglue-sdk boundary: setup,
+  the hard rule in full, how to keep the patch current. Read before touching the
+  renderer or the SDK checkout.
+- [`research.md`](research.md) — narrative background: what the project is, current
+  architecture, how comparable projects (UnleashedRecomp, DPRecomp, Xenia) solve the
+  same problems. Read for context, or to explain the project to someone new.
+- [`history.md`](history.md) — terse, chronological log of what was tried, what broke,
+  what fixed it. Read for provenance on a specific past decision, or to pick up a
+  session exactly where it left off (top section).
+- [`archive/`](archive) — dead ends and superseded plans, kept only so the same mistake
+  isn't repeated blind. Not part of the fork (see `.gitignore`) — local reference only.
+  Skip unless a specific archived topic comes back up.
+
+If you're about to do something not covered by a rule above and you're unsure whether
+the user would want it done autonomously, ask rather than assume.

--- a/docs/ai/history.md
+++ b/docs/ai/history.md
@@ -17,25 +17,61 @@ Facts below marked **(verified YYYY-MM-DD)** were re-checked against the real
 tree/binaries on that date. Everything else is historical and may be stale.
 Last full audit: **2026-08-17**.
 
-## ⏭️ NEXT SESSION: START HERE — native renderer is getting fully rewritten, SDK-independent (2026-08-18)
+## ⏭️ NEXT SESSION: START HERE — start Phase 0 of the SDK-independent native renderer rewrite (2026-08-19)
 
-Decided (not started): `rexgpu-nativevk` as described everywhere below this point is
-being replaced entirely with an UnleashedRecomp-style renderer that hooks the game's
-D3D9 calls directly and never touches rexglue-sdk's GPU-emulation pipeline at all — not
-even from inside its own draw call, which is what the current architecture still does
-despite living outside the SDK checkout. Real plan, with existing groundwork already
-identified (every D3D9 entry point's guest address is already known; an orphaned stub
-scaffold in `render_hooks_stub.cpp` already matches the shape needed):
-`archive/native-renderer-rewrite-plan.md`. Read that before doing ANY native-renderer
-work — everything else in this file and in `nativevk.md` describes the current,
-temporary architecture, not the target.
+**The rewrite is decided and fully planned, but implementation has not started at all.**
+Read `archive/native-renderer-rewrite-plan.md` in full before writing any native-renderer
+code -- it has the phased rollout, the known groundwork that already carries over
+(every D3D9 guest address already known, XenosRecomp pipeline untouched, vertex-fetch
+decode / bindless-heap / constant-buffer techniques already proven), and the one real
+open risk that must be validated FIRST (Phase 0): does hooking D3D9 draw calls directly
+actually see ~100% of real draws, and is shader identity resolvable for shaders that
+bypass `CreateVertexShader` via IM_LOAD. Do not skip Phase 0 and jump to writing
+renderer code -- if it fails, the approach needs to change before anything else is built.
 
-Also done this session: opened a real PR branch (`nativevk-on-renderer`, pushed to
-`origin`) built on `masterspike52/reNut:Renderer`'s actual git history — `linux-work`
-(referenced throughout this file below) turned out to have zero shared ancestry with
-upstream at all, so it could never have merged cleanly. All 24 overlapping files were
-hand-reconciled (see that branch's own commits for the reasoning per file), not
-bulk-overwritten.
+Everything else in this file and in `nativevk.md` describes the CURRENT, SDK-dependent
+`rexgpu-nativevk` architecture -- accurate today, but explicitly being replaced, not the
+target. `rexgpu-nativevk` is still fully present in the repo (patch file, SDK-side files,
+debug panel), just no longer required for a normal build (see below) -- full removal is
+its own later step once the new renderer has something to replace it with.
+
+**PR status**: `nativevk-on-renderer` branch, pushed to `origin`, open as PR #38 against
+`masterspike52/reNut:Renderer`, mergeable clean. Built on Renderer's real git history
+(`linux-work`, referenced throughout this file below, had zero shared ancestry with
+upstream at all and could never have merged cleanly -- see that branch's own commits for
+how the 24 overlapping files were hand-reconciled, not bulk-overwritten). Per the repo
+owner's explicit request: `mullhwucrash.cpp` was reverted back to byte-identical with
+Renderer/main (the real `simde_mm_blendv_ps`->`_epi8` bug fix found this session was
+dropped from the PR -- owner didn't want already-functioning shared files touched).
+Everything else (Linux fixes, debug panel, NativeVK scaffolding, `sleep.h`'s real
+`PPC_HOOK`->`REX_HOOK` fix) stayed in one combined PR, per the owner's explicit request
+not to split it into separate branches.
+
+**Two real build-breaking bugs found+fixed via the owner's own build attempts**:
+1. `cmake/rexglue_xenosrecomp.cmake`'s `PATCH_COMMAND sh -c "..."` doesn't work on
+   Windows (`sh` not on PATH) -- replaced with a portable CMake script
+   (`cmake/apply_xenosrecomp_patch.cmake`), verified against the real XenosRecomp
+   checkout (both fresh-apply and already-applied paths).
+2. `rexgpu-nativevk` was in the default `GPU_PLUGINS` list, so ANY normal build without
+   a manually-patched SDK checkout (i.e. everyone using a plain/prebuilt SDK install,
+   including the owner) hard-failed at configure with "unknown GPU plugin 'nativevk'".
+   Fixed by dropping `nativevk` from the default list in reNut's own `CMakeLists.txt` --
+   `rexgpu-xenos` only now; `nativevk` stays buildable locally by re-adding it after the
+   one-time SDK patch setup in `nativevk.md`, just not required by default.
+
+Also found (SDK-side, real, worth keeping in the patch): `rex_resolve_version()` in
+rexglue-sdk's own `CMakeLists.txt` didn't pass `SOURCE_DIR`, so in `add_subdirectory()`/
+`REXSDK_DIR` mode it ran `git describe` against reNut's OWN repo (which has an unrelated
+`v1.1.0` tag) instead of the SDK checkout -- caused a spurious "floor version behind tag
+version" hard error. Fixed with an explicit `SOURCE_DIR` argument.
+
+Also done: cleaned ~90+ narrative/session-dated comments ("Real fix (2026-08-17,
+user-requested): ...") out of the native-renderer code across this repo and the SDK
+patch -- see that commit for what was deliberately left alone (`xenosrecomp_native_renderer.patch`,
+since the separate XenosRecomp checkout it's built from has real unverified functional
+changes sitting in it, unrelated to this cleanup). Added `docs/ai/MIGRATION.md` -- the
+generalized process for bringing any project onto `Renderer` cleanly, based on exactly
+what this session actually did.
 
 ## Team fork prep + real capture-hash bug found+fixed (2026-08-18)
 

--- a/docs/ai/history.md
+++ b/docs/ai/history.md
@@ -17,7 +17,27 @@ Facts below marked **(verified YYYY-MM-DD)** were re-checked against the real
 tree/binaries on that date. Everything else is historical and may be stale.
 Last full audit: **2026-08-17**.
 
-## ⏭️ NEXT SESSION: START HERE — team fork prep + real capture-hash bug found+fixed (2026-08-18)
+## ⏭️ NEXT SESSION: START HERE — native renderer is getting fully rewritten, SDK-independent (2026-08-18)
+
+Decided (not started): `rexgpu-nativevk` as described everywhere below this point is
+being replaced entirely with an UnleashedRecomp-style renderer that hooks the game's
+D3D9 calls directly and never touches rexglue-sdk's GPU-emulation pipeline at all — not
+even from inside its own draw call, which is what the current architecture still does
+despite living outside the SDK checkout. Real plan, with existing groundwork already
+identified (every D3D9 entry point's guest address is already known; an orphaned stub
+scaffold in `render_hooks_stub.cpp` already matches the shape needed):
+`archive/native-renderer-rewrite-plan.md`. Read that before doing ANY native-renderer
+work — everything else in this file and in `nativevk.md` describes the current,
+temporary architecture, not the target.
+
+Also done this session: opened a real PR branch (`nativevk-on-renderer`, pushed to
+`origin`) built on `masterspike52/reNut:Renderer`'s actual git history — `linux-work`
+(referenced throughout this file below) turned out to have zero shared ancestry with
+upstream at all, so it could never have merged cleanly. All 24 overlapping files were
+hand-reconciled (see that branch's own commits for the reasoning per file), not
+bulk-overwritten.
+
+## Team fork prep + real capture-hash bug found+fixed (2026-08-18)
 
 **Two unrelated threads finished this session, read both before continuing:**
 

--- a/docs/ai/history.md
+++ b/docs/ai/history.md
@@ -1,0 +1,1150 @@
+# reNut Project Memory
+
+> **Scope**: chronological log — what was tried, what broke, what fixed it, session by
+> session. Read this when you need *provenance* for a specific past decision or bug, or
+> to pick up exactly where the last session left off (see the top section). Skip it if
+> you just need current architecture/rules — that's [`START_HERE.md`](../START_HERE.md)
+> and [`research.md`](research.md) instead. This file is terse and machine-oriented by
+> design; `research.md` is the narrative/human-readable counterpart.
+
+reNut/rexglue: static recompilation of Banjo-Kazooie: Nuts & Bolts (Xbox 360)
+to native Linux. XenosRecomp compiles Xenos GPU shader microcode -> HLSL ->
+DXC -> SPIR-V ahead of time. Goal: replace the "stock" runtime-translated
+(interpreter-based) shader path with real native Vulkan pipelines per
+shader pair, without visual corruption.
+
+Facts below marked **(verified YYYY-MM-DD)** were re-checked against the real
+tree/binaries on that date. Everything else is historical and may be stale.
+Last full audit: **2026-08-17**.
+
+## ⏭️ NEXT SESSION: START HERE — team fork prep + real capture-hash bug found+fixed (2026-08-18)
+
+**Two unrelated threads finished this session, read both before continuing:**
+
+**1. Team collaboration prep, DONE**: this fork's native-renderer work (rexglue-sdk diff
+reduced from ~1900 lines to a small patch, one virtual hook + Vulkan device features, see
+`nativevk.md`) is committed on `linux-work`, ready to push to `origin` (`iNiKKo/reNut`)
+and PR against `masterspike52/reNut:Renderer`. **Plugin renamed** (2026-08-18, user request --
+"renut" was confusing next to the project's own name): `gpu_plugin = "renut"` ->
+`gpu_plugin = "nativevk"`, CMake target `rexgpu-renut` -> `rexgpu-nativevk`,
+`src/graphics/renut/` -> `src/graphics/nativevk/` (SDK side), `renut_xenos_pipeline_cache.*` ->
+`nativevk_xenos_pipeline_cache.*`, `renut_phase1_native_draw.*` -> `nativevk_phase1_native_draw.*`,
+`renut_shader_debug_panel.cpp` -> `nativevk_shader_debug_panel.cpp`,
+`RenutCommandProcessor`/`RenutGraphicsSystem` -> `NativeVkCommandProcessor`/
+`NativeVkGraphicsSystem`, `RENUT_OPTIMISATIONS` -> `NATIVEVK_OPTIMISATIONS`. Deliberately NOT
+renamed (genuinely project-level, not plugin-specific): `config/renut_hooks.toml`,
+`renut_config.toml`, `src/renut_engine/*`, the generated `renut_xenos_shader_cache.h`/`.cpp` and
+its `renut_xenos_shader_batch()`/`renut_synthesize_*()` CMake functions (shared build-pipeline
+naming, not the plugin itself). Live config (`~/.config/renut/renut.toml`) already updated to
+`gpu_plugin = "nativevk"`. Rebuilt and verified end-to-end (both `rexgpu-nativevk` and
+`rexgpu-xenos` link cleanly, deployed, md5-verified).
+
+**CORRECTION (2026-08-18, later same day)**: an earlier note in this file claimed
+`upstream/Renderer` already has "an independent, unrelated, overlapping native-shader effort
+from another contributor" -- **this was wrong**, based on a misread `git diff --stat` (files
+that only exist on `linux-work` were misattributed as also existing on `Renderer` with
+different content). Directly verified via `git cat-file -e` on both branches: `Renderer` has
+**zero** native-shader-conversion files (no `tools/`, no `ucode_analyze.cpp`, no
+`renut_xenos_shader_cache.h`, nothing under `cmake/patches/`) -- it's a smaller, differently
+scoped branch (FPS overlay, mouse/keyboard controls, texture tools, general engine/gameplay
+fixes). This means every native-renderer file merges into `Renderer` as a pure, zero-conflict
+addition. The real (normal, expected) merge-conflict surface is the ~33 files that exist on
+both branches -- mostly core engine/build files each branch touched independently
+(`CMakeLists.txt`, `config/renut_hooks.toml`, `src/renut_engine/shader_dump.cpp`,
+`src/renut_app.h`, `src/renut_engine/hooks.cpp`, etc.), with moderate, normal divergence (tens
+to a few hundred changed lines each), not a duplicate-effort collision. `resources/` (16MB
+personal reference PDFs) deliberately NOT committed -- copyright/repo-bloat concern, left for
+the user to decide.
+
+**2. Real bug found+fixed while verifying the refactor didn't regress anything**: playtesting
+after the refactor showed the native shader debug panel had stopped appearing at all. Root cause
+(confirmed via direct measurement, not guessed): `shader_dump.cpp`'s `dumpShaderBlob()` hashed
+the WRONG byte range (header+ucode) for `shaders/vs_*.bin`/`ps_*.bin` capture filenames --
+every other real hash in the codebase (the runtime's own `Shader::ucode_data_hash()`, and this
+same file's OWN `computeShaderUcodeHash()`) hashes ucode-only. This silently broke vertex-shader
+identity tracking specifically (pixel shaders don't need the declaration-correlation this hash
+feeds, so they were unaffected) -- confirmed via an extended real play session: 0/163 distinct
+vertex shaders ever matched the native cache, pixel shaders matched ~96%. Fixed
+(`src/renut_engine/shader_dump.cpp`, commit `52a3d9c`). **Requires a fresh capture session to
+take effect** -- existing `shaders/` captures predate the fix and are permanently mis-hashed.
+
+**Status after the fix, NOT fully resolved**: rebuilt the whole pipeline from a fresh capture
+(194 real vertex shader captures with the corrected hash, 97 survived into
+`shaders_synthesized/`), but the native shader cache still only ends up with 80 real
+(non-heuristic) vertex-shader entries out of ~275 candidate containers -- most fail
+`batch_build_synthetic_containers.py`'s synthesis for reasons that look like the SAME
+pre-existing, well-documented XenosRecomp/corpus gaps already described elsewhere in this file
+(missing vertex-fetch data, missing DefinitionTable literal constants for heuristic-only IM_LOAD
+captures) -- NOT re-investigated further this session, ran out of scope. Spot-checked one very
+common, frequently-drawn real vertex shader (`vs_1638329963af0285`, real vertex bindings, no
+high float-constant registers referenced) that still doesn't make it into
+`shaders_synthesized/` despite looking like a clean candidate -- worth a direct
+`build_synthetic_container.py` invocation to see its real rejection reason, if resumed.
+
+**Next step if resumed**: play for a real, extended session (the fix is real and confirmed
+working end-to-end for shaders that DO make it into the cache) to build a bigger fresh capture
+corpus, then investigate remaining single-shader conversion failures the same way prior sessions
+did (`ucode_analyze` + direct tool invocation), rather than assuming they're already covered by
+the general "known gaps" narrative.
+
+## ⏭️ (older) user tested bindless-heap fix, ZERO visible change
+
+**2026-08-18, same day, after the fix below shipped**: user played and reported "still have
+flickering and other, nothing changed at least i didn't notice a change." This is the SAME
+"real verified bug, zero visible improvement" outcome as the 6 shader-translation bugs fixed
+2026-08-17 (see `renut_native_shader_investigation_2026_08_17` memory / CORE UNSOLVED PROBLEM
+section below). Two independent rounds of real fixes at two different levels (shader
+translation correctness, then GPU descriptor-synchronization) both produced no measurable
+change — that convergence is itself evidence worth acting on before writing more per-bug
+fixes.
+
+**Action taken in response**: added a boot-time env-var kill switch,
+`RENUT_DISABLE_ALL_NATIVE=1`, in `RecordAndCheckPairEnabled()`
+(`renut_xenos_pipeline_cache.cpp`) — forces every native shader pair off from process start
+(unlike the debug panel's "Disable All", which can't reach pairs built during the intro videos
+before the panel is reachable, and unlike `marked_bad_shaders.txt`, which only lists specific
+already-known-bad pairs). Built, deployed, verified matching md5 on both `.so` files
+(`librexgpu-renutrd.so` md5 `7d1b6812298b4df6ab18db35a7d034fd`; `librexgpu-xenosrd.so`
+unchanged, `f50420e5759a96752a6c7a11898f78a9`).
+
+**RESULT (2026-08-18, same day): flickering PERSISTS with `RENUT_DISABLE_ALL_NATIVE=1` set
+(zero native draws, 100% stock rendering).** User's exact report: "Still flickering."
+
+**This is a major pivot, not a footnote.** The entire native-shader-corruption investigation
+since 2026-08-16 (6 shader-translation bugs fixed 8/17, the bindless-heap descriptor race fixed
+8/18, none of which moved the needle) was aimed at the wrong subsystem for THIS symptom. The
+flickering is NOT caused by native rendering — it happens identically in pure stock mode. The
+original 2026-08-16 "confirmed via A/B test" conclusion (recorded in `renut_native_renderer`
+memory) was almost certainly contaminated by the exact gotcha documented in this file: the old
+"Disable All" panel button can't reach pairs built before the panel is reachable (after the
+intro videos), so that earlier "native-only" test was never actually 100% stock. This clean
+boot-time kill switch is the first trustworthy A/B on this question.
+
+**Do NOT resume native-shader-corruption investigation for the flickering symptom.** It may
+still be worth fixing for its own sake (native perf/correctness), but it is not the cause of
+what the user is calling "flickering." The native-shader "stretched textures / non-spawning
+items" corruption (CORE UNSOLVED PROBLEM section below) is a SEPARATE symptom from this
+flickering — do not conflate them going forward; they need independent root-causing.
+
+**Characterized (2026-08-18, user answered directly)**: specific textures/objects flicker (not
+whole-screen, not tearing, not UI/HUD), and it's CONSTANT — happens even standing still, not
+tied to camera movement. User's own read: "This flickering happens from our implementation of
+native shaders" — but this directly conflicts with the RENUT_DISABLE_ALL_NATIVE=1 result above
+(flicker persists with zero native draws). Resolution: the bug must be in SHARED code the
+native-renderer effort modified but which ALSO runs for stock draws — not in anything gated
+behind "is this pipeline native."
+
+**Found via `git diff` against pristine rexglue-sdk** (`cd rexglue-sdk-src && git status`/`git
+diff` — this SDK clone has ALL native-effort changes as uncommitted working-tree diffs, so this
+is the complete real diff, not something to re-derive): the biggest non-native-gated behavioral
+change in shared code is `kRenutDynamicConstants`
+(`include/rex/graphics/vulkan/command_processor.h:53`, was `#if RENUT_OPTIMISATIONS` / true) —
+switches the constants descriptor set from "rewritten every draw" to "written once, rebound
+with per-draw dynamic offsets," with non-trivial reuse/batching bookkeeping added throughout
+`VulkanCommandProcessor::UpdateBindings()` (`command_processor.cpp` ~7706-7881, `else if (true)`
+branch, `renut_constants_dynamic_set_`, `renut_dynamic_offset_values`). This runs on EVERY draw
+(native or stock) and wrong per-draw offsets → wrong constants → wrong transform/UV would look
+exactly like "specific object flickers, constant, standing still." Other shared-file diffs in
+this SDK (`texture_cache.cpp` +21 lines, `pipeline_cache.cpp` +178, `shared_memory.cpp` +21,
+`deferred_command_buffer.cpp` +10) are smaller and not yet individually audited — check these
+next if the test below doesn't confirm.
+
+**DIAGNOSTIC BUILD SHIPPED, TEST NOT YET RUN**: forced `kRenutDynamicConstants = false`
+unconditionally in `command_processor.h` (was gated on `RENUT_OPTIMISATIONS`), reverting every
+draw's constant-buffer binding to the old always-rewrite-the-descriptor-set path. Built,
+deployed, verified matching md5 (`librexgpu-renutrd.so` `4ce60ebdebb330b3d171c7e4d292dca2`).
+**Next step: have the user test with this build (native rendering back to its normal
+enabled-by-default state, i.e. do NOT set RENUT_DISABLE_ALL_NATIVE this time — testing the
+OTHER suspect now) and report whether the flickering is gone.**
+- If flickering STOPS: root cause found — `kRenutDynamicConstants`'s dynamic-offset bookkeeping
+  has a real bug; revert the header to `#if RENUT_OPTIMISATIONS` permanently (this "optimization"
+  isn't worth a correctness bug) rather than debug the offset logic further, unless perf data
+  says otherwise.
+- If flickering PERSISTS: rule this out, move to the next shared-file diff candidates
+  (`texture_cache.cpp`, `pipeline_cache.cpp`, `shared_memory.cpp`, `deferred_command_buffer.cpp`
+  — none audited yet, check with `git diff` in `rexglue-sdk-src` the same way this one was found).
+
+**RESULT: flickering PERSISTS with `kRenutDynamicConstants=false` too.** Ruled out.
+
+**User confirmed the critical fact that resolves scope (2026-08-18)**: the TRUE original stock
+renderer (before any native-renderer-effort changes at all) "runs almost perfectly" — no
+flickering. So this is not a pre-existing stock bug, and it's not native pipelines specifically
+(disabling those didn't help either) — it is a real regression somewhere in the native-effort's
+SHARED-code changes (the ones that run unconditionally for every draw, not gated behind "is this
+draw using a native pipeline"). Two of the four now-known non-native-gated shared-file diffs are
+ruled out by elimination reasoning so far only by inference, not yet directly tested:
+`kRenutDynamicConstants` tested and ruled out above. `command_processor.cpp` has substantial
+OTHER non-native-gated additions beyond that flag (barrier-site tracking, texture-write
+instrumentation counters, `InvalidateVertexBufferResidency`/`InvalidateAllVertexBufferResidency`
+— NOTE: "vertex buffer residency" naming strongly resembles the deferred-vfetch-flush effort
+that `renut_barrier_attribution` memory says was "ABANDONED+REVERTED 2026-08-16" — VERIFY this
+residency code is not a leftover fragment of that revert, it's a real question mark, not
+confirmed either way yet). Still fully unaudited: `texture_cache.cpp` (+21 lines),
+`pipeline_cache.cpp` (+178 lines, largest unaudited one), `shared_memory.cpp` (+21),
+`deferred_command_buffer.cpp` (+10). **Next session: audit these via `git diff` in
+`rexglue-sdk-src`, starting with `pipeline_cache.cpp` (largest) and the
+`InvalidateVertexBufferResidency` question, before guessing another toggle-and-test cycle.**
+
+**Audited same day, 2026-08-18**:
+- `InvalidateVertexBufferResidency`/`InvalidateAllVertexBufferResidency` calls: confirmed
+  pre-existing (unmodified context lines in the diff, not additions) — real Xenia vertex-buffer
+  cache invalidation, unrelated to the deferred-vfetch-flush effort or to renut. Ruled out.
+- `pipeline_cache.cpp` (+178 lines): 100% diagnostic microcode-dump/disassembly-log
+  infrastructure, gated behind `renut_dump_ucode_hash` cvar (default `false`) or one-shot debug
+  logging. No rendering-behavior change. Ruled out.
+- `texture_cache.cpp` (+21), `shared_memory.cpp` (+21): pure perf counters (increment-only,
+  never read except by the frame-trace CSV writer, which is itself off by default). Ruled out.
+- `deferred_command_buffer.cpp` (+10) + its header: adds `CmdVkSetCullMode`/`CmdVkSetFrontFace`
+  dispatch cases, but grep confirms **zero call sites anywhere in the tree** — dead code, never
+  invoked. Ruled out.
+- **`src/graphics/pipeline/texture/cache.cpp`'s `TextureCache::RequestTextures()` — FOUND real
+  candidate, un-gated by native/A-B-benchmark-inactive (i.e. active by default in normal play)**:
+  an early-return optimization (`if (!(used_texture_mask & ~texture_bindings_in_sync_) && ...)
+  return;`) skips the entire texture-binding refresh (including `binding.texture =
+  FindOrCreateTexture(...)`) whenever a fetch-constant register's "in sync" bit is set, on the
+  theory that nothing downstream would do anything anyway. But `VulkanTextureCache::RequestTextures`
+  (the Vulkan override, `texture_cache.cpp:568`) calls this base function THEN unconditionally
+  uses `binding.texture` for real GPU image-layout-transition work every draw regardless. If
+  `texture_bindings_in_sync_` is ever stale relative to the real state of `binding.texture` (e.g.
+  a texture object gets evicted/replaced through a path that doesn't clear this specific bit),
+  the skip would leave a wrong/dangling texture bound — exactly matching "specific
+  textures/objects flicker, constant, standing still." This is the ONE remaining un-tested,
+  behavior-changing, non-native-gated diff found via the SDK's own `git diff` against upstream.
+
+**DIAGNOSTIC BUILD #2 SHIPPED, TEST NOT YET RUN**: disabled the early-return (`if (false && ...)`
+in `TextureCache::RequestTextures`, `src/graphics/pipeline/texture/cache.cpp` ~line 471) so
+every draw always re-walks and re-validates its texture bindings, same as true pristine stock.
+Built, deployed, verified matching md5 (`librexgpu-renutrd.so` `55993982ddeac75477278a832fbd2020`).
+Also reverted the ruled-out `kRenutDynamicConstants=false` diagnostic back to its normal
+`#if RENUT_OPTIMISATIONS` gating (back to `true`) so this test isolates only the texture-cache
+change. **Next step: user tests normally (no env var, native enabled by default) and reports
+whether flickering is gone.**
+- If flickering STOPS: root cause found. Either revert this optimization permanently (correctness
+  over the perf win), or — better — find what actually leaves `texture_bindings_in_sync_` stale
+  and fix that specific gap instead of removing the whole optimization.
+- If flickering PERSISTS: this specific hypothesis is wrong too — see the FULL AUDIT below,
+  completed same day.
+
+**RESULT: flickering STILL PERSISTS with `TextureCache::RequestTextures`'s early-return
+disabled too.** Ruled out; restored to its normal `#if RENUT_OPTIMISATIONS` state (reverted to
+active).
+
+**Third candidate found+tested the same session, result NOT YET confirmed by the user**
+(build shipped, DO NOT assume the outcome): `SharedMemory::RequestRanges` (base
+`shared_memory.cpp`) was changed to reuse a persistent member scratch vector
+(`request_ranges_scratch_`) instead of a local one, on a hot per-draw path (~6k calls/frame).
+Disabled (forced back to a local vector), built, deployed, verified matching md5
+(`librexgpu-renutrd.so` `f566b553876afdd45850248b8e777e2b`). **User has not yet tested this
+build — get that result before concluding anything about this candidate**, then proceed to the
+full-audit findings below regardless of this one result (the audit itself is independently
+valid either way).
+
+## FULL SHARED-CODE DIFF AUDIT COMPLETE (2026-08-18) — every uncommitted change in the SDK checked
+
+User pushed back on one-at-a-time toggle guessing ("please just look into the full
+implementation... double check everything"). Response: used `git diff --stat` in
+`rexglue-sdk-src` (this SDK clone's ENTIRE native-effort history is uncommitted working-tree
+diff against pristine upstream — nothing to bisect via commits, but the full diff itself is
+directly readable) to enumerate literally every modified file, then read each one in full and
+classified it. Result — **every single non-native-gated file diff in the SDK is now
+individually accounted for**:
+
+| File | What changed | Verdict |
+|---|---|---|
+| `command_processor.cpp` (vulkan) | `kRenutDynamicConstants` dynamic-offset descriptor reuse | **Tested disabled — ruled out** |
+| `command_processor.cpp` (vulkan) | ~40 perf counters/timers, barrier-site tracking, A/B benchmark harness | Counters only, unused when their cvars are off — ruled out |
+| `command_processor.cpp` (base) | perf counters + gates a debug-log lookup behind `should_log()` | Behaviorally identical when logging is off — ruled out |
+| `pipeline/texture/cache.cpp` | `RequestTextures` early-return on already-in-sync bindings | **Tested disabled — ruled out** |
+| `pipeline/texture/cache.cpp` | one-shot tiling-format inventory log | Logging only — ruled out |
+| `pipeline_cache.cpp` (vulkan) | raw-ucode/vfetch-disasm dump tooling | Gated behind `renut_dump_ucode_hash` (default false) / one-shot debug log — ruled out |
+| `texture_cache.cpp` (vulkan) | 2 perf counters in `RequestTextures` | Counters only — ruled out |
+| `shared_memory.cpp` (vulkan) | 3 perf counters in `UploadRanges` | Counters only — ruled out |
+| `shared_memory.cpp` (base) | `RequestRanges` reuses a persistent scratch vector instead of a local one | **Tested disabled — ruled out** |
+| `deferred_command_buffer.cpp/h` | adds `CmdVkSetCullMode`/`CmdVkSetFrontFace` | Dead code, zero call sites anywhere in the tree — ruled out |
+| `translator.cpp`/`translator_disasm.cpp`/`shader.h` | thread an `instruction_address` field through vertex-fetch parsing; null-check crash fix in disasm | Purely additive metadata + a debug-only crash fix, doesn't change parsing/translation output — ruled out |
+| `vulkan_submission_tracker.cpp` | GPU-wait timing counters around `vkWaitForFences` | Stores `VkResult` in a local before comparing — behaviorally identical — ruled out |
+| `vulkan_upload_buffer_pool.cpp` | adds `VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT` when a pool requests `VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT` | Conditional on a usage bit only native's own constant pool sets — inert for stock buffers — ruled out |
+| `vulkan_device.cpp`/`device.h` | enables optional device features/extensions (bufferDeviceAddress, descriptor indexing, extendedDynamicState) | Feature enablement only; nothing uses descriptor-indexing/extended-dynamic-state features outside native-only code and the dead `CmdVkSetCullMode` above — ruled out |
+| `renderdoc_api.cpp`/`dynlib.*` | `Load` → `LoadExisting` (`dlopen(..., RTLD_NOLOAD)`) for RenderDoc detection only | Unrelated to rendering — ruled out |
+| `CMakeLists.txt` / `rexglue_install.cmake` / `graphics/CMakeLists.txt` | build wiring for new renut source files/targets | Not runtime logic — not read in full, but not a plausible per-draw-behavior source |
+
+**Bottom line: there is no remaining un-tested, behavior-changing, non-native-gated code path
+in this SDK's diff that hasn't at least been shipped for testing.** Three real candidates were
+found and individually disabled/rebuilt/deployed: `kRenutDynamicConstants` (tested, ruled out),
+`TextureCache::RequestTextures`'s early-return (tested, ruled out), and
+`SharedMemory::RequestRanges`'s scratch-buffer reuse (shipped, user result pending — check
+history.md's top section for whether this came back before reading further). Everything
+else in the diff is counters/logging/dead-code/unrelated-tooling with no plausible rendering
+effect.
+
+**This means the premise itself needs re-examination next session.** Either:
+(a) the bug is in reNut's OWN code (not the SDK) — `renut_xenos_pipeline_cache.cpp` and friends
+   are native-PIPELINE-gated by design, but are they fully inert when
+   `RENUT_DISABLE_ALL_NATIVE=1`? Re ‑verify: does anything in that file run unconditionally
+   before/outside the `RecordAndCheckPairEnabled` gate — e.g. `EnsureBindlessHeapInitialized`,
+   descriptor pool/layout creation, or anything touching the SAME descriptor sets/layouts stock
+   also uses (shared pipeline layout, shared descriptor pool)? This was NOT checked this
+   session — the disable flag only gates PIPELINE SELECTION, not necessarily every side effect
+   of the native code having run at all during this process's lifetime;
+(b) the RENUT_DISABLE_ALL_NATIVE=1 test itself has a gap (e.g. does disabling stop pipeline
+   CREATION too, or only which pipeline gets bound for a draw — if native pipelines are still
+   being built/warmed even while disabled, and that creation path has a side effect on shared
+   Vulkan state, disabling draw SELECTION wouldn't fully isolate it);
+(c) the user's "always been there in pristine" claim needs one more sanity check: is it possible
+   what they remember as "runs almost perfectly" pre-dates a change that's actually
+   ALWAYS-COMPILED-IN (not `#if RENUT_OPTIMISATIONS` gated at all) rather than something in this
+   diff — i.e. check if `RENUT_OPTIMISATIONS` itself is unconditionally `1` for the `renut`
+   target (confirmed earlier: `target_compile_definitions(rexgpu-renut PRIVATE
+   RENUT_OPTIMISATIONS=1)`, always on for this target, never actually toggle-able at runtime) —
+   so "disable the native shaders" and "disable RENUT_OPTIMISATIONS" are NOT the same lever, and
+   a true pristine-behavior test has never actually been run on the CURRENT build. **Next
+   session: try a build with `RENUT_OPTIMISATIONS=0` for `rexgpu-renut` (not just the
+   `RENUT_DISABLE_ALL_NATIVE=1` runtime flag) as the real clean-room test** — this compiles out
+   every one of the above candidates simultaneously via the same guard they all share, rather
+   than continuing to hunt file-by-file.
+
+## BREAKTHROUGH (2026-08-18, same day): the "fully disabled" A/B test was never actually complete
+
+Also checked (b) from the list above before jumping to the `RENUT_OPTIMISATIONS=0` clean-room
+build, since it's cheaper to verify first: **does `RENUT_DISABLE_ALL_NATIVE=1` actually stop
+EVERY native substitution path?** Answer: **no.** There are TWO separate, independent native
+substitution mechanisms in `command_processor.cpp`'s draw path
+(`renut_xenos_pipeline_cache.cpp:5104` region):
+1. `renut_xenos_pipeline::HasNativePipeline(...)` — the general, "convert the important/common
+   shaders" pipeline cache. This IS what `RENUT_DISABLE_ALL_NATIVE=1` gates (via
+   `RecordAndCheckPairEnabled`).
+2. `renut_phase1::IsTargetDraw(...)` (`renut_phase1_native_draw.cpp`) — an OLDER, separate
+   "Phase 1" proof-of-concept, checked SECOND, completely independent of the flag above. It
+   matches purely on VERTEX shader hash (`kTargetVertexShaderHash =
+   0x67021cae68a26b46`) against ONE specific real vertex shader confirmed present in actual
+   gameplay, and when matched, substitutes a hand-picked, UNRELATED, hardcoded pixel shader
+   (`ps_12c73f3eb45dad49`) — its own header comment states outright: **"substituted draws will
+   not visually match what the guest draw would have looked like... an explicit, understood
+   tradeoff for making the mechanism observable/measurable at all, not a mistake."** This was
+   left ACTIVE, unconditionally, in every build shipped this whole investigation, including the
+   "RENUT_DISABLE_ALL_NATIVE=1, zero native draws" test that the user's earlier "still
+   flickering" result was based on. **That earlier test was not actually a clean stock-only
+   run** — this one specific real, frequently-drawn shader was still being deliberately
+   mis-rendered the whole time.
+
+**Fixed**: wired `RENUT_DISABLE_ALL_NATIVE=1` into `IsTargetDraw` too (local `std::getenv` check
+in `renut_phase1_native_draw.cpp`, since it's a different translation unit than the
+anonymous-namespace flag in `renut_xenos_pipeline_cache.cpp`). Built, deployed, verified matching
+md5 (`librexgpu-renutrd.so` `1e0acb0e5778da9c16fd53445ae180f1`).
+
+**Next step, NOT yet run: the user needs to re-test with `RENUT_DISABLE_ALL_NATIVE=1` set —
+THIS is now the first genuinely complete "100% stock, zero native substitution of any kind"
+build in this whole investigation.**
+- If flickering STOPS now: confirms native rendering (in one of its two forms) IS the real
+  cause after all, and specifically narrows it to either general native pipelines or this one
+  Phase 1 shader — worth then testing `RENUT_DISABLE_ALL_NATIVE` unset (normal native-enabled
+  play) but with ONLY the Phase 1 mechanism forced off, to isolate which of the two it actually
+  is. Given Phase 1's deliberately-wrong-pixel-shader design, it's a strong standalone suspect
+  for at least PART of what's been reported.
+- If flickering PERSISTS even now: the native-rendering hypothesis is genuinely dead for this
+  symptom, and the `RENUT_OPTIMISATIONS=0` clean-room build (see above) is the next real step —
+  at that point everything renut-authored will be compiled out simultaneously.
+
+**RESULT: flickering STILL PERSISTS even with the Phase 1 gap closed
+(`RENUT_DISABLE_ALL_NATIVE=1`, both native mechanisms now genuinely off).**
+
+**Deploy-chain sanity check (2026-08-18, user asked "are you sure I'm compiling/deploying the
+right thing")**: verified end-to-end, all real:
+- User confirmed (asked directly, not assumed) they launch
+  `out/build/linux-amd64-relwithdebinfo/renut` directly -- NOT either of the two
+  `reNut-x86_64.AppImage` files on the system (one next to the game files, one in
+  `reNut/dist/`), which is good because **neither AppImage bundles `librexgpu-renutrd.so` at
+  all** (extracted both, confirmed only `librexgpu-xenosrd.so`/`librexruntimerd.so`/
+  `libTracyClientrd.so` present) -- would have been a real dead end if they'd been testing via
+  either one.
+- Plugin path resolution confirmed via source (`gpu_plugin_loader.cpp:56`,
+  `rex::filesystem::GetExecutableFolder() / PluginFileName(name)`) -- relative to the
+  EXECUTABLE's own location, not CWD, so launching from any terminal directory still loads the
+  right file.
+- Live user config confirmed: `~/.config/renut/renut.toml` has `gpu_plugin = "renut"` (not
+  `"xenos"`).
+- Every rebuild this session verified matching md5 between the SDK's build output and the
+  deployed copy in the game's build dir, plus a successful `ctypes.CDLL` load, before handing
+  off to the user.
+**Conclusion: the build/deploy chain is not the problem. The flicker is real and has survived
+every fix and every full native-disable this session.**
+
+## Where this leaves things — native rendering hypothesis is now genuinely exhausted
+
+Both native substitution mechanisms fully disabled, tested clean, flicker unchanged. Combined
+with the full shared-code audit (all 3 real candidates individually tested, all ruled out), the
+native-renderer effort's code is no longer a plausible source of THIS symptom. Two real options
+remain for next session, in priority order:
+1. **`RENUT_OPTIMISATIONS=0` clean-room build** (compile-time, not runtime) -- the one thing
+   never actually tried. Compiles out literally everything renut-authored in the SDK
+   simultaneously (all instrumentation, all optimizations, all native pipeline code paths) via
+   the single shared guard. If flicker STILL persists even here, the bug predates ALL of this
+   session's and prior sessions' native-renderer work entirely, and is either in reNut's own
+   game-side code (hooks, recompiled game code in `generated/renut_recomp.*.cpp`, midasm hooks)
+   or is a genuine pre-existing Xenia-stock/driver issue that the user's "runs almost perfectly"
+   recollection may be misremembering or that has a narrower trigger condition than "always."
+2. If (1) still flickers: pivot to driver/environment-level checks (this is an RDNA4 card on a
+   very new/recent driver stack per `renut_native_shader_investigation` memory) -- try disabling
+   MSAA/other `renut.toml` options one at a time, check for `VK_LAYER_KHRONOS_validation`
+   messages during a play session (not yet done this investigation), and reconsider whether
+   "flickering, specific textures/objects, constant, standing still" might describe a driver-side
+   texture-compression/caching bug rather than anything in this codebase at all.
+
+## REAL BUG FOUND AND FIXED (2026-08-18) — vertex-fetch batching, not a toggle-and-test guess
+
+User asked to double check the xenos-vs-renut A/B directly (not assumed): **confirmed by the
+user that `gpu_plugin = "xenos"` (zero renut code, separate CMake target
+`rexgpu-xenos`) is 100% clean, no flickering, no artifacts.** This is the first fully clean A/B
+in the whole investigation and definitively confirms the bug is in code exclusive to
+`rexgpu-renut`.
+
+Re-examined the CMakeLists.txt: `REXGPU_RENUT_SOURCES = REXGPU_XENOS_SOURCES` (same base file
+list, compiled twice with different `RENUT_OPTIMISATIONS` defines) plus a few renut-exclusive
+files. Read the renut-exclusive files in full
+(`src/graphics/renut/{command_processor,graphics_system,plugin_main}.cpp`) — confirmed trivial
+pass-through subclassing, not the cause. That leaves only `#if RENUT_OPTIMISATIONS` blocks in
+the SHARED files. Grepped every remaining occurrence in `command_processor.cpp` not yet
+individually audited (previous sessions only checked a subset) and found a real one at
+`VulkanCommandProcessor::IssueDraw`'s vertex-fetch-request loop, ~line 4843-4926:
+
+**The bug**: this code batches missing vertex-buffer upload requests instead of issuing them
+immediately (real, legitimate perf optimization -- fewer barrier transitions). But the per-index
+dedup cache (`vertex_buffer_states_[vfetch_index].address/.size`) was updated to the NEW target
+address/size **at the moment an entry was queued into the batch**, before the batched
+`SharedMemory::RequestRanges` call actually ran (that only happens once, after the ENTIRE
+vfetch double-loop finishes). If the function returned early for ANY other reason between
+queuing an entry and reaching that flush -- e.g. a LATER vfetch constant in the same loop turns
+out invalid and hits one of the existing `return false;` paths a few lines below (line
+~4878/4882) -- the batch's `RequestRanges` call never runs, so the actual GPU upload for every
+already-queued entry silently never happens. But their `state.address/size` had ALREADY been
+optimistically updated to match the target -- so on every SUBSEQUENT draw reusing that exact
+same vertex-buffer address (extremely common; a static mesh's fetch constant doesn't change
+draw-to-draw), the "already in sync, skip" check at the top of the loop (`state.address ==
+vfetch_constant.address && state.size == vfetch_constant.size`) would now incorrectly return
+true, permanently skipping the real upload forever for that vertex buffer -- until the game
+happens to rewrite that fetch constant to a different address (which self-heals it, explaining
+why this wouldn't be 100% permanent/universal, just persistent for specific objects). This is a
+real, non-hypothetical correctness bug: a specific real object's vertex data can get "stuck"
+un-uploaded (rendering with stale/zeroed/whatever-was-there-before data) for the rest of the
+session, matching "specific textures/objects [wrong], constant, standing still" exactly, and
+explaining why it's PER-OBJECT rather than universal (only objects unlucky enough to be queued
+in the same draw as a later invalid fetch constant are affected).
+
+**Fixed**: moved the `state.address = ...; state.size = ...;` assignment out of the queuing
+point and into the success loop that runs only after the batched `RequestRanges` call is
+confirmed to have succeeded (mirrors exactly what the immediate/non-batched fallback path a few
+lines below already does correctly). Built, deployed, verified matching md5
+(`librexgpu-renutrd.so` `15e260af417e46c2bee0da52d52bbbb5`). `gpu_plugin` confirmed still
+`"renut"` in the live config (was temporarily switched to `"xenos"` for the A/B test, switched
+back).
+
+**RESULT: flickering STILL PERSISTS even with the vfetch-batching bug fixed.** Keep the fix
+(it's a real bug regardless), but it is not the/a sole cause of the reported symptom.
+
+**Remaining `#if RENUT_OPTIMISATIONS` blocks individually checked same session** (all of
+`command_processor.cpp`'s occurrences, `command_processor.h:832`, `pipeline_cache.cpp`'s):
+all confirmed counters/logging/scratch-buffer-declaration only, matching the earlier full audit.
+**Every `#if RENUT_OPTIMISATIONS` block in the entire SDK is now individually accounted for.**
+Also confirmed: `renut_xenos_pipeline::`/`renut_phase1::` functions are called ONLY from the two
+already-gated sites in `IssueDraw` (grepped every call site) -- no unconditional setup/side
+effect runs when both are disabled. `rexgpu-xenos` vs `rexgpu-renut` build flags differ only in
+`RENUT_OPTIMISATIONS`, `VK_ENABLE_BETA_EXTENSIONS`, extra source files, and imgui include dirs --
+no optimization-level or sanitizer difference that could explain divergent UB exposure.
+
+## External research (2026-08-18): XenosRecomp's real, documented limitations
+
+User asked to research whether Xenos->Vulkan shader conversion has ever worked reliably.
+Fetched XenosRecomp's own README (hedge-dev/XenosRecomp on GitHub). Key facts, verified by
+direct quote, not paraphrase:
+- Built explicitly for **Unleashed Recompiled** (Sonic Unleashed), which "implements a
+  translation layer for the renderer rather than emulating the Xbox 360 GPU" -- a
+  fundamentally different integration style than reNut's (Xenia-derived GPU-EMULATION renderer
+  substituting native pipelines into an otherwise-emulated fixed-function pipeline). Explicit
+  warning: "Users are expected to modify the recompiler to fit their needs. Do not expect the
+  recompiler to work out of the box."
+- Named incomplete/missing: dynamic register indexing (partially addressed by reNut's own
+  2026-08-17 fix, see fixes-history), mini vertex-fetch instructions, 1D textures, several
+  texture fetch features, memexport (reNut has its own graceful-skip for this), point size,
+  INF/NaN ALU edge cases, integer constants.
+- **Boolean constants packed into a 32-bit integer, capped at 16 per stage** -- explicitly
+  flagged as "potentially insufficient for other games requiring up to 128 boolean registers."
+  NOT yet checked against Banjo-Kazooie: Nuts & Bolts' real shader corpus this session -- if any
+  BK:N&B shader indexes a boolean constant register >=16, it would silently alias/misread,
+  producing a wrong-but-shader-specific result. Real, concrete, unchecked lead for the
+  ORIGINAL native-shader corruption (stretched textures/non-spawning items), NOT the current
+  flicker (native is fully disabled and still flickers, so this can't be its cause right now).
+- Vertex-declaration handling has Sonic-Unleashed-specific hardcoded overrides ("Certain
+  semantics are forced to be uint4 instead of float4 for specific shaders in Sonic Unleashed")
+  and instanced-geometry handling is stated outright to be "completely game specific and must be
+  manually implemented for other games" -- BK:N&B's own equivalent overrides, if any are needed,
+  have never been audited for existence.
+- **This explains the ORIGINAL, still-unsolved "CORE UNSOLVED PROBLEM" (stretched
+  textures/non-spawning items, see that section below) far better than anything investigated in
+  the 2026-08-17 session** -- those bugs were all real, but none were "is this game hitting a
+  documented, named XenosRecomp gap that was only ever solved for a different game's shader
+  set." **Does NOT explain the CURRENT flicker**, which is proven (by the disable tests above)
+  to occur with zero XenosRecomp-compiled shaders executing at all.
+
+## Where this leaves things, honestly, end of session
+
+Two genuinely separate problems are now untangled:
+1. **The ORIGINAL native-shader corruption** (stretched textures, non-spawning items) -- a real,
+   still-open problem, now with a much stronger research-backed lead (XenosRecomp's named,
+   game-specific gaps above, especially the 16-boolean-constant cap) than any prior session's
+   guesses. Next step: audit BK:N&B's real shader corpus for boolean-constant usage patterns the
+   same way earlier sessions measured `exp_adjust`/`signed_rf_mode`/texture-dimension usage
+   (`tools/ucode_analyze.cpp` + a `scratchpad/` sweep script) -- concrete, checkable, not another
+   guess.
+2. **The CURRENT flicker** (specific textures/objects, constant, standing still) -- proven via
+   multiple independent tests to be UNRELATED to native shaders (`RENUT_DISABLE_ALL_NATIVE=1`
+   covering both substitution mechanisms, still flickers) and unrelated to 4 individually-tested
+   real behavioral candidates (`kRenutDynamicConstants`, `TextureCache::RequestTextures`
+   early-return, `SharedMemory::RequestRanges` scratch reuse, the vfetch-batching bug -- fixed,
+   kept, but not the/a sole cause). Every line of the SDK's diff against pristine upstream has
+   now been read and classified. **Code-reading of this diff is exhausted as a technique for
+   this specific symptom.** Confirmed via `gpu_plugin = "xenos"` A/B (user-verified 100% clean)
+   that the bug is real and specific to `rexgpu-renut`'s compiled output, not a environment/
+   driver-wide issue.
+   ~~Recommended next step: use RenderDoc~~ -- user asked for Tracy instead + a verbose debug
+   log; RenderDoc needs interactive GUI use neither of us has here, Tracy is a timing profiler
+   (doesn't show resource/data state), so built the actual right tool instead: see below.
+
+## NEW TOOL BUILT 2026-08-18: live-triggered verbose per-draw trace file
+
+Built at the user's explicit request ("focus on adding a lot of debugging that gets put into a
+file for you to read... every step the renderer takes it outputs what it does and what it
+expects"). Not RenderDoc (needs interactive GUI, neither of us has display access) or Tracy
+(timing only, doesn't show what data a draw actually used) -- a plain text trace file, since I
+can read files directly.
+
+**How it works** (`command_processor.cpp`, all in `rex::graphics::vulkan` namespace, NOT gated
+by `RENUT_OPTIMISATIONS` so it also compiles into `rexgpu-xenos` for a future true A/B if ever
+needed):
+- `renut_verbose_trace_frames` cvar (int, default 0, currently `2` in
+  `~/.config/renut/renut.toml`) -- how many frames to capture once triggered.
+- **Live file trigger, not a boot-time counter** (first version was boot-time-only and would
+  have only ever captured the intro videos -- caught and fixed before shipping): every frame
+  (`RenutVerboseTraceOnFrameEnd`, called from `IssueSwap`), the game does one cheap
+  `std::filesystem::exists()` check for `renut_start_trace.flag` next to the executable
+  (`out/build/linux-amd64-relwithdebinfo/`). When found, it's deleted (fires once) and the next
+  N frames get traced to `renut_verbose_trace.log` in the same directory, then the file is
+  closed automatically.
+- **To trigger a capture**: with the user already standing at/near the flickering object,
+  create `out/build/linux-amd64-relwithdebinfo/renut_start_trace.flag` (empty file, any content)
+  -- I can do this myself directly via the Write tool, no user action needed once they're in
+  position. Read `renut_verbose_trace.log` afterward, also directly.
+- **What gets logged per draw**: `vs_<hash>`/`ps_<hash>`, primitive type, index count; every
+  vertex-fetch constant touched (`ALREADY SYNCED, skipped` vs `MISS ... requesting upload`, plus
+  the batch-flush outcome); every texture binding resolved (fetch_constant, dimension, signed,
+  the real `VkImageView` pointer, flagged `-- NULL VIEW` if unbound); and the final
+  native-vs-Phase1-vs-stock DECISION line. Two consecutive frames of the exact same static scene
+  can be diffed line-by-line -- anything that differs between them for the same draw (a
+  different image-view pointer for the same fetch_constant, a vfetch flipping between SYNCED and
+  MISS, etc.) is the actual mechanism of the flicker, not a guess.
+**USED, 2026-08-18, same session**: user got in front of flickering geometry, trigger fired
+twice ~2s apart (renamed to `renut_trace_A.log`/`renut_trace_B.log` before each got overwritten
+by the next capture). `renut_verbose_trace_frames` in `renut.toml` does NOT hot-reload from a
+live-edited file while the process is already running (edited 2->4 mid-session, had no effect,
+stayed at the boot-time value of 2) -- only 1 full frame captured per trigger despite requesting
+more; worked around by triggering twice and diffing the two single-frame snapshots directly
+instead of true N-consecutive-frames.
+
+**Findings from analysis** (`renut_trace_A.log`/`renut_trace_B.log`, both still on disk in
+`out/build/linux-amd64-relwithdebinfo/` for further analysis):
+- ~53% of all texture bindings resolve to a NULL `VkImageView` (7786/14488 in the first single-
+  frame capture) -- **investigated and RULED OUT as a bug**: this is the `is_signed=true`
+  variant of a texture whose real fetch-constant is currently unsigned, in code SHARED with
+  `rexgpu-xenos` (confirmed clean) -- `spirv_translator_fetch.cpp` always statically declares
+  both signed/unsigned bindings per Xenos's real per-channel-sign hardware feature, but only
+  samples whichever one the real runtime sign bits select; a texture legitimately not needed
+  this draw stays unbound. Normal, not a lead.
+- **Real finding, not yet resolved either way**: diffed the two single-frame snapshots
+  (`scratchpad`-style Python, not saved -- rerun the same regex-based parse over
+  `renut_trace_A.log`/`renut_trace_B.log` if resuming this) by grouping texture bindings per
+  (vertex shader hash, pixel shader hash, stage, fetch_constant, signed) and comparing the SET
+  of real `VkImageView` pointers seen. Out of 3239 such keys common to both captures, 12 differ
+  -- ALL 12 are `fetch_const=11, unsigned`, across 11 DIFFERENT shader pairs, and they all swap
+  between the exact same two real texture pointers (`0x7fa2b76b46c0` /`0x7fa2b62b66b0`) from
+  capture A to capture B, while the user stood still. Drilled into one pair
+  (`vs_9bd6d5e87f320c3a`/`ps_1068bca74c165c43`): it draws exactly twice per frame in both
+  captures (once with `tex11=nil`, once with a real pointer), and it's the SECOND draw's real
+  pointer that flips between captures.
+- **Genuinely ambiguous, not resolved**: this is consistent with EITHER (a) a real stale-binding
+  bug on the shared hardware fetch-constant register 11 (many objects share it across a frame;
+  something reads whichever value happens to be bound at a slightly wrong moment), OR (b) normal
+  intended behavior -- the same shader pair legitimately reused for multiple different on-screen
+  objects/icons within one frame, each meant to bind its own different texture, and the two
+  captures just happened to draw those instances in a different order/content 2 seconds apart
+  (menu icons/HUD elements can animate even while the player stands still). Asked the user
+  whether the visible flicker looks like it toggles between two distinct looks vs. random noise
+  -- answer was "not sure," inconclusive.
+
+**Next session, concrete and cheap**: the codebase ALREADY has an unrelated feature
+(`GetDebugShaderLabels()`/`DebugLabelPositions()`, `ndc_x`/`ndc_y`, see "2026-08-17 late
+session" notes below) that records each native draw's on-screen NDC position. Extend the SAME
+idea into `RenutVerboseTraceFile()`'s per-draw logging (print the draw's real NDC/screen
+position alongside its texture bindings) -- this would let the register-11 finding above be
+resolved definitively: if the two flip-flopping draws land at the SAME screen position across
+captures, it's a real bug; if they land at two different, sensible positions, it's normal
+per-instance reuse. Also worth fixing properly this time: make `renut_verbose_trace_frames`
+actually take effect without a process restart (either re-read it fresh every trigger poll
+instead of only once, or confirm/document that a restart really is required) so a true
+N-consecutive-frame capture is possible instead of stitching together separately-triggered
+single frames.
+
+**Prior fix, implemented, built, and deployed** (details below, kept for provenance — this is
+the fix that produced zero visible change, described above):
+
+What changed, in `renut_xenos_pipeline_cache.cpp`:
+- `kBindlessHeapSlotCount` grown from 32 to 4096 (descriptor pool size and set-layout binding
+  count already derived from this constant, so this propagated automatically; build succeeded
+  with no device-limit failures reported at pool-creation time).
+- `BindlessHeapState` gained `std::unordered_map<uint64_t, uint32_t> texture2d_slot_map` (keyed
+  by a combined `VkImageView`+`VkSampler` identity hash, `CombineTextureSamplerKey`) and
+  `uint32_t next_free_texture2d_slot = 0`.
+- `BindTexture2DFixedSlot` renamed to `ResolveTexture2DSlot`, now takes an `out_slot` param:
+  resolves the real view/sampler as before, looks up its identity in `texture2d_slot_map`,
+  reuses the slot if already allocated, else allocates `next_free_texture2d_slot++` and writes
+  the descriptor exactly once. Returns false (triggering a full draw skip, matching stock's
+  fallback behavior) if the slot pool is exhausted — logs one real warning via a
+  `static std::atomic<bool> warned` guard, not spammed per-draw.
+- `IssueNativeDraw`'s texture-binding loop now writes the **assigned stable slot** (not
+  `tb.fetch_constant`) into `shared_constants.texture2d_indices[tb.fetch_constant]` /
+  `sampler_indices[tb.fetch_constant]` — this is the actual fix: two different draws in the
+  same frame that both use hardware register N for two different real textures now each get
+  their OWN permanent slot number written into their OWN per-draw `SharedConstants` buffer,
+  instead of both racing to overwrite ONE shared descriptor-set slot keyed by register number.
+- The `>= kBindlessHeapSlotCount` bound check in the same loop was corrected to `>= 16` — that
+  check is about the `texture2d_indices[16]` array position (`tb.fetch_constant`, a hardware
+  register 0-31), which is a completely different number from the (now much larger)
+  `kBindlessHeapSlotCount` slot-pool size. Reusing the pool-size constant there would have
+  silently allowed out-of-bounds array writes into `SharedConstantsLayout` once the pool grew
+  past 16. Caught and fixed during this session's edit, not a leftover bug.
+
+**Original root-cause narrative** (verified 2026-08-18, before the fix above; kept for
+provenance):
+
+**Verified root cause of the persistent flickering/wrong-texture symptom** (see the
+"CORE UNSOLVED PROBLEM" section below for full backstory/prior fixes): the native
+path's bindless texture heap (`BindlessHeapState` in
+`/home/nick/Desktop/reNut-build-scratch/rexglue-sdk-src/src/graphics/vulkan/renut_xenos_pipeline_cache.cpp`)
+indexes heap slots by the Xenos hardware fetch-constant REGISTER NUMBER (0-31,
+`kBindlessHeapSlotCount`), not by real texture identity. Verified facts (not
+speculation):
+1. Xenos hardware has exactly 32 fetch-constant registers; this game has far more
+   than 32 distinct textures, so the same register number is guaranteed to get
+   rebound to different real textures many times within one frame -- that's normal
+   fixed-function operation, not a bug in the game.
+2. `GetHeapState()` returns ONE `static BindlessHeapState`, shared for the whole
+   process lifetime -- not duplicated per frame-in-flight.
+3. `kMaxFramesInFlight = 3` (`command_processor.h`), and the codebase's OWN existing
+   pattern elsewhere (`swap_descriptors_*` arrays) shows it already knows to
+   duplicate descriptor resources per frame-in-flight for exactly this reason -- the
+   bindless heap just doesn't do it.
+4. The STOCK renderer's real texture-binding path (`texture_cache.cpp`/
+   `command_processor.cpp` ~line 7649-7684) does NOT use this pattern at all -- it
+   writes fresh per-draw descriptor image info with dirty-tracking tied to the
+   actual current draw, never a shared slot reused across unrelated draws by
+   register number.
+
+`vkUpdateDescriptorSets` writes take effect immediately on the CPU, and a whole
+frame's draws are recorded before the GPU touches any of them -- so whichever draw
+last wrote a given slot number wins for EVERY draw in that frame (and possibly the
+previous still-in-flight frame) that references that slot number. Frame-to-frame
+timing jitter changes which write "wins" -> flickering, not a fixed wrong-but-stable
+error. This is forced by the four facts above, not a guess.
+
+**Exact fix plan (executed 2026-08-18 exactly as written below — kept for provenance)**:
+1. Key heap slots by STABLE texture identity (the real `VkImageView` handle --
+   stable while a texture stays resident -- paired with its `VkSampler`) instead of
+   `fetch_constant_index`. Add e.g. `std::unordered_map<std::pair<VkImageView,VkSampler>, uint32_t>`
+   (needs a hash/equal for the pair, or combine into a single key) plus a
+   `uint32_t next_free_slot = 0;` to `BindlessHeapState`.
+2. Grow `kBindlessHeapSlotCount` from 32 to a few thousand (e.g. 4096) --
+   `renut_xenos_pipeline_cache.cpp:471`. Descriptor pool size
+   (`pool_sizes[0/1].descriptorCount`, ~line 631/633) and set-layout binding count
+   (~line 549) already derive from this constant, so bumping it should propagate
+   automatically -- verify device limits (`maxDescriptorSetSampledImages` etc.) are
+   comfortably above 4096 on the RX 9070 target before assuming this is free.
+3. Rewrite `BindTexture2DFixedSlot` (~line 1654-1692, currently keyed on
+   `fetch_constant_index`, `kBindlessHeapSlotCount` guard at line 1663) to: resolve
+   view/sampler as today, look up the (view,sampler) pair in the map, reuse the
+   slot if found, else allocate `next_free_slot++` (bounds-check against the new
+   larger `kBindlessHeapSlotCount`) and write the descriptor ONCE (not every call).
+   Needs an out-parameter or return value carrying the assigned slot number back to
+   the caller (current signature just returns bool success/fail).
+4. Update `IssueNativeDraw`'s texture-binding loop (~line 1916-1955,
+   `shared_constants.texture2d_indices[tb.fetch_constant] = tb.fetch_constant;` /
+   same for `sampler_indices`) to write the ASSIGNED STABLE SLOT returned by step 3,
+   not `tb.fetch_constant`. This is the actual value XenosRecomp's compiled
+   shaders read at runtime (`shader_recompiler.cpp:1272-1277`,
+   `vk::RawBufferLoad<uint>(SharedConstants + dim*64 + registerIndex*4)`) -- the
+   `registerIndex` in that formula is still `tb.fetch_constant` (that part of the
+   ABI is correct and already fixed this session), only the STORED VALUE at that
+   byte offset needs to change from "the register number" to "the real heap slot."
+5. No eviction in this first pass -- slots accumulate for the session (acceptable;
+   note as a known follow-up if very long play sessions ever matter).
+6. After implementing: `ninja rexgpu-renut` (from
+   `/home/nick/Desktop/reNut/out/build/linux-amd64-relwithdebinfo`, NOT the
+   standalone SDK dir -- see "Standing procedures" section for why), copy fresh
+   `librexgpu-renutrd.so` to the game build dir, verify via ctypes, hand to user.
+   No shader reconversion needed (XenosRecomp/HLSL side is untouched by this fix,
+   only the C++ runtime-side heap management changes).
+
+**Also still true from the prior fix that DID ship and IS deployed** (verify still
+correctly in place before starting the above, don't re-do): `SharedConstantsLayout`'s
+first 256 bytes hold `texture2d_indices[16]`/`texture3d_indices[16]`/
+`texturecube_indices[16]`/`sampler_indices[16]` (was dead zeroed padding before
+2026-08-17's root-cause fix); debug-colorize mode defaults to `false` (was
+accidentally left `true`, which had been masking pixel-stage fixes during testing --
+fixed same session, confirm it's still `false` before assuming a build "does
+nothing").
+
+## Project Map
+
+### Game repo: `/home/nick/Desktop/reNut/` (git, branch `linux-work`; main is `main`)
+- `CMakeLists.txt` — `project(renut)`, C++23, `add_executable(renut ...)`.
+  Wires the shader pipeline: `renut_xenos_shader_batch(renut ...)` with
+  dependencies `renut_synthesize_constant_tables_target` and
+  `renut_synthesize_containers_from_ucode_target`, and forces
+  `rexgpu-renut` to depend on `renut_xenos_shader_batch`.
+- `cmake/rexglue_xenosrecomp.cmake` — FetchContent of hedge-dev/XenosRecomp as a
+  host tool; defines `renut_xenos_shader()` (single shader -> HLSL) and
+  `renut_xenos_shader_batch()` (whole dump dir -> compiled SPIR-V cache .cpp).
+  Header comment holds the real rationale for the patch below. **Read it before
+  touching the shader build.**
+- `cmake/patches/xenosrecomp_graceful_skip.patch` — two bundled upstream fixes:
+  (1) DXC compile failures become logged skips instead of `assert()` segfaults;
+  (2) `std::execution::par_unseq` -> `seq` in XenosRecomp's own multi-shader loop.
+  **Do not revert.** Measured: `par_unseq` deterministically dropped ~450/2135
+  shaders per run; `seq` converts 100% in ~50s. Applied idempotently via `sh -c`
+  (a bare PATCH_COMMAND string does *not* get a shell — that bug was real and fixed).
+- `CMakePresets.json` — presets `linux-amd64-{debug,release,relwithdebinfo}` and
+  `win-amd64-*`. The one in use is `linux-amd64-relwithdebinfo`.
+- `archive/native-renderer-plan.md` (~85KB) — the long-form native-renderer plan
+  (Phase 0/1/...). Referenced by the cmake files. Large; grep it, don't read whole.
+- `archive/deferred-vfetch-flush.md` (~17KB) — deferred-flush design; that rewrite
+  was **abandoned and reverted** (see memory `renut_barrier_attribution`). Historical.
+- `config/renut_hooks.toml` — midasm hooks (guest addresses -> named C++ hooks).
+- `renut_manifest.toml` / `renut_config.toml` — rexglue SDK project manifest
+  (`sdk_version = "0.9.0"`, entrypoint `assets/default.xex`, out dir `generated`).
+- `src/renut_engine/` — game-side C++: fixes, hooks, `shader_dump.cpp`
+  (guest ShaderContainer parsing; all reads go through `RENUT_BSWAP32` because
+  guest memory is big-endian), `renut_xenos_shader_cache.h`.
+
+### Repo tools: `/home/nick/Desktop/reNut/tools/` (verified 2026-08-17)
+- `xenos_batch_convert.py` — batch-converts shader ucode -> SPIR-V via XenosRecomp.
+  Per-shader subprocess isolation + caching. Parallel via
+  `ThreadPoolExecutor(max_workers=os.cpu_count() or 4)` (line ~237).
+- `build_synthetic_container.py` — synthesizes D3DX9 shader containers.
+  `check_for_missing_literal_constants()` (line ~426) rejects shaders referencing
+  float const registers >=252 without real DefinitionTable data.
+- `batch_build_synthetic_containers.py` — the **batch driver** for the above.
+  This is where `--reject-heuristic` actually lives (it forwards the flag to
+  `build_synthetic_container.py`). Not in `xenos_batch_convert.py`.
+- `xenos_synthesize_constant_table.py` — constant-table synthesis step.
+- `ucode_analyze.cpp` + `build_ucode_analyze.sh` -> binary `ucode_analyze` in the
+  build dir. Dumps structural JSON per ucode file (bindings, formats, float
+  constants, dynamic addressing, ...). Usage: `ucode_analyze <vs|ps> <file.ucode>`.
+- `xenos_cache_unpack.cpp` — unpacks the generated shader cache.
+- `compare_traces.py`, `frame_inventory.py`, `resolve_barrier_sites.sh` — older
+  perf/trace analysis helpers from the barrier-attribution work.
+- `syntax_check_sdk.sh` — syntax-only check of SDK sources (fast pre-build sanity).
+
+### SDK source (build/edit this, NOT a repo checkout): `/home/nick/Desktop/reNut-build-scratch/rexglue-sdk-src/`
+Headers and sources are in **separate trees** — this was wrong in an earlier
+version of this file:
+- Sources: `src/graphics/...`
+  - `src/graphics/command_processor.cpp` — shared PM4 packet dispatch, incl.
+    `ExecutePacketType3_IM_LOAD` / `_IM_LOAD_IMMEDIATE` (line ~977/1705). This is
+    the path that loads shaders straight into sequencer memory with **no D3D9
+    declaration** — the structural root of the vertex-declaration problem.
+  - `src/graphics/vulkan/` — the stock Vulkan backend plus the native effort:
+    `command_processor.cpp`, `pipeline_cache.cpp`, `shader.cpp`,
+    `render_target_cache.cpp`, `texture_cache.cpp`, `shared_memory.cpp`,
+    `primitive_processor.cpp`, `deferred_command_buffer.cpp`, `graphics_system.cpp`.
+  - **Native shader path**: `src/graphics/vulkan/renut_xenos_pipeline_cache.{h,cpp}`
+    — pipeline cache, bindless heap, `HasNativePipeline()` (cpp:681),
+    `IssueNativeDraw()`, `USAGE_LOCATIONS` mirroring (cpp:986/1018/1062),
+    primitive-type fallbacks (cpp:703/725).
+  - `src/graphics/vulkan/renut_shader_debug_panel.cpp` — ImGui debug panel
+    (**no matching `.h`** — its API is declared in `renut_xenos_pipeline_cache.h`,
+    e.g. `Set/GetNativeShaderLabelMatrixRegister` at h:215/216).
+  - `src/graphics/vulkan/renut_phase1_native_draw.{cpp,h}` +
+    `renut_phase1_shaders_spirv.inc` — the earlier Phase-1 hand-built native draw
+    experiment; separate from the pipeline-cache path above.
+  - `src/graphics/renut/` — the shipped **renut plugin** itself
+    (`command_processor.cpp`, `graphics_system.cpp`, `plugin_main.cpp`).
+- Public headers: `include/rex/graphics/...`
+  (`include/rex/graphics/vulkan/command_processor.h`, `include/rex/graphics/renut/…`,
+  `include/rex/graphics/d3d12/…`). `out/install/linux-amd64/include/` is an
+  install-time copy — **don't edit that one**.
+- Built plugins: `out/linux-amd64/librexgpu-renutrd.so`,
+  `librexgpu-xenosrd.so`, `librexruntimerd.so`, `libSPIRV-Tools-sharedrd.so`,
+  `libTracyClientrd.so`.
+
+### Reference documents: `/home/nick/Desktop/reNut/resources/` (indexed 2026-08-17)
+25 PDFs, ~16MB. Extracted plain text cached in scratchpad `restext/` for fast grepping
+(`pdftotext` is installed). **Composition matters: this is a CPU/system library, not a
+GPU one.**
+- **PowerPC / VMX ISA references (authoritative, for XenonRecomp-side work)**:
+  `vector_simd_pem.ppc.2005AUG23.pdf` (318pp, VMX/SIMD PEM), `ALTIVECPEM.pdf` (346pp),
+  `ibm-ppc64-book1.pdf` (220pp), `ibm-ppc64-book2.pdf` (62pp).
+- **Official MS XDK white papers** (`xbox 360 tech docs/`, 21 files, 5-25pp each):
+  CPU overview/caches/alignment/best-practices, VMX128 instruction summary,
+  multithreading + lockless programming, compiler technology, memory page sizes,
+  memory copy functions, dump debugging, build profiling, storage, security, XGD3.
+- **`github repos.txt`**: UnleashedRecomp, XenonRecomp, XenosRecomp, idaxex,
+  XEXLoaderWV, ghidra-fidb-xenonsdk, x360-fidb-generator, fable2mod forum thread.
+- **VERIFIED ABSENT — do not go looking again**: zero occurrences anywhere in the corpus
+  of `xenos`, `vfetch`, `tfetch`, `interpolator`, `vertex declaration`,
+  `constant register`, `shader model`, `render target`. There is **no** Xenos ISA,
+  shader-microcode, or Xbox-360-D3D9 graphics reference here. The native-shader work
+  gets nothing from these; XenosRecomp's own source + Xenia remain the only real
+  primary sources for that.
+- **The two docs with any GPU content**:
+  - `system_xbox_360_hw_overview.pdf` (5pp) — corroborates the hardware model
+    independently: 48 ALUs, one vector + one scalar op per clock, 10MB eDRAM,
+    predicated tiling, HLSL SM3.0 "and beyond", 32-bit IEEE float throughout. Two lines
+    are directly relevant to our conversion failures: *"Vertex shaders can fetch from
+    textures"* (so the 3 `implicit lod in vertex stage` failures are a legitimate,
+    officially-supported feature — fix by emitting `SampleLevel`, not by skipping), and
+    *"shaders also have the unique ability to directly access main memory"* (memory
+    export was a promoted first-class feature, so our 10 memexport shaders are expected,
+    not exotic).
+  - `system_Synchronous_and_Asynchronous_Swaps_Xbox_360.pdf` (21pp) — eDRAM →
+    front-buffer `Resolve` semantics and GPU/CPU swap synchronisation. Relevant to
+    present/frame-pacing and render-target handling, not to shader translation.
+
+### Build output / runtime dir: `/home/nick/Desktop/reNut/out/build/linux-amd64-relwithdebinfo/`
+- `renut` — the game binary (~190MB).
+- `librexgpu-renutrd.so` / `librexgpu-xenosrd.so` — **copies** of the SDK-built
+  plugins. Must be re-copied after every SDK build (see recipe).
+- `marked_bad_shaders.txt` — user-curated `vs_<hash> ps_<hash>` pairs marked bad
+  in-game. Gitignored, not source controlled. Currently **64 pairs / 35 distinct
+  vertex shaders** (verified 2026-08-17). `.bak` alongside holds the pre-cleanup 78.
+- `generated/renut_xenos_shader_cache_manifest.txt` — authoritative per-shader
+  `<tag> <status>` conversion status.
+- `generated/renut_xenos_shader_cache.cpp` (+ `.compressed.cpp`,
+  `.hashremap.bin`, `.resultcache.json`) — the generated cache.
+- `shaders_ucode_hash/` — raw ucode per hash: **525 `vs_*`, 1436 `ps_*`** (1961 files).
+- `ucode_analyze` — built analysis binary.
+- `_deps/xenosrecomp-{src,build,subbuild}/` — the FetchContent'd XenosRecomp.
+- Logs: `~/.local/state/renut/logs/renut_NNN[.M].log` — rotates at ~5MB with a
+  numeric suffix (e.g. `renut_004.10.log`), so one "session" spans many files and
+  one file can span several process launches. Sort by mtime, don't assume naming.
+- Live GPU mem stats (this machine, AMD): `/sys/class/drm/card1/device/mem_info_{vram,gtt}_used`.
+  `card1` is correct here (verified 2026-08-17) but is machine-specific.
+
+## Build/Deploy Recipe
+
+1. `ninja -C out/build/linux-amd64-relwithdebinfo renut`
+2. Verify the plugin loads: `python3 -c "import ctypes; ctypes.CDLL('<sdk>/out/linux-amd64/librexgpu-renutrd.so')"`
+3. `command cp -f` **both** `librexgpu-renutrd.so` and `librexgpu-xenosrd.so` from
+   `/home/nick/Desktop/reNut-build-scratch/rexglue-sdk-src/out/linux-amd64/`
+   to `/home/nick/Desktop/reNut/out/build/linux-amd64-relwithdebinfo/`.
+   **Mandatory** — stale plugin copies silently run old code with no error.
+   Check with `md5sum` on both paths before concluding a test result means anything.
+4. User builds/tests via display access; I don't have one (division of labor).
+
+## Current shader conversion status (measured 2026-08-17 from the live manifest)
+
+| | total | ok | failed |
+|---|---|---|---|
+| Vertex | 516 | **280 (54.3%)** | 236 |
+| Pixel | 1537 | **1531 (99.6%)** | 6 |
+| All | 2053 | 1811 (88.2%) | 242 |
+
+Failure breakdown: `skipped-by-xenosrecomp:SPIR-V` 224 vs + 6 ps;
+`skipped-by-xenosrecomp:memory` 10 vs; `skipped-by-xenosrecomp:duplicate` 2 vs.
+
+**Key structural fact**: the conversion deficit is *entirely* vertex shaders.
+Pixel shaders are essentially solved (99.6%). Every remaining conversion-yield
+lever is a vertex-declaration / vertex-semantic problem. Historical numbers
+quoted elsewhere (12/1884 -> 1492/1884 -> 1706/2208) are older snapshots of a
+differently-sized dump; use the table above.
+
+Note: the manifest (2053 entries) and `shaders_ucode_hash/` (1961 files) don't
+match 1:1 — the manifest also carries entries from container-synthesis inputs
+that have no standalone ucode file. Don't assume one implies the other.
+
+## ✅ DONE (2026-08-17): positional-location rewrite + boolean-constant fix, built and deployed
+
+All fixes below are **applied, compiled, linked, and copied into the live game build
+dir**. Not yet visually tested by the user (I have no display).
+
+**Applied and verified compiling/linking**
+- `_deps/xenosrecomp-src/XenosRecomp/shader_common.h` — `g_Booleans` (1 dword) →
+  `g_BooleanWord(i)` (8 dwords, 256 bools); trailing shared fields moved
+  260/264/272 → 288/292/300. DXIL `DEFINE_SHARED_CONSTANTS` updated to match.
+- `shader_recompiler.cpp` — bool defines + conditional jumps index the full 256-bit
+  file by raw `boolAddress` (also removes upstream issue #17's need for "-128");
+  vertex `[[vk::location]]` now **positional** (`location i` = i-th element) with a
+  `maxVertexInputAttributes = 32` graceful bail; `INTERPOLATORS` extended with
+  Normal0/1/2, Tangent0, Binormal0; register file 32 → 64 (`kNumRegisters`).
+- `src/renut_engine/renut_xenos_shader_cache.h` — `kRenutMaxVertexLocations` 16 → 32;
+  new `kRenutTexCoordSemanticUnset` sentinel + `vertexTexCoordSemanticIndex[]` field
+  on `RenutXenosShaderCacheEntry` (see below).
+- `tools/xenos_cache_unpack.cpp` — `ExtractVertexLocations()` now positional;
+  `LookUpVertexLocation` kept but `[[maybe_unused]]`. New
+  `ExtractVertexTexCoordSemanticIndices()` reads the raw usage/usageIndex bitfield
+  XenosRecomp already writes per vertex element (untouched by the positional-location
+  change) and emits it as a second parallel array, same remap/keying pattern as
+  `vertexLocations[]`.
+- SDK `renut_xenos_pipeline_cache.cpp`, `GetOrCreatePipeline()`:
+  - `SharedConstantsLayout` widened (`booleans[8]`, size 288 → 320, new static_asserts);
+    uploads all 8 bool dwords.
+  - `is_packed_normal_like_usage` (~line 1040) no longer keys off `real_location`
+    (meaningless now that locations are positional) — tests
+    `fetch.attributes.data_format` directly against `k_10_11_11`/`k_11_11_10`/
+    `k_2_10_10_10`, the same enum `VertexFormatToVkFormat()` already switches on.
+  - `is16BitFormat`'s `semanticIndex` recovery (~line 1077, `g_SwappedTexcoords`)
+    no longer switches on `attribute_info.location` — reads
+    `vs_entry->vertexTexCoordSemanticIndex[raw_attribute_index - 1]` instead (the
+    new cache field above). **Key insight found while implementing this**:
+    `tfetchTexcoord()`'s `semanticIndex` argument is baked into the HLSL as a
+    compile-time literal by XenosRecomp itself
+    (`shader_recompiler.cpp`'s `recompile(VertexFetchInstruction)`, reading its own
+    `vertexElements` map) — that part was never broken by the location change.
+    Only this pipeline-cache code's *separate*, redundant runtime reconstruction of
+    the same fact (for the `swapped_texcoords_mask` it uploads) needed fixing.
+
+**Verified end to end**
+- `ninja XenosRecomp` (in game build dir) — clean.
+- Isolated re-probe of the 242 previously-failing shaders: 224 now compile.
+- `ninja rexgpu-renut` (SDK build, `REXSDK_DIR` mode, `RENUT_HAVE_XENOS_SHADER_CACHE=1`)
+  — clean, links `librexgpu-renutrd.so`. (A standalone SDK-only build without
+  `REXSDK_DIR`'s full context hits a **pre-existing, unrelated** `#else`-branch
+  compile error in `IssueNativeDraw` — dead code, `RENUT_HAVE_XENOS_SHADER_CACHE=0`
+  path, not touched by this session, not the real build path — ignore it.)
+- **Real batch conversion re-run** (deleted `resultcache.json` to bypass the
+  content-hash cache, which is not keyed on the XenosRecomp binary version and was
+  silently serving stale skip results): **2035/2053 shaders converted (99.1%)**,
+  vertex **499/516** — matches the projected yield exactly. Remaining 18 skips are
+  the known-legitimate set (10 memexport, 5 vertex implicit-LOD, 2 duplicate-usage,
+  1 swizzle).
+- Fresh `librexgpu-renutrd.so` (117MB, SDK's own `out/linux-amd64/`) copied via
+  `cp -f` into the game build dir
+  (`out/build/linux-amd64-relwithdebinfo/librexgpu-renutrd.so`, was stale from 17:25,
+  now current) and confirmed loadable via `ctypes.CDLL` with all deps resolving.
+
+**Patch captured (2026-08-17, no longer at risk)**: `cmake/patches/xenosrecomp_graceful_skip.patch`
+deleted, replaced by `cmake/patches/xenosrecomp_native_renderer.patch` — a single
+consolidated patch (old graceful-skip fixes + this session's booleans/positional-location
+fixes), generated via `git diff` against the pristine FetchContent checkout and verified
+with `git apply --check` against a fresh clone of the same upstream commit
+(`990d03b`). `cmake/rexglue_xenosrecomp.cmake`'s `PATCH_COMMAND` updated to reference
+the new filename. A clean CMake reconfigure will now reproduce the current tree exactly.
+
+**Still open**
+- **User has not yet visually/gameplay-tested this build.** This is the actual
+  "1 to 1" verification — everything above is compile/link/yield verification only.
+- Runtime `maxVertexInputAttributes` device-limit check before pipeline creation
+  (promised in `renut_xenos_shader_cache.h`'s comment, not yet added) — no shader in
+  the real corpus currently needs more than 28, so not urgent, but a future capture
+  with more attributes would silently misbehave without it.
+
+## LIVE SILENT-CORRUPTION BUG (2026-08-17): boolean constants in 81% of pixel shaders
+
+Found by reading XenosRecomp's open issue tracker (issue #17, filed by upstream's own
+author, still open). **This affects shaders that convert successfully and are in use —
+unlike the conversion-failure bugs below, it produces wrong rendering, not a skip.**
+
+**Measured: 1240 of 1531 converted pixel shaders (81%) branch on a boolean constant
+whose bit index is outside the representable range.** 0 of 280 vertex shaders affected.
+
+Mechanism, verified end to end:
+1. Xenos has **256 boolean constants** (`XE_GPU_REG_SHADER_CONSTANT_BOOL_000_031` ..
+   `_224_255`, 8 dwords). Vertex bools live at 0-127, pixel bools at 128-255.
+2. Our pixel shaders really do use high ones — observed `b129`, `b130`, `b243`-`b254`.
+3. XenosRecomp models the whole file as **one uint32** (`g_Booleans`), 16 bools per
+   stage, pixel offset by +16 (`shader_recompiler.cpp:1309`). It emits
+   `#define b243 (1 << 259)`.
+4. A shift of 259 on a 32-bit value is undefined in SPIR-V; AMD masks the shift to 5
+   bits, so `1 << 259` becomes `1 << 3`. `b243`-`b254` therefore test bits **3-14**,
+   which is the *vertex* bool window. Compiles clean, binds clean, branches wrong.
+5. Independently, `renut_xenos_pipeline_cache.cpp:1713` uploads **only dword 0**
+   (`regs[XE_GPU_REG_SHADER_CONSTANT_BOOL_000_031]`), i.e. bools 0-31. Bools 128+ are
+   never sent to the GPU at all. So even a correctly-computed bit would read stale data.
+- Note `b129`/`b130` land on bits 17/18 by modular accident — the *shift* is right but
+  the *data* is still bools 17/18, not 129/130. Nothing in this path is actually correct.
+- Timing note: `g_Booleans` was only wired to real guest data on 2026-08-17 (it was
+  hardcoded 0 before). Previously every such branch took the false path consistently;
+  now they read real-but-wrong bits, so **native-shader behaviour may have changed
+  character very recently**. Worth knowing before comparing against older observations.
+
+Fix shape (upstream README anticipates this: *"may require increasing the size of the
+`g_Booleans` data type for other games"*):
+- Widen `g_Booleans` to 8 dwords / 256 bits in `shader_common.h` and in
+  `SharedConstantsLayout` (currently `uint32_t booleans` at byte 256).
+- Emit word+bit selection instead of a single shift, and drop the `+16` pixel offset —
+  with a real 256-bit file the raw `boolAddress` is already correct, which also resolves
+  upstream issue #17 (no need for its "subtract 128" workaround).
+- Upload all 8 dwords in `IssueNativeDraw()`, not just the first.
+- Re-check `static_assert(sizeof(SharedConstantsLayout) == 288)` and the byte-256 offset
+  assert when the layout grows.
+
+## ROOT CAUSE FOUND (2026-08-17): the vertex-shader conversion deficit
+
+Full write-up (designed, readable): https://claude.ai/code/artifact/b760eff3-3850-4f0f-9676-29c06a4d1463
+
+Method: re-ran every failing shader through XenosRecomp in isolation and captured the
+real compiler diagnostic. Scripts kept in scratchpad: `probe_failures.py`,
+`analyze_locations.py`, `check_location_collisions.py`. **Measured, not inferred.**
+
+| n | vs | ps | diagnostic | cause |
+|---|---|---|---|---|
+| 198 | 198 | 0 | `partial explicit stage input location assignment via vk::location(X) unsupported` | usage missing from `USAGE_LOCATIONS` |
+| 28 | 23 | 5 | `use of undeclared identifier` | `r63` (15) + interpolator naming (13) |
+| 10 | 10 | 0 | memexport | genuinely unimplemented upstream |
+| 3 | 3 | 0 | implicit LOD in vertex stage | needs explicit LOD |
+| 2 | 2 | 0 | duplicate usage/usageIndex | our own guard working |
+| 1 | 0 | 1 | vector swizzle out of bounds | undiagnosed |
+
+**Bug A (198 shaders, 84% of vertex failures).** `shader_recompiler.cpp:78-97`
+`USAGE_LOCATIONS[]` has 17 entries and its own comment says *"specialized Vulkan
+locations for Unleashed Recompiled... Likely not going to work with other games."*
+The emit loop (`shader_recompiler.cpp:1397-1404`) only prints `[[vk::location(N)]]`
+on a table hit — a miss emits the parameter with **no location at all**, and DXC
+rejects *partial* explicit location assignment, killing the whole shader. Missing
+usages here: `POSITION2..12`, `TEXCOORD8..12`.
+**Critical nuance: 0 of those 198 have a real captured vertex declaration** (only 12
+vertdecls exist project-wide). The high usage indices are artifacts of our own
+synthesis heuristic's global counter. So naively widening the table = 198 shaders
+compiling with *guessed* semantics, i.e. exactly what `--reject-heuristic` suppresses.
+
+**Bug B (15 shaders).** `ExportRegister::VSPointSizeEdgeFlagKillVertex = 63` has no
+case in the VS export switch (`shader_recompiler.cpp:631-685`); it falls through to
+the interpolator lookup, misses, and generates a write to undeclared `r63`. Only
+`r0..r31` are declared (`shader_recompiler.cpp:1530`) though ALU operands mask to
+`0x3F` (r0-r63). Upstream README lists "Point size" as unimplemented.
+
+**Bug C (13 shaders).** `INTERPOLATORS[]` (`shader_recompiler.cpp:99-119`) declares
+only TEXCOORD0-15 + COLOR0-1, so a container interpolator with usage
+Normal/Tangent/Binormal names a nonexistent `oNormal0`/`iNormal0` parameter.
+
+### Verified NEGATIVE results — do not re-investigate
+- **Register-file overflow is NOT a general cause.** No shader in the partial-location
+  group references r32+. Only r63 appears, for Bug B. (Tested, hypothesis refuted.)
+- **`vk::location` collisions are NOT a live corruption source.** `USAGE_LOCATIONS`
+  maps both `(Position,1)` and `(TexCoord,7)` to location 15 — a real aliasing bug —
+  but all 280 converted vertex shaders were checked and **0 collide**, including all
+  35 marked-bad ones. It is a trap for whoever extends the table, not a current bug.
+- Interpolator-count mismatch: structurally impossible (all 18 declared unconditionally).
+
+### Recommended fix order (see artifact §6 for full reasoning)
+- **A. Assign vertex locations positionally per shader** (location i = i-th vertex
+  element), on both the container side and `ExtractVertexLocations()`/`GetOrCreatePipeline()`.
+  Makes the semantic name irrelevant to wiring — dissolves the heuristic-guessing
+  problem instead of tolerating it, and kills the location-15 collision by construction.
+  Upstream README:67 independently recommends exactly this. Ceiling: largest shader needs
+  **28 attributes**; this GPU (RX 9070 / RADV) exposes `maxVertexInputAttributes = 32`,
+  so it fits — but that exceeds the portable 16 minimum, so gate it on a runtime check.
+- **B.** Declare `r0..r63`; add an explicit (possibly deliberately-ignored) case for
+  export register 63.
+- **C.** Name interpolators by index, not usage.
+- **D. Highest-value item for the CORRUPTION problem** (A-C only fix *compile* failures):
+  audit the silent Tier-2 assumptions — `g_SwappedTexcoords` re-swizzles 16-bit data
+  **only for TEXCOORD**, and `R11G11B10` unpacking is applied **only** to
+  NORMAL/TANGENT/BINORMAL. A 16-bit non-TEXCOORD attribute or a packed format on another
+  usage is silently wrong data with no error — exactly the "stretched texture"/"wrong
+  lighting" signature. Decidable offline from existing `ucode_analyze` output.
+- **E.** Fetch opcodes other than `TextureFetch`/`GetTextureWeights` (incl.
+  `SetTextureLod`, gradient setters) are silently dropped at
+  `shader_recompiler.cpp:228-229` — route them to the graceful-skip path.
+
+## XenosRecomp / Shader Facts (verified)
+
+- Every vertex shader unconditionally declares/writes all 16 `oTexCoordN`; every pixel shader unconditionally declares all 16 `iTexCoordN`. Interpolator-count mismatch between VS/PS is structurally impossible — ruled out as a corruption cause.
+- `USAGE_LOCATIONS[]` fixed table (XenosRecomp `shader_recompiler.cpp`): Position=0, Normal=1, Tangent=2, Binormal=3, TexCoord0-3=4-7, Color0=8, BlendIndices0=9, BlendWeight0=10, Color1=11, TexCoord4-7=12-15.
+- Guest memory (`rex::memory::Memory::TranslatePhysical<T>`) is **big-endian** — must use `rex::memory::load_and_swap<T>()` from `<rex/memory/utils.h>` to read correctly. (Game-side code uses its own `RENUT_BSWAP32` macro for the same reason.)
+- `Runtime::instance()->memory()` is the public accessor to the real memory singleton (`SharedMemory::memory()` is protected, don't use it from outside).
+- 26/748 real Banjo shaders segfault XenosRecomp's own directory-scan driver outright (confirmed 2026-08-17) — this is why `xenos_batch_convert.py` isolates each shader in its own subprocess rather than using upstream's batch mode.
+
+## FIXED: Build only used 4 cores
+
+Root cause: `tools/xenos_batch_convert.py`'s per-shader isolation loop was fully sequential in Python (unrelated to the XenosRecomp internal `seq` patch, which was correctly left alone). Fixed by wrapping the per-shader subprocess run in `concurrent.futures.ThreadPoolExecutor(max_workers=os.cpu_count())`; each shader still runs in its own subprocess/tempdir for crash isolation, results collected via `as_completed` and merged single-threaded afterward (no shared-state races). **Verified still present 2026-08-17.**
+
+## FIXED: GTT memory leak -> DEVICE_LOST crash (~14.5-14.9k frames)
+
+- Symptom: `radv/amdgpu: Not enough memory for command submission` -> `VK_ERROR_DEVICE_LOST`, reproducible after several minutes just idling in the main menu.
+- Root cause: `BindlessHeapState::constants_pool` (a page-based ring buffer, `GraphicsUploadBufferPool`) never had `Reclaim()` called on it anywhere in `renut_xenos_pipeline_cache.cpp`, so pages were never recycled — confirmed via live polling of `mem_info_gtt_used` (climbed ~6MB/s indefinitely, no plateau).
+- Fix (**verified in tree 2026-08-17**): `renut_xenos_pipeline_cache.cpp:1599-1601` — once-per-frame `heap.constants_pool->Reclaim(command_processor.GetCompletedFrame())` in `IssueNativeDraw()`, gated by `BindlessHeapState::last_reclaimed_frame` (declared cpp:490) so it runs once per `GetCurrentFrame()`, mirroring the stock renderer's `uniform_buffer_pool_->Reclaim(frame_completed_)` in `command_processor.cpp`.
+- Verified at the time: post-fix GTT usage flat ~301-304MB over 5+ min / 300+ samples, sailed past the old crash point (15,180+ frames, clean exit).
+- FAILED, ruled out during diagnosis: fence pools, transient descriptor sets, barrier-site tracking, CSV trace writer — all reviewed clean before finding the real leak.
+
+## FIXED: Shader debug panel QoL (2026-08-17, user-requested)
+
+- Each recorded native shader pair has a stable 1-based `display_id` (`DebugShaderPairInfo::display_id`, `renut_xenos_pipeline_cache.h:149`), assigned at first-seen time, shown as `#N` prefix in the panel (`renut_shader_debug_panel.cpp:93`) instead of raw hash pairs.
+- Panel section split changed from live `enabled` state to `marked_bad` (static, from `marked_bad_shaders.txt` at boot) — "All Shaders" vs "Marked Bad" sections, so toggling a pair for testing no longer moves it and makes it hard to re-find.
+- Added `SetMarkedBadShaderPairsEnabled(bool)` + "Disable All Bad" / "Enable All Bad" buttons.
+
+## ONGOING / UNVERIFIED: On-screen shader labels
+
+- Feature: floating `#<display_id>` label drawn at each native pair's last-drawn screen position (`DebugShaderLabel`, `GetDebugShaderLabels()`, declared `renut_xenos_pipeline_cache.h:178`).
+- Position is computed in `IssueNativeDraw()` by reading the real guest vertex position (via `TranslatePhysical`+`load_and_swap`, only for `VK_FORMAT_R32G32B32(A32)_SFLOAT` position formats) and multiplying by 4 float4 registers starting at a "matrix base register".
+- FAILED (2x): guessed base register = c0 (WVP convention), both with local origin and with real vertex position — labels clustered above the player character in both cases. **Research confirms why**: there is no fixed hardware/OS WVP-register convention on Xenos; register allocation is whatever the original title's D3D9 HLSL compiler chose, per shader.
+- Current state: base register is a **live ImGui slider (0-252)** (`Set/GetNativeShaderLabelMatrixRegister`, declared `renut_xenos_pipeline_cache.h:215-216`, backed by an atomic at `renut_xenos_pipeline_cache.cpp:156`, driven from `renut_shader_debug_panel.cpp:253-256`) so the user can calibrate in-game without rebuilding. **NOT yet confirmed correct by the user.**
+- Also fixed: label overlap/clustering — greedy O(n^2) per-frame collision-avoidance pushdown in `DrawOnScreenLabels()`.
+- Next step if resumed: user drags the slider in-game against a known object and reports what register (if any) tracks it. If none does, a general fix needs the real per-shader constant table (name -> register), which is the *same* reflection-data problem blocking shader conversion.
+
+## CORE UNSOLVED PROBLEM: native shader corruption (stretched textures, non-spawning items)
+
+User's stated belief/priority (2026-08-17): a large fraction of shaders marked "bad" actually work natively, and most corruption is concentrated in a smaller set of genuinely broken shaders — wants this root-caused, not worked around.
+
+**2026-08-17, later same day: user tested the positional-location+boolean build — more shaders convert, but visual stretching is unchanged and remains the top-priority visual problem** (worse than missing objects). Found and fixed a strong additional candidate:
+
+**FOUND+FIXED: vfetch scan order vs. container/compile order mismatch (measured 51% of multi-attribute bindings affected).**
+- `renut_xenos_pipeline_cache.cpp`'s `GetOrCreatePipeline()` walked `vb.attributes` in raw ucode-scan order to index `vertexLocations[]`/`vertexTexCoordSemanticIndex[]` (`raw_attribute_index`).
+- But `tools/build_synthetic_container.py`'s `build_vertex_container()` explicitly **sorts each binding's attributes by `offset_words`** before writing the container's `vertexElementsAndInterpolators[]` array (`attributes.sort(key=lambda a: (a["binding_index"], a["offset_words"]))`), and XenosRecomp's `shader_recompiler.cpp` assigns `[[vk::location(i)]]` by that same array **position** `i` (`for (i = 0; i < vertexElementCount; i++) ... vertexElementsAndInterpolators[field18+i]`), not by instruction address.
+- So whenever a shader's vfetch instructions aren't already in ascending-offset order within a binding, the runtime's `raw_attribute_index` (scan order) pointed at the WRONG element of `vertexLocations[]`/`vertexTexCoordSemanticIndex[]` (container/sorted order) — silently binding the wrong buffer data to the wrong shader input.
+- **Measured empirically** (`scratchpad/check_order2.py`, extracting real ucode from all 516 `shaders_synthesized/vs_*.bin` containers and running through `ucode_analyze`): **307 of 600 multi-attribute vertex bindings (51%) have out-of-order vfetch instructions.** This is large-scope, not an edge case.
+- **Fix** (`renut_xenos_pipeline_cache.cpp`, `GetOrCreatePipeline()`, right before the per-binding attribute loop): build a local `std::stable_sort`ed copy of each binding's attributes by `fetch.attributes.offset` before iterating, matching the container's own sort exactly, so `raw_attribute_index` lines up with `vertexLocations[]`/`vertexTexCoordSemanticIndex[]` again. Needs `#include <algorithm>` (added).
+- **Verified**: `ninja rexgpu-renut` compiles/links clean (one transient unrelated clang segfault on the huge generated shader-cache .cpp on the first attempt, succeeded cleanly on retry — not caused by this change, the generated data was untouched). Full `renut` relinked, fresh `librexgpu-renutrd.so` copied to the game build dir and confirmed loadable via ctypes. **Not yet visually confirmed by the user** — this is the very next thing to check.
+- This does NOT touch shader conversion yield (still 2035/2053) — it's a pure runtime binding-order fix, orthogonal to what compiles.
+
+- `marked_bad_shaders.txt` cleaned 2026-08-17: 14/78 entries were **stale** (vs or ps hash no longer `ok` in the manifest, so they're excluded from native rendering anyway by the literal-constant fix). Removed via script; backup at `marked_bad_shaders.txt.bak`. **64 pairs / 35 distinct vertex shaders remain** (verified 2026-08-17).
+- Interpolator-count mismatch: ruled out (structurally impossible, see above).
+- Structural correlation attempt (`scratchpad/analyze_marked_bad.py`, using `ucode_analyze`) — **run against the pre-cleanup 78-entry list**, i.e. 44 distinct marked-bad vertex shaders vs 120 random "ok" controls:
+  - Marked bad: multi-row vertex stream (>=8 attrs/binding) 4.5%, dynamic float constant addressing 6.8%, avg bindings 1.00, avg attrs 4.41, `R32G32_FLOAT`-family format ~20.5% vs 5.8% control.
+  - Control: multi-row 9.2%, dynamic addressing 0%, avg attrs 4.91.
+  - Conclusion: correlations weak/inconclusive, not a smoking gun. Do not over-index on the format difference. If re-run, use the cleaned 35-shader set.
+- One deep-dive sample (`vs_2efa6fb4aaedd053` + `ps_144b4fe879000405`, decompiled via direct single-file XenosRecomp invocation) turned out to be a screen-space/post-effect shader (`float4 r0 = float4((iPos.xy - 0.5) * ...)`), not representative — don't generalize from it.
+- **Recommended next step (not yet executed)**: clean in-game re-test now that the GTT-leak crash is fixed and the stale list is purged — re-mark what's actually still broken from scratch rather than mining the old mixed-vintage list.
+
+## 2026-08-17 late session: user directive — treat the whole native renderer as unproven, stop micro-test-loop, systematic audit against the real Xenia stock translator
+
+User's exact framing (governs future sessions on this topic): "treat everything about the native renut renderer as wrong until proven it's correct... whatever we have right now is certain wrong." Also explicitly: no more one-fix-then-ask-user-to-test-then-report loops — batch real fixes, verify they compile, deploy, let user play freely, only check back when something concrete is found or a batch is ready.
+
+**Key methodological realization**: the "stock" renderer in this codebase (`pipeline_cache.cpp`/`translator.cpp`/`draw.cpp`) is not a fallback to be replaced — it's Xenia's real, working `SpirvShaderTranslator`, ported wholesale. It is the authoritative reference for "what correct Xenos→Vulkan translation looks like," available for direct comparison, not something to re-derive from screenshots. Every real bug found this session was found by diffing native behavior against this stock code, not by guessing from visual symptoms. Use this method first for any future investigation here.
+
+**Debug tooling added this session (still in tree, off by default via checkbox except where noted)**:
+- F5 panel checkbox "Debug: colorize native draws by shader pair" (`SetDebugColorizeMode`/`GetDebugColorizeMode`, `renut_xenos_pipeline_cache.cpp`) — swaps the real (possibly-broken) vertex shader's pixel stage for a trivial flat-color fragment shader (`renut_debug_color_spirv.h`, hand-compiled via `glslangValidator`), color derived per-(vs,ps)-hash. Only colorizes pairs whose pipeline is built **fresh while the mode is on** — does NOT retrofit already-cached pipelines (an earlier version that did this caused a real, confirmed regression: recreating live pipeline objects under load stalled native draw counts and caused flickering — reverted). **Currently defaults to `true` at boot** (`DebugColorizeModeFlag`'s initial value) so it's active before the intro videos/panel are reachable — flip back to `false` once this diagnostic effort concludes, it is not meant to ship on.
+- Panel line "N native draw(s) since launch" (`PeekLastFrameDrawCount`) — reads `state.draw_count` (declared in `renut_xenos_pipeline_cache.cpp`) directly; it's a running total since boot, NOT per-frame (the per-frame reset only happens inside `TakeDrawCount()`, which is only ever called from the CSV trace writer, confirmed inactive in normal play — don't reintroduce a "last frame" framing without fixing that first).
+- **Real bug found+fixed in this tooling itself**: `IssueNativeDraw`'s pipeline-handle lookup (`state.pipelines` linear scan) only ever matched `entry.pipeline`, never `entry.debug_pipeline` — with debug mode on, EVERY native draw silently vanished (not colorized, not stock-fallback, just never issued, permanently for that pipeline's lifetime) because the lookup always failed and the function returned before drawing. Fixed by matching either handle. This produced the "~50% of the map missing" report — was a real bug in the debug feature, not evidence about the renderer itself. Don't re-conflate the two if this comes up again.
+
+**Real fixes shipped this session, ranked by how the systematic audit rated their likely visual impact (none individually confirmed to fix the corruption yet — user reported "nothing noticeable changed" after the first batch, more found and shipped after)**:
+
+1. **`ndc_scale`/`ndc_offset` position correction, X/Y only** — stock's `spirv_translator.cpp` applies `position_xyz = position_xyz * ndc_scale + ndc_offset * position_w` to EVERY vertex shader's output unconditionally (covers viewport remap, window offset, half-pixel offset, D3D-vs-GL clip convention, reverse-Z, and the entire clip-disabled/screen-space-quad case — full-screen UI/video/post-process). Native shaders had zero equivalent beyond a half-pixel-only term. Wired via a new `VulkanCommandProcessor::last_viewport_info()` accessor (`command_processor.h`/`.cpp`) exposing the SAME `ViewportInfo` stock computes once per `IssueDraw` call (no duplicate/divergent computation), fed to XenosRecomp-compiled shaders via new `g_NdcScale`/`g_NdcOffset` shared constants (`shader_common.h`, `SharedConstantsLayout` in `renut_xenos_pipeline_cache.cpp`).
+   - **Real regression found+fixed same day**: first version applied this to Z too (matching stock's formula literally) — user's next test showed individual native shaders going INVISIBLE when toggled on. Root cause: stock's Z scale/offset (often 0.5/0.5) assumes semantic knowledge of the guest's clip-space convention that a full translator has and a raw ucode pass-through (XenosRecomp) does not — applying it blindly pushed vertices outside the valid depth range and got them clipped. Scoped back to X/Y only (`shader_recompiler.cpp`'s two injection sites, both now emit `oPos.xy = oPos.xy * g_NdcScale.xy + g_NdcOffset.xy * oPos.w;`, Z untouched). **Z-axis equivalent remains a real, unexamined gap** — if revisited, do NOT just copy stock's formula again; the Xenos DX-clip-space-convention/reverse-Z semantics need to be understood specifically for XenosRecomp's raw output first.
+2. **Alpha test now dynamic per-draw, with compare-function gating** — was a static spec constant baked once at shader-conversion time (whatever `RB_COLORCONTROL.alpha_test_enable` happened to be when XenosRecomp's static analysis ran), now reads the real register every draw via new `g_AlphaTestEnable` shared constant. **Real regression found+fixed same day**: first version gated on `alpha_test_enable` alone; XenosRecomp's compiled `clip(oC0.w - g_AlphaThreshold)` hardcodes exactly ONE comparator (GEQUAL-keep — discard when `oC0.w < threshold`), with no way to express D3D9's other 7 `D3DCMP_*` functions. Games commonly leave the alpha-test unit enabled while setting `ALPHAFUNC=ALWAYS` as a no-op idiom — the first version would wrongly discard via GEQUAL logic on every such draw instead of discarding nothing. Now gated on `alpha_test_enable && alpha_func == xenos::CompareFunction::kGreaterEqual` (`renut_xenos_pipeline_cache.cpp`, `IssueNativeDraw`). **This is currently the single strongest candidate for "enabling native rendering makes geometry disappear"** — not yet confirmed by the user (deployed, awaiting play).
+3. **`RB_DEPTHCONTROL` now goes through `draw_util::GetNormalizedDepthControl`** instead of reading the raw register — matches stock's real `RB_MODECONTROL.edram_mode` gate (force-disables depth entirely outside `kColorDepth`/`kDepthOnly` modes). Narrower/lower-confidence than items 1-2.
+4. **`color_blend_state.attachmentCount` was hardcoded to `1`** regardless of how many color render targets (MRT) a draw actually uses — Vulkan requires this to exactly match the real attachment count (both under dynamic rendering and classic render passes). Any draw using more than one simultaneous color target would have had undefined/silently-dropped output on attachments 1+. Fixed by computing the real count once (shared with the existing dynamic-rendering attachment-count computation, same `render_pass_key.depth_and_color_used` bits — one source of truth, not two) and building an array of that many identical `VkPipelineColorBlendAttachmentState` entries (`renut_xenos_pipeline_cache.cpp`).
+
+**RULED OUT with real measurement (2026-08-17, same day)**: `exp_adjust`/`signed_rf_mode` on vertex fetches. Added `exp_adjust`/`signed_rf_mode` fields to `tools/ucode_analyze.cpp`'s JSON output (they weren't emitted before), then swept all 516 real `shaders_synthesized/vs_*.bin` containers (`scratchpad/check_exp_signed.py`): **5115 total vertex attributes examined, 0 with nonzero `exp_adjust`, and of 2351 signed attributes, 0 use `signed_rf_mode` other than `kZeroClampMinusOne` (value 0)**. Critically, `kZeroClampMinusOne` (Microsoft's clamped/has-a-zero convention, `max(c/(2^(b-1)-1), -1)`) IS what Vulkan's own `_SNORM` format spec implements — the "known gap" in the code comments was about the OTHER mode (`kNoZero`, OpenGL's alternate no-zero mapping), which **this game's real data never uses at all**. Both items in the earlier audit write-up were real theoretical gaps but are proven non-issues for this specific game's corpus — do not re-investigate without new evidence (e.g. a newly-added shader capture that behaves differently).
+
+**Ranked but NOT yet acted on** (from the systematic audit, still real/open):
+- Alpha test only handles GEQUAL now (see fix #2) — the other 7 compare functions still can't clip correctly; currently those draws just never clip (safer than before, but not fully correct either).
+- Texture views always requested as unsigned (`BindTexture2DFixedSlot` hardcodes `is_signed=false`) — shaders sampling a texture as signed-normalized data get the wrong interpretation. Investigated but NOT fixed: stock's real signedness (`VulkanShader::TextureBinding::is_signed`, `texture_cache.cpp`'s `IsAnySignSigned(binding->swizzled_signs)`) is derived from the real guest texture FORMAT/swizzle data during translation, not a simple per-instruction field `Shader::TextureBinding`/`ParsedTextureFetchInstruction` exposes anywhere (confirmed via grep — no `is_signed` field exists on the texture-fetch side of `shader.h` at all, unlike the vertex-fetch side). Fixing this properly needs understanding stock's format/signedness derivation first; deprioritized this session to avoid another guessed-and-wrong regression like the two already found and fixed today.
+- **QUANTIFIED, narrow, NOT fixed**: `BindlessHeapState` only ever populates the Texture2D descriptor array (`texture2d_entries`) — 3D and Cube map slots are left permanently unbound (`renut_xenos_pipeline_cache.cpp`'s own comment: "Only Texture2D is populated for now... 3D/Cube slots stay unbound"). Added a `dimension` field to `tools/ucode_analyze.cpp`'s texture-binding JSON (wasn't emitted before) and swept all 1537 real `shaders_synthesized/ps_*.bin` containers (`scratchpad/check_tex_dim2.py`): of 35135 total texture fetch instructions, **34967 are 2D (99.5%), 137 are Cube (0.4%), 29 are 3D (0.08%), 2 are 1D**. Real but narrow — likely a handful of specific shaders (skyboxes, reflective/cubemap-lit surfaces), not a systemic cause of the widespread corruption. Any native shader hitting one of these 166 fetches samples an unbound descriptor (garbage/undefined, `VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT` makes this valid-but-wrong rather than a validation error). Left unfixed this session — low value relative to effort given the small real-corpus count; if revisited, needs `texture3d_entries`/`texturecube_entries` arrays populated the same way `texture2d_entries` already is, plus a same-shaped write path in `BindTexture2DFixedSlot` (which would need renaming/generalizing since it's 2D-specific by name and logic right now).
+
+**Ruled out this session** (do not re-investigate without new evidence): quad-list/rectangle-list/point-sprite primitives already correctly fall back to stock (`PrimitiveTypeToVkTopology` explicitly rejects them); front-face winding/cull-mode convention matches stock exactly (line-for-line same register bits, same ternary); texture residency request (`RequestTextures`) and shader translation (`EnsureShadersTranslated`, which populates `GetUsedTextureMaskAfterTranslation`) both run unconditionally before the native/stock branch, not gated behind which path is taken; stencil state defaults safely to disabled (not a source of invisibility); wrong-AppImage-being-tested was considered and ruled out (the AppImage on the user's Desktop is a stale Aug-11 build with no `librexgpu-renutrd.so` at all, but the user's screenshots showed the F5 panel/debug-colorize/draw-counter features working, which only exist in the dev build — they are testing the right binary).
+
+## Standing procedures / gotchas
+
+- Two-step verification mandatory before every test cycle: (1) verify `.so` loads via ctypes, (2) `command cp -f` both plugin files to the game directory, (3) `md5sum` both copies to prove they match. Skipping this silently tests stale code — this has bitten this project before.
+- Edit the SDK at `reNut-build-scratch/rexglue-sdk-src/src/...`, never `out/install/linux-amd64/include/...` (install-time copy).
+- `ls` is aliased in this shell (bare `ls -la` can silently produce nothing, `ls -t` demands `--time <FIELD>`) — use `command ls`.
+- zsh globs `--include=*.cpp` as a filename pattern and fails with "no matches found" — quote grep args or omit `--include`.
+- `grep -F "^${vs} "` does NOT anchor (`-F` disables regex anchors) — use `awk -v t="$vs" '$1==t{print}'` for exact-field manifest lookups.
+- User division of labor: I fix/investigate code, user builds/runs the actual game (I don't have display access), except read-only live GPU-memory polling via `/sys/class/drm/...` which I can do myself.

--- a/docs/ai/nativevk.md
+++ b/docs/ai/nativevk.md
@@ -1,0 +1,76 @@
+# Native renderer: rexglue-sdk setup
+
+> **Scope**: everything specific to the `rexgpu-nativevk` plugin and its relationship to
+> the external `rexglue-sdk` checkout — setup, the hard boundary rule, and how to keep
+> the patch current. Read this before touching anything under `rexglue-sdk-src/` or
+> `src/graphics/nativevk/`. If you're not working on the renderer, skip to
+> [`../START_HERE.md`](../START_HERE.md).
+
+## Hard rule: rexglue-sdk itself should not need to be edited
+
+The lead rexglue developer's stated architecture: fixes/features belong in reNut's own
+code, using rexglue's existing extension points — not edits to rexglue-sdk source. The
+Linux audio fixes (`src/renut_engine/linuxfixes/{audio_backend,audio_client_guard}.cpp`)
+are the reference pattern: `REX_HOOK` link-time symbol interposition, zero rexglue-sdk
+edits. Before editing anything inside the SDK checkout, ask whether the same effect is
+reachable via a hook, an env var, or a new file placed alongside existing SDK files
+(additive, not modifying) instead. The two exceptions that *do* require real edits, kept
+deliberately minimal and documented inline at their call sites, are: the one virtual hook
+on `VulkanCommandProcessor::IssueDraw` (`TryNativeDraw`) that lets a plugin substitute a
+native pipeline, and the Vulkan device-feature enablement (`bufferDeviceAddress`,
+`descriptorIndexing`, etc.) that bindless native pipelines need — device creation predates
+plugin loading, so there is no hook to attach to there. Everything else — pipeline cache,
+shader debug panel, Phase 1 draw path, the trace-hook — lives in new files under
+`src/graphics/nativevk/` and `src/graphics/vulkan/nativevk_*` inside the SDK tree, added
+fresh rather than editing existing rexglue-sdk source.
+
+**rexglue-sdk source is never committed to this repo.** The checkout lives entirely
+outside reNut (`REXSDK_DIR`, see setup below) and reNut's git history contains zero SDK
+source files — only the generated patch below, which is the sole bridge between what's
+committed here and what the external checkout needs.
+
+## Keeping the patch current
+
+`cmake/patches/rexglue_sdk_native_renderer.patch` is a snapshot, not tracked live —
+regenerate it (`git diff --binary > cmake/patches/rexglue_sdk_native_renderer.patch` from
+inside the SDK checkout) any time you finish a change there, and commit the regenerated
+patch in the same reNut commit as the reNut-side change it supports. Check
+`git -C /path/to/rexglue-sdk status --short` before assuming the patch is current — an
+uncommitted SDK-side change with no matching patch update means a fresh clone following
+the setup steps below won't reproduce it.
+
+The native renderer (`rexgpu-nativevk` plugin) builds against a checkout of
+[rexglue/rexglue-sdk](https://github.com/rexglue/rexglue-sdk) with one small patch applied,
+plus this repo's own build wiring. rexglue-sdk itself needs almost no changes — see
+`cmake/patches/rexglue_sdk_native_renderer.patch`'s own diff for exactly what's touched (a
+single virtual hook on `VulkanCommandProcessor::IssueDraw` for plugins to substitute a native
+pipeline, plus the Vulkan device-feature enablement bindless native pipelines need). Everything
+else the native renderer actually needs — the pipeline cache, shader debug panel, Phase 1
+draw path — lives entirely in this repo's own `src/graphics/nativevk/`-mirrored files inside the
+SDK, added fresh rather than editing existing rexglue-sdk source.
+
+## One-time setup
+
+```sh
+# 1. Clone rexglue-sdk at the commit this patch was built against.
+git clone https://github.com/rexglue/rexglue-sdk.git /path/to/rexglue-sdk
+cd /path/to/rexglue-sdk
+git checkout 3eb9b511b4140d2769e27be63eae57d41bfa2afa
+
+# 2. Apply the native-renderer patch (from this repo).
+git apply /path/to/reNut/cmake/patches/rexglue_sdk_native_renderer.patch
+
+# 3. Point the reNut build at it.
+cmake --preset linux-amd64-relwithdebinfo -DREXSDK_DIR=/path/to/rexglue-sdk
+```
+
+## After that
+
+Normal build (`cmake --build --preset ...` or `ninja` from the build dir) picks up
+`rexgpu-nativevk` (the native renderer plugin) and `rexgpu-xenos` (the stock, unmodified-behavior
+plugin — useful as a clean A/B reference: set `gpu_plugin = "xenos"` in `renut.toml` to compare
+against `gpu_plugin = "nativevk"`).
+
+If the patch stops applying cleanly after a rexglue-sdk update, regenerate it from a working
+tree with the fix applied: `git diff --binary > cmake/patches/rexglue_sdk_native_renderer.patch`
+from inside the rexglue-sdk checkout, and update the commit hash above.

--- a/docs/ai/nativevk.md
+++ b/docs/ai/nativevk.md
@@ -76,10 +76,13 @@ cmake --preset linux-amd64-relwithdebinfo -DREXSDK_DIR=/path/to/rexglue-sdk
 
 ## After that
 
-Normal build (`cmake --build --preset ...` or `ninja` from the build dir) picks up
-`rexgpu-nativevk` (the native renderer plugin) and `rexgpu-xenos` (the stock, unmodified-behavior
-plugin — useful as a clean A/B reference: set `gpu_plugin = "xenos"` in `renut.toml` to compare
-against `gpu_plugin = "nativevk"`).
+A normal build only requires `rexgpu-xenos` (`GPU_PLUGINS xenos` in reNut's own
+`CMakeLists.txt`) -- `rexgpu-configure_target()` hard-errors if a listed plugin's target
+doesn't exist, and most builds (any plain/unpatched installed SDK package included) don't
+have `rexgpu-nativevk` available, so it's deliberately not in the default list. If you've
+done the one-time setup above and want to actually build `rexgpu-nativevk`, add `nativevk`
+back to that `GPU_PLUGINS` line locally -- don't commit that change, since it breaks the
+build for anyone without a patched SDK checkout.
 
 If the patch stops applying cleanly after a rexglue-sdk update, regenerate it from a working
 tree with the fix applied: `git diff --binary > cmake/patches/rexglue_sdk_native_renderer.patch`

--- a/docs/ai/nativevk.md
+++ b/docs/ai/nativevk.md
@@ -6,6 +6,16 @@
 > `src/graphics/nativevk/`. If you're not working on the renderer, skip to
 > [`../START_HERE.md`](../START_HERE.md).
 
+**This entire architecture is being replaced (decided, not started).** Even though
+`rexgpu-nativevk`'s own source lives outside the SDK checkout, it still substitutes a
+pipeline from *inside* rexglue-sdk's own draw call, so it still depends on the SDK's
+GPU-emulation stack to get there. The decided direction is a full, UnleashedRecomp-style
+rewrite with zero dependency on rexglue-sdk's rendering pipeline — see
+[`archive/native-renderer-rewrite-plan.md`](archive/native-renderer-rewrite-plan.md) for
+the real plan. Everything below describes the current, temporary architecture — accurate
+today, but not the target. Once the rewrite starts, this file gets replaced rather than
+patched.
+
 ## Hard rule: rexglue-sdk itself should not need to be edited
 
 The lead rexglue developer's stated architecture: fixes/features belong in reNut's own

--- a/docs/ai/research.md
+++ b/docs/ai/research.md
@@ -1,0 +1,465 @@
+# reNut Knowledge Bible
+
+> **Scope**: narrative background — what reNut/rexglue/XenosRecomp actually are, the
+> current architecture, and how comparable projects (UnleashedRecomp, DPRecomp, Xenia)
+> solve the same problems. Read this for context before making an architectural call, or
+> to explain the project to someone new. Skip it if you already know the shape of the
+> project and just need the rules ([`START_HERE.md`](../START_HERE.md)) or a specific
+> past event ([`history.md`](history.md)).
+
+Living reference document: what this project is, where it stands, what's been tried,
+what's left, and how comparable projects solve the same problems. This is a *narrative/
+research* document for humans — for terse machine-oriented state, see `history.md`.
+Update this when the project's stage, goals, or research picture changes; update
+`history.md` for tactical discoveries/fixes/failures.
+
+Last updated: 2026-08-17. All numeric claims re-verified against the live tree
+and shader manifest on 2026-08-17 (§2a) — earlier drafts of this file carried
+stale conversion counts.
+
+---
+
+## 1. What reNut Is
+
+reNut is a native Linux/Windows port of **Banjo-Kazooie: Nuts & Bolts** (Xbox 360, 2008),
+built on **rexglue** (`rexglue-sdk`), a static-recompilation toolkit in the spirit of
+Xenia (emulator) and the hedge-dev `*Recomp` family (static recompilers), but structured
+as a reusable SDK rather than a single-game bespoke renderer.
+
+- **CPU side**: the Xbox 360's PowerPC code is statically recompiled ahead-of-time into
+  C++ (one function per original subroutine, `sub_XXXXXXXX`, in `generated/`). This part
+  is mature and shipping — the game boots, plays, and is generally stable, with a number
+  of hand-written fixes for recompiler mis-translations (see `src/renut_engine/fixes/`).
+- **GPU side**: two coexisting paths.
+  1. **Stock/shipped path ("renut" plugin)**: runtime translation of the Xenos GPU command
+     stream to Vulkan calls, interpreting the guest's shader microcode via emulation each
+     frame. This is what every user actually plays on today. Correct, ~35-40fps in the
+     city, GPU-bound.
+  2. **Native-renderer effort (in progress, not shipped)**: statically recompile
+     individual Xenos vertex/pixel shader microcode programs to real Vulkan pipelines
+     ahead of time via **XenosRecomp** (hedge-dev's shader recompiler, PPC-GPU-microcode →
+     HLSL → DXC → SPIR-V), then substitute them in at draw time instead of interpreting.
+     Goal: near-native shader execution cost instead of per-instruction emulation.
+
+reNut's specific complication (see §6 for how this differs from sibling projects): it
+must recover shaders from **live captured Xbox 360 GPU microcode**, not from an offline
+extraction of the game's original shipped shader containers with intact D3D9 reflection
+data. Nuts & Bolts' shaders are frequently missing that reflection data, and a large
+fraction of the game's most-used shaders never go through a capturable D3D9
+`CreateVertexShader`/`CreatePixelShader` call at all (see §4).
+
+## 2. Current Stage
+
+| Subsystem | Stage |
+|---|---|
+| CPU recompilation / core gameplay | **Shipping.** Stable, playable, Linux + Windows. |
+| Stock GPU path (`renut` plugin) | **Shipping.** Correct, in daily use. |
+| Native shader substitution | **Experimental, off the shipped critical path.** Real pipelines render correctly for a subset of shaders; a real GTT-leak crash blocking long play sessions was found and fixed this week; the core "why do many native shaders visually corrupt" question is still open. |
+| Shader debug tooling (panel, on-screen labels) | **Actively being built out**, in direct response to user needs for bisecting native-shader corruption. |
+| Build pipeline (batch shader conversion) | **Mature and fast** (parallelized this week); conversion yield is the current bottleneck, not raw throughput. |
+
+### 2a. Conversion yield — real measured numbers (2026-08-17)
+
+Read straight from `generated/renut_xenos_shader_cache_manifest.txt`:
+
+| | total | converted ok | failed |
+|---|---|---|---|
+| **Vertex shaders** | 516 | **280 (54.3%)** | 236 |
+| **Pixel shaders** | 1537 | **1531 (99.6%)** | 6 |
+| All | 2053 | 1811 (88.2%) | 242 |
+
+Failure reasons: `skipped-by-xenosrecomp:SPIR-V` 224 vs + 6 ps;
+`:memory` 10 vs; `:duplicate` 2 vs.
+
+**This table sharpens the whole document.** Pixel-shader conversion is
+effectively a solved problem at 99.6%. *All* remaining conversion-yield loss is
+vertex shaders, and vertex shaders are precisely where the missing D3D9 vertex
+declaration / usage-semantic data lives (§4, §6). This is direct quantitative
+confirmation that vertex-declaration recovery (§5) is not just *a* lever — it is
+the *only* remaining lever on shader coverage.
+
+Older figures quoted in this project's history (12/1884 → 1492/1884 → 1706/2208,
+"~500 unconvertible vertex shaders") are earlier snapshots of a differently-sized
+shader dump and are superseded by the table above. On-disk raw ucode today:
+525 `vs_*` + 1436 `ps_*` = 1961 files (the manifest carries slightly more entries
+because container-synthesis inputs don't all have a standalone ucode file).
+
+## 3. Goals
+
+**Primary, currently-blocking goal**: fix native-shader visual corruption (stretched
+textures, non-spawning items) so more of the ~2050 captured shaders can be safely
+substituted in. The user's stated belief (2026-08-17): a large fraction of shaders
+currently marked "bad" likely work correctly natively, and the corruption is
+concentrated in a smaller set of genuinely-broken shaders rather than being pervasive —
+this is the thing worth root-causing, not papering over with more exclusion heuristics.
+
+**Secondary/longer-term goals**:
+- A real, isolated, timer-based A/B performance measurement per shader (native vs
+  stock-translated) — never done. Whole-scene comparisons so far show native
+  substitution at partial coverage is **not** a clear win (see §4), so this matters before
+  investing further in scaling shader count.
+- Recover real vertex declarations (usage semantics) for IM_LOAD-loaded shaders, which
+  currently have none — the single biggest known lever on how many vertex shaders can be
+  safely converted at all (see §4, §5).
+- Decide whether positional/index-based interpolator linkage (Xenia's real hardware
+  model, see §6) is worth building as an alternative to XenosRecomp's semantic-name
+  requirement — potentially unlocks most of the **236 currently-failing vertex
+  shaders** (§2a), but is real engineering effort, not a quick patch.
+
+## 4. What We've Done (chronological, by outcome)
+
+### ✅ Done — shipped / verified working
+- CPU recompiler crash fixes (`mullhwucrash.cpp` and friends) — game is stable.
+- Linux port: XDG paths, mnk controls, audio backend/UAF fixes, POSIX file-access fix.
+- Batch shader-conversion pipeline (XenosRecomp wrapper): synthesizes valid D3DX9
+  constant-table blobs (float/bool constants) from `ucode_analyze`'s own analysis when the
+  real captured container lacks one — raised real conversion yield from 12/1884 to
+  1492/1884 at the time, and the pipeline now stands at 1811/2053 (88.2%) overall
+  (§2a for the current, authoritative breakdown).
+- **Two real upstream XenosRecomp bugs patched locally**
+  (`cmake/patches/xenosrecomp_graceful_skip.patch`, do not revert):
+  (1) any failed DXC compile hit a bare `assert()` with no null-check and
+  segfaulted the whole process — now a logged skip carrying the shader hash and
+  real reason; (2) XenosRecomp's own `std::execution::par_unseq` multi-shader loop
+  **deterministically dropped ~450 of 2135 shaders on every run** with identical
+  input (bisected; the same set converts 100% under `std::execution::seq` in ~50s).
+  Root cause is DXC-internal `thread_local` state, not our code. Separately, 26/748
+  Banjo shaders segfault XenosRecomp's directory-scan driver outright, which is why
+  `tools/xenos_batch_convert.py` runs each shader in its own subprocess.
+- `--reject-heuristic` filter: rejects vertex containers where any attribute's usage
+  semantic had to be *guessed* (no real captured vertex declaration) — trades shader count
+  for correctness; **confirmed via live screenshot** this eliminates the
+  shattered-triangle corruption class it targets.
+- **Vertex input LOCATION bug** (a real, structural correctness bug, present since the
+  very first working native shader): Vulkan locations were assigned sequentially instead
+  of matching XenosRecomp's fixed usage-based `USAGE_LOCATIONS` table. Fixed and verified
+  end-to-end (binary + runtime inspection). Did **not** fix the visible corruption for the
+  shaders exercised in a normal play session (their layouts were too simple to trigger it) —
+  but is a real correctness fix regardless, and matters for future, more complex shaders.
+- **Confirmed via direct A/B test** (force `HasNativePipeline()` false): the remaining
+  visible corruption is caused by something inside specific live native shaders, **not**
+  by mixing native and stock rendering in the same scene.
+- Build parallelism: `xenos_batch_convert.py` per-shader loop was fully sequential in
+  Python (unrelated to XenosRecomp's own internal `seq`-vs-`par_unseq` choice, which is
+  intentionally `seq` — see §5). Parallelized via `ThreadPoolExecutor`.
+- Shader debug panel QoL: stable numbered IDs, decoupled toggle-vs-move-to-disabled,
+  bulk "Enable/Disable All Bad" buttons.
+- **Real GTT memory leak found and fixed**: `constants_pool` in the native-pipeline
+  bindless heap was never calling `Reclaim()`. Root-caused via live GPU-memory polling
+  (not guessed), fixed with a once-per-frame reclaim call, verified via before/after
+  telemetry (unbounded climb → flat plateau, crash point sailed past cleanly).
+- Cleaned `marked_bad_shaders.txt`: removed 14/78 stale entries (shaders that no longer
+  convert to native at all after the constant-table fix, so marking them "bad" was moot).
+  **64 pairs remain, covering only 35 distinct vertex shaders** (verified 2026-08-17) —
+  i.e. the corruption reports concentrate on a small vertex-shader set that gets paired
+  with many different pixel shaders, which is itself evidence for the user's hypothesis
+  that the problem is a narrow set of genuinely-broken shaders rather than pervasive.
+
+### 🟡 Tried, real result, but not a net win — informative, not a dead end
+- Full ucode-based synthesis (bypassing the D3D9-hook capture limitation, see below):
+  raised converted count to 1590/2143 with 148 shader pairs live in real gameplay
+  simultaneously — but introduced severe visible corruption, root-caused to the vertex
+  usage-semantic heuristic guessing wrong for non-trivial attribute layouts. Led directly
+  to `--reject-heuristic` above.
+- Native substitution at ~150/1268 drawn pairs (partial coverage): **measured performance
+  regression**, not improvement (main menu ~150fps → 20-80fps with native+heuristic on).
+  Per-draw native overhead (pipeline lookup, bindless descriptor/constant bookkeeping) is
+  evidently not cheap enough to net-win at low substitution percentages. This is why a
+  real isolated A/B measurement (goal in §3) now matters more than raw shader-count scaling.
+- On-screen shader position labels: two static "WVP is at register c0-c3" guesses both
+  put labels above the player character instead of at each object. Converted into a live,
+  panel-adjustable calibration slider instead of a third blind guess — **this is expected
+  behavior given real-world findings in §6** (there is no fixed hardware WVP-register
+  convention; it's whatever the original D3D9 shader compiler happened to allocate,
+  per-shader).
+
+### ❌ Reverted — real regression found
+- A fix to `AnalyzeUcode()`'s control-flow-bound heuristic (raised offline shader-analysis
+  success from 39 to 98) was reverted after it caused a full black-screen regression in
+  the **shipped stock renderer**, which shares this exact function. Do not re-edit the
+  shared runtime path for this; a separate offline-only analysis function would be needed.
+
+### ⛔ Unsolved / blocked (root problem, not yet cracked)
+- **Vertex declaration recovery for IM_LOAD-loaded shaders.** The game's most-used
+  shaders are loaded directly into GPU sequencer memory via `IM_LOAD`/`IM_LOAD_IMMEDIATE`
+  PM4 packets, never through a capturable D3D9 `CreateVertexShader`/`SetVertexDeclaration`
+  call — so there is no real captured usage-semantic data for them, structurally, via any
+  existing hook. This is the direct cause of needing the heuristic (and therefore
+  `--reject-heuristic`'s shader-count cost). No public prior art exists for recovering
+  this (see §6) — Xenia sidesteps the whole category by not needing D3D9-level semantics
+  in the first place.
+- **Root cause of visible corruption in the *specific* shaders currently live** — narrowed
+  to "something inside specific native shaders" (not mixing, not the location bug for the
+  simple shaders tested), but the exact mechanism is still unidentified. See §5 checklist.
+
+## 5. Checklist of Ideas / Potential Next Steps
+
+Ideas below are unranked except within groups; check off / annotate as they're tried.
+Cross-reference `history.md` before starting any of these — some overlap with
+documented failed approaches.
+
+> **2026-08-17 update — the vertex-shader half of this list is now root-caused.**
+> Every failing shader was re-run through the real compiler and its diagnostic captured.
+> 198 of 236 vertex failures (84%) are a single bug: XenosRecomp's Unleashed-specific
+> `USAGE_LOCATIONS` table omits the usages our shaders use, and a table miss emits a
+> vertex parameter with *no* `[[vk::location]]`, which DXC rejects outright. Two smaller
+> bugs (undeclared `r63` = unimplemented point-size export, 15 shaders; interpolator
+> table missing non-TEXCOORD usages, 13 shaders) account for most of the rest.
+> Full analysis with measured tables, ruled-out hypotheses and a ranked fix order:
+> https://claude.ai/code/artifact/b760eff3-3850-4f0f-9676-29c06a4d1463
+> See `history.md` for the terse version with file:line references.
+> **Note the trap**: 0 of those 198 have a real captured vertex declaration, so simply
+> widening the table ships 198 shaders wired from *guessed* semantics. The fix is to stop
+> routing vertex data through D3D9 usage names at all (item below, now evidence-backed).
+
+**Root-causing the current corruption (highest priority):**
+- [ ] Clean re-test pass now that the GTT-leak crash and stale marked-bad entries are
+      fixed — get an up-to-date, uninterrupted signal on which of the 64 remaining
+      marked-bad pairs are actually still broken.
+- [ ] **NEW, highest-value corruption lead (2026-08-17).** Audit XenosRecomp's two silent
+      "Tier 2" assumptions, both of which produce *wrong data with no error* — the exact
+      shape of the reported symptoms. (1) `g_SwappedTexcoords` corrects the 16-bit YXWZ
+      endian-swizzle **only for TEXCOORD** semantics; a 16-bit NORMAL/COLOR/etc. attribute
+      is silently swizzled wrong. (2) `R11G11B10` unpacking is applied **only** to
+      NORMAL/TANGENT/BINORMAL; the same packed format on any other usage is read as raw
+      float garbage. Upstream's README explicitly flags both as Unleashed-specific
+      assumptions other games may need to extend. Both are decidable **offline** from
+      `ucode_analyze`'s already-decoded per-attribute `data_format` — this is a query over
+      existing data, not a rewrite, and it directly targets stretched-texture/bad-lighting
+      symptoms rather than compile failures.
+- [ ] Per-attribute data-correctness audit (stride/offset/format) for a specific corrupted
+      shader once identified, rather than structural (interpolator count, location)
+      checks — the known symptom shapes (stretched textures = UV-ish, odd lighting =
+      normal-ish) point at per-attribute *data* correctness, not topology/linkage.
+- [ ] Use the on-screen-label calibration slider (once a working register value for at
+      least one shader is found) to help visually correlate a specific broken shader with
+      a specific broken object in-game.
+
+**Vertex declaration recovery (biggest lever on shader count):**
+- [ ] Investigate inspecting live vertex buffer memory/strides at draw time as an
+      alternative signal to captured D3D9 declarations (not explored yet).
+- [ ] Evaluate whether `data_format`/component-count patterns already known per-attribute
+      (from ucode analysis alone) could produce a *smarter* heuristic than blind
+      POSITION-then-TEXCOORD, without needing real captured declarations (not explored
+      yet — different from the two heuristics already tried and reverted/kept).
+- [ ] Test the "paired pixel shader's own interpolator-usage container" cross-reference
+      idea from §6's research — real PS containers may survive capture more often than VS
+      ones; on real hardware, VS export (usage, usageIndex) must match what the PS
+      declares for the pair to function, so a real PS-side declaration could backfill the
+      VS side. Untried, quick to falsify.
+- [ ] **PROMOTED TO TOP PRIORITY (2026-08-17, now evidence-backed).** Positional/
+      index-based linkage as a structural replacement for XenosRecomp's semantic-name
+      requirement, modeled on Xenia's real hardware behavior (§6): assign Vulkan location
+      *i* to the *i*-th vertex element of each shader, on both the container side and
+      `ExtractVertexLocations()`/`GetOrCreatePipeline()`. Measured payoff: unblocks the
+      198 shaders failing on partial-location assignment, and does so *without* trusting
+      the heuristic's guessed semantic names, because the name stops affecting wiring.
+      Also dissolves the latent `(Position,1)`/`(TexCoord,7)` → location-15 collision by
+      construction. Confirmed feasible: largest shader needs 28 attributes, this GPU
+      exposes 32 (gate on a runtime check — the portable minimum is 16). XenosRecomp's own
+      README recommends precisely this ("a generic solution would assign unique locations
+      per vertex shader"), so it is the sanctioned direction, not a fork.
+      Justification for the primary reason this was previously deferred as "the most work":
+      it is now clear the alternative is *more* work, because every other path requires
+      recovering vertex declarations that structurally do not exist.
+
+**Robustness / diagnostics:**
+- [x] ~~Patch XenosRecomp locally to skip-and-log (not crash) on any failed DXC compile.~~
+      **DONE** — shipped as `cmake/patches/xenosrecomp_graceful_skip.patch` (verified
+      present and applied 2026-08-17). This is why the manifest now carries informative
+      `skipped-by-xenosrecomp:<reason>` entries instead of silent segfaults.
+- [ ] Root-cause the one still-unexplained XenosRecomp crash (`ps_9c016d19c75c8b76`,
+      only reproduces in the real batch pipeline, not in isolation) — low priority.
+      **Confirmed still broken 2026-08-17, and in an informative way**: its `.ucode` file
+      exists on disk, yet the shader has **no manifest line at all** — not even a
+      `skipped-by-xenosrecomp:` entry. Every other failure produces a logged skip thanks
+      to the graceful-skip patch, so this one is dropping out *before* the patched
+      error path, i.e. it's a different failure mode than an ordinary DXC reject.
+      That makes it a cheap, well-isolated diagnostic target if picked up.
+
+**Performance:**
+- [ ] Build the real isolated single-shader GPU-timer A/B measurement (native vs
+      stock-translated), still never done despite being flagged as important twice.
+      Blocked on having at least one *visually clean* native shader to measure fairly.
+- [ ] If per-draw native overhead is confirmed to be the bottleneck (not shader execution
+      cost itself), investigate reducing it: pipeline cache hit-rate, descriptor write
+      reduction, bindless heap bookkeeping cost per draw — none investigated yet.
+
+**Geometry coverage:**
+- [ ] Decide whether to implement real geometry-shader expansion for
+      `kRectangleList`/`kQuadList` primitives (currently hard-fallback to stock,
+      permanently) — probably fine to leave as-is (likely cheap UI/2D draws), but not
+      formally decided.
+
+## 6. Research: How Comparable Projects Handle This
+
+All of the following (except Xenia, an emulator) are members of the **hedge-dev
+`*Recomp` family** — `XenonRecomp` (PowerPC CPU recompiler) + `XenosRecomp` (Xenos
+shader recompiler) are the actual shared upstream tools; reNut, UnleashedRecomp, and
+Fable2Recomp are three independent *consumers* of that toolchain (reNut and
+Fable2Recomp additionally share the `rexglue` SDK layer on top; UnleashedRecomp does not
+use rexglue — it has its own bespoke renderer).
+
+### UnleashedRecomp (Sonic Unleashed, hedge-dev — the most mature sibling)
+- Uses XenosRecomp for shader translation, same as reNut.
+- **Structurally different GPU pipeline**: a renderer **written from scratch**, not a
+  retrofit onto an existing runtime-translated GPU backend. Every shader it compiles is
+  fed by an **offline extraction of the game's real shipped shader containers** — real
+  D3DXSHADER_CONSTANTTABLE reflection data intact, because Sonic Unleashed's shaders were
+  built with that data present (unlike Nuts & Bolts, which frequently stripped it).
+  Confirmed via direct GitHub code search: zero hits for "IM_LOAD" anywhere in their
+  repo — they structurally never encounter the missing-declaration problem reNut has,
+  because their capture method is a different (offline, complete) one that never depends
+  on runtime hooks catching every shader as it's created.
+- Modern rendering techniques: **bindless textures** and **shader specialization**
+  (reNut's own native path also uses a bindless heap — same real technique, independently
+  arrived at).
+- **Async/predictive pipeline compilation**: traverses the game's rendering structures
+  ahead of time during asset loading to determine what pipelines will be needed, compiling
+  them in the background instead of hitching at first-use. reNut's native path currently
+  does none of this (lazy, first-use `GetOrCreatePipeline`) — a real potential technique
+  to adopt if/when native coverage grows large enough for compile stutter to matter.
+- Skips real Xbox 360 GPU hardware quirks entirely where not needed for a PC port
+  (no eDRAM emulation, etc.) — same category of simplification reNut benefits from by
+  not being a cycle-accurate emulator.
+
+### Fable2Recomp (early-stage, actively developed, shares reNut's exact SDK)
+- Explicitly built on **rexglue**, same SDK as reNut ("static recompilation approach
+  based on the ReXGlue project"). The closest sibling project architecturally.
+- Public documentation does not yet describe its GPU/shader approach in any technical
+  detail — appears to be earlier-stage than reNut on this specific front (no evidence
+  found of a working native-shader substitution effort; likely still on/targeting a
+  runtime-translated GPU path, same starting point reNut had before this effort began).
+  A linked upstream issue (`hedge-dev/XenonRecomp#77`, "Fable 2 Recomp and possible issues
+  and help needed") shows they're still working through **CPU-side** recompilation issues
+  (missing-instruction errors), i.e. earlier in the pipeline than reNut's GPU-stage work.
+- **Worth periodically re-checking** as it matures — being on the same SDK means any
+  native-shader infrastructure they build (or blockers they hit) is maximally relevant to
+  reNut, more so than UnleashedRecomp's bespoke-renderer approach.
+
+### Viva Piñata Recomp / TiP-Recomp (both Rare, both rexglue, both very early-stage)
+
+Two separate rexglue-based projects for Rare's Viva Piñata games — the closest *studio*
+sibling to reNut (Rare made both Banjo-Kazooie: Nuts & Bolts and the Viva Piñata games on
+the same generation of in-house tech, so shared engine-level quirks/patterns are plausible,
+even though these are separate codebases, not a shared game engine repo):
+
+- **`VivaPinataRecomp/VivaPinataRecomp`** — the original 2006 Viva Piñata (Xbox 360).
+  Extremely early stage (2 commits as of this check) — no README/technical documentation
+  published yet, nothing to compare against on the GPU/shader front at this time.
+- **`SolarCookies/TiP-Recomp`** — *Viva Piñata: Trouble in Paradise* (2008 sequel).
+  Also rexglue-based, "very early" development, targeting Windows first with Linux
+  planned. Stated goal is explicitly to move off Xenia emulation and enable modding the
+  way a native PC port would, rather than a performance argument specifically — good
+  context for why these Rare titles keep getting picked up by the rexglue community
+  (moddability + platform support), same motivation as reNut's own userbase likely cares
+  about, distinct from (though compatible with) the native-shader performance goal.
+  No GPU/shader-specific technical documentation published yet either.
+- **Why worth tracking**: both are pre-CPU-recompilation-maturity stage (earlier than
+  Fable2Recomp even), so there's nothing to learn from their GPU handling *yet* — but
+  being Rare titles on rexglue, any Rare-engine-specific CPU recompiler quirks or fixes
+  they document (analogous to reNut's own `mullhwucrash.cpp`-class fixes) could be
+  directly relevant later, and it's plausible (unconfirmed) their shader capture will hit
+  the same IM_LOAD/missing-reflection-data problems reNut hit, given the games share a
+  console generation and likely a similar in-house Rare toolchain lineage. Re-check
+  periodically as they mature past early CPU-recompile stage.
+
+### Xenia (Xbox 360 emulator — not a recompiler, but shares the exact same GPU hardware target)
+- **The single most relevant real architectural lead found this project has** (see
+  `history.md` and `renut_shader_conversion_blockers.md` for full detail): on real
+  Xenos hardware, interpolator linkage between vertex shader exports and pixel shader
+  imports is **purely positional (by register index), not by semantic name**. Export
+  register `o0` is always position; generic interpolators `o1`-`o15` link to the pixel
+  shader's inputs by index alone. Xenia's `shader_translator.cc`/`dxbc_shader_translator.cc`
+  never emit named HLSL semantics for interpolators at all — it links VS export N to PS
+  import N directly in the compiled bytecode.
+  - **Why this matters for reNut**: XenosRecomp's approach (emit real HLSL with named
+    D3D9 semantics, resolved via a captured `Interpolator` usage/usageIndex array) is
+    real, but not the *only* valid approach, and is the actual source of reNut's ~500
+    currently-unconvertible vertex shaders (no captured declaration → no semantic name →
+    assert/crash). A positional-linkage alternative is a real, scoped (if substantial)
+    engineering idea — see §5 checklist.
+- eDRAM (10MB embedded framebuffer memory, unique to Xenos) is emulated in system memory
+  by Xenia via manual render-target management — not directly relevant to reNut's shader
+  problem, but useful background if any eDRAM-dependent rendering path is ever hit.
+- Xenia emulates at the hardware/microcode level generally, never reconstructing D3D9 API
+  objects (vertex declarations, shader objects) — this is *why* it never needed the kind
+  of object-layout reverse-engineering reNut once attempted and confirmed is a dead end
+  (no public documentation of the real Xbox 360 D3D9 object memory layout exists anywhere
+  — NDA'd XDK material, not search-indexed).
+
+### Xbox 360 / Xenos hardware documentation (Free60, Beyond3D, general)
+- Free60's Xenos GPU page and Beyond3D's architecture writeup describe the hardware
+  (unified shader architecture, R500-family lineage, 10MB eDRAM, SM3.0-plus) but **do
+  not** document shader constant register *allocation conventions* (e.g. "WVP is always
+  at c0") — because there isn't one. Constant register assignment is a decision made by
+  the original title's D3D9 HLSL compiler at build time, per shader, not a fixed hardware
+  or OS convention.
+  - **This directly explains** why reNut's two static "WVP is at c0-c3" guesses for the
+    on-screen shader label feature both failed (§4) — there was never a reason to expect
+    a single fixed register to work across different shaders in the first place. The
+    live-adjustable calibration slider (current approach) is the *correct* structural
+    response to this fact, not a stopgap — a truly general fix would need the real
+    per-shader constant table (name → register mapping), which is exactly the same
+    reflection data problem blocking full shader conversion in the first place (§4).
+- No source anywhere (Xenia, Free60, Beyond3D, XenosRecomp's own issue tracker, general
+  shader-decompilation literature) describes an ALU-pattern-based technique for inferring
+  vertex-declaration semantics from raw microcode alone. If reNut ever builds one, it
+  would be genuinely novel, not a known/documented technique being reimplemented.
+
+### Summary: where reNut is similar vs different
+
+| | reNut | UnleashedRecomp | Fable2Recomp | Viva Piñata Recomp / TiP-Recomp | Xenia |
+|---|---|---|---|---|---|
+| Developer of original game | Rare | Sonic Team | Lionhead | Rare | N/A |
+| CPU recompiler | XenonRecomp family (via rexglue) | XenonRecomp | XenonRecomp (via rexglue) | XenonRecomp (via rexglue) | N/A (emulated, not recompiled) |
+| Shader recompiler | XenosRecomp | XenosRecomp | Unknown/not yet built | Unknown/not yet built | N/A (own translator, positional linkage) |
+| SDK layer | rexglue | Bespoke | rexglue | rexglue | N/A |
+| Shader source data | Live runtime capture (D3D9 hooks + raw ucode capture) — **frequently incomplete** | Offline extraction of real shipped containers — **complete** | Unknown | Unknown | N/A — reads real hardware command stream live, no declaration recovery needed at all |
+| Native shader coverage | Partial, experimental, corruption not fully root-caused | Full (their whole renderer *is* native) | Unknown/earlier stage | Very early stage, no GPU work published yet | N/A (always "native" in the sense of always-translated-at-runtime) |
+| Bindless textures/shader specialization | Yes (native path) | Yes | Unknown | Unknown | N/A |
+| Predictive/async pipeline compile | No (lazy, first-use) | Yes | Unknown | Unknown | N/A |
+
+## 7. Where things actually live (orientation)
+
+Full path/symbol detail is in `history.md` — this is the two-minute version,
+because the single most common way to waste time on this project is editing or
+testing the wrong copy of something.
+
+- **Two separate trees.** The game repo is `/home/nick/Desktop/reNut/` (git, branch
+  `linux-work`). The rexglue SDK — where all GPU/renderer work happens — is a
+  *different, non-repo* tree at
+  `/home/nick/Desktop/reNut-build-scratch/rexglue-sdk-src/`. Renderer edits go there.
+- **In the SDK, headers and sources are split**: sources under `src/graphics/…`,
+  public headers under `include/rex/graphics/…`. There is also an install-time header
+  copy under `out/install/linux-amd64/include/` — **never edit that one.**
+- **The native shader effort is essentially two files**:
+  `src/graphics/vulkan/renut_xenos_pipeline_cache.{h,cpp}` (pipeline cache, bindless
+  heap, `HasNativePipeline()`, `IssueNativeDraw()`) plus
+  `src/graphics/vulkan/renut_shader_debug_panel.cpp` (ImGui panel — note it has **no**
+  matching `.h`; its API is declared in the pipeline-cache header).
+- **The `IM_LOAD` problem lives in** `src/graphics/command_processor.cpp`
+  (`ExecutePacketType3_IM_LOAD` / `_IM_LOAD_IMMEDIATE`) — the shared PM4 dispatch,
+  not the Vulkan backend. That's the code path where a shader arrives with no D3D9
+  declaration attached, which is the structural origin of §4's blocker.
+- **Building deploys nothing.** `ninja -C out/build/linux-amd64-relwithdebinfo renut`
+  builds the SDK plugins into the *SDK's* `out/linux-amd64/`. They must then be
+  `cp -f`'d into the game's build dir, and the copies `md5sum`-checked. A stale plugin
+  copy runs old code silently, with no error — this has invalidated test results here
+  before, and is the single most important gotcha on the project.
+- **The shader build is CMake-driven**: `cmake/rexglue_xenosrecomp.cmake` fetches and
+  patches XenosRecomp and defines `renut_xenos_shader_batch()`; the actual conversion
+  work is done by `tools/xenos_batch_convert.py` (parallel, per-shader subprocess
+  isolation) fed by `tools/batch_build_synthetic_containers.py` (which is where
+  `--reject-heuristic` lives) and `tools/xenos_synthesize_constant_table.py`.
+- **Ground truth for shader status** is always
+  `out/build/linux-amd64-relwithdebinfo/generated/renut_xenos_shader_cache_manifest.txt`
+  (`<tag> <status>` per line). §2a is just this file, counted.
+
+---
+
+The throughline: reNut's core blocker (§4, §5) is fundamentally a **data-availability**
+problem specific to how Nuts & Bolts' shaders were built and captured, not a problem with
+the shared XenosRecomp/XenonRecomp tooling itself, and not (per Xenia's real architecture)
+even a fundamental requirement of correctly running Xenos shaders at all — a
+positional-linkage approach could sidestep it, at real engineering cost.

--- a/generated/rexglue.cmake
+++ b/generated/rexglue.cmake
@@ -40,12 +40,19 @@ macro(rexglue_setup_target target_name)
         ${CMAKE_CURRENT_SOURCE_DIR}/src
         ${CMAKE_CURRENT_SOURCE_DIR}/generated
     )
+    # Real fix (2026-08-19): matches the current rexglue codegen template
+    # (resources/templates/init/rexglue_cmake.inja in rexglue-sdk, confirmed
+    # against the pinned commit docs/ai/nativevk.md documents) exactly --
+    # this file previously linked a 5-way split (rex::core/system/kernel/
+    # graphics/ui) that is stale relative to that template, which links only
+    # rex::runtime. Confirmed neither rex::graphics nor rex::core exist as
+    # real targets in the pinned SDK commit at all (add_subdirectory mode:
+    # only rex::core and rex::ui ALIAS targets exist, no rex::graphics
+    # anywhere; find_package mode: only rex::runtime is exported, with
+    # rex::system/rex::kernel as ALIASes onto it) -- this stale line hard-
+    # failed configure in BOTH modes with "target ... was not found".
     target_link_libraries(${target_name} PRIVATE
-        rex::core
-        rex::system
-        rex::kernel
-        rex::graphics
-        rex::ui
+        rex::runtime
     )
     rexglue_configure_target(${target_name})
 endmacro()

--- a/packaging/AppRun
+++ b/packaging/AppRun
@@ -1,0 +1,182 @@
+#!/bin/sh
+# reNut AppImage entrypoint.
+#
+# Two jobs before handing off to the binary:
+#   1. First-run game data setup -- offer to extract a disc image the user owns
+#      into ~/.local/share/renut/game and write the path config the runtime
+#      reads. Entirely optional: declining or cancelling just launches renut,
+#      whose built-in path wizard covers the same ground.
+#   2. Supply a default GPU plugin, since the cvar defaults to empty.
+#
+# POSIX sh only -- /bin/sh is dash on Debian/Ubuntu.
+
+set -u
+
+HERE="$(dirname "$(readlink -f "$0")")"
+BIN="$HERE/usr/bin/renut"
+XISO="$HERE/usr/bin/extract-xiso"
+
+CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/renut"
+# Written by PathConfigStore (src/renut_engine/path_config_store.h). Distinct
+# from renut.toml, which holds cvars.
+PATHS_CFG="$CONFIG_DIR/renut.cfg"
+CVAR_CFG="$CONFIG_DIR/renut.toml"
+DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/renut"
+
+# ---------------------------------------------------------------- dialogs --
+# zenity on GNOME-ish systems, kdialog on KDE. With neither, every helper below
+# reports failure and the whole first-run block is skipped in favour of the
+# in-app wizard.
+DIALOG=""
+if command -v zenity >/dev/null 2>&1; then
+    DIALOG=zenity
+elif command -v kdialog >/dev/null 2>&1; then
+    DIALOG=kdialog
+fi
+
+ask_yes_no() {
+    case "$DIALOG" in
+        zenity)  zenity --question --title="reNut" --width=420 --text="$1" ;;
+        kdialog) kdialog --title "reNut" --yesno "$1" ;;
+        *)       return 1 ;;
+    esac
+}
+
+show_error() {
+    case "$DIALOG" in
+        zenity)  zenity --error --title="reNut" --width=420 --text="$1" ;;
+        kdialog) kdialog --title "reNut" --error "$1" ;;
+        *)       printf 'reNut: %s\n' "$1" >&2 ;;
+    esac
+}
+
+pick_iso() {
+    case "$DIALOG" in
+        zenity)  zenity --file-selection --title="Select your game disc image" \
+                        --file-filter="Disc images | *.iso *.ISO" \
+                        --file-filter="All files | *" ;;
+        kdialog) kdialog --title "Select your game disc image" \
+                         --getopenfilename "$HOME" "*.iso *.ISO|Disc images" ;;
+        *)       return 1 ;;
+    esac
+}
+
+# Runs "$@", showing an indeterminate progress dialog while it works. The exit
+# status is the command's, not the dialog's, so callers can tell what happened.
+run_with_progress() {
+    _label="$1"; shift
+    case "$DIALOG" in
+        zenity)
+            "$@" 2>/dev/null | zenity --progress --title="reNut" --pulsate \
+                --auto-close --no-cancel --width=420 --text="$_label" 2>/dev/null
+            ;;
+        *)
+            printf 'reNut: %s\n' "$_label"
+            "$@"
+            ;;
+    esac
+}
+
+# ------------------------------------------------------- game data present --
+# True when the config names a game_data_root that still exists. A config
+# pointing at a deleted or unplugged directory counts as absent, so the user
+# gets offered setup again rather than a confusing runtime failure.
+have_game_data() {
+    [ -f "$PATHS_CFG" ] || return 1
+    _root=$(sed -n \
+        's/^[[:space:]]*game_data_root[[:space:]]*=[[:space:]]*"\(.*\)"[[:space:]]*$/\1/p' \
+        "$PATHS_CFG" | head -n 1)
+    [ -n "$_root" ] && [ -d "$_root" ]
+}
+
+# ------------------------------------------------------------- extraction --
+# extract-xiso lays the disc root out either directly in the target directory or
+# one level down, depending on version and image layout. Rather than guess, find
+# the directory that actually holds default.xex.
+find_game_root() {
+    _stage="$1"
+    _xex=$(find "$_stage" -maxdepth 3 -iname 'default.xex' -type f 2>/dev/null | head -n 1)
+    [ -n "$_xex" ] || return 1
+    dirname "$_xex"
+}
+
+extract_iso() {
+    _iso="$1"
+    _stage="$DATA_DIR/.extract-staging"
+
+    rm -rf "$_stage"
+    if ! mkdir -p "$_stage"; then
+        show_error "Could not create $_stage."
+        return 1
+    fi
+
+    # -x extract, -d target directory.
+    if ! run_with_progress "Extracting game files. This can take several minutes." \
+            "$XISO" -x -d "$_stage" "$_iso"; then
+        rm -rf "$_stage"
+        show_error "extract-xiso could not read that image.
+
+Xbox 360 discs come in several layouts and not every dump is supported. If this
+image is a redump-style ISO it should work; trimmed or compressed formats (CCI,
+GOD, ZAR) need converting to a plain ISO first."
+        return 1
+    fi
+
+    _root=$(find_game_root "$_stage")
+    if [ -z "$_root" ]; then
+        rm -rf "$_stage"
+        show_error "Extraction finished but no default.xex was found.
+
+That usually means the image is not the right game, or it is an Xbox (original)
+disc rather than an Xbox 360 one."
+        return 1
+    fi
+
+    rm -rf "$DATA_DIR/game"
+    mkdir -p "$DATA_DIR"
+    if ! mv "$_root" "$DATA_DIR/game"; then
+        rm -rf "$_stage"
+        show_error "Could not move the extracted files into $DATA_DIR/game."
+        return 1
+    fi
+    rm -rf "$_stage"
+
+    mkdir -p "$DATA_DIR/user" "$CONFIG_DIR"
+    # Matches PathConfigStore::Save's format so the runtime and the in-app
+    # wizard both read it back.
+    {
+        printf '# renut path configuration\n'
+        printf 'game_data_root   = "%s"\n' "$DATA_DIR/game"
+        printf 'user_data_root   = "%s"\n' "$DATA_DIR/user"
+        printf 'update_data_root = ""\n'
+    } > "$PATHS_CFG"
+
+    return 0
+}
+
+# --------------------------------------------------------------- first run --
+# Skipped silently when extract-xiso was not bundled or no dialog tool exists;
+# the in-app wizard is always there as the fallback.
+if ! have_game_data && [ -x "$XISO" ] && [ -n "$DIALOG" ]; then
+    if ask_yes_no "reNut needs the files from your game disc.
+
+Extract them from a disc image now? You will need an ISO of a game you own.
+
+Choosing No opens reNut's own path setup instead."; then
+        iso=$(pick_iso) || iso=""
+        if [ -n "$iso" ]; then
+            extract_iso "$iso" || true
+        fi
+    fi
+fi
+
+# ----------------------------------------------------------------- launch --
+# The gpu_plugin cvar defaults to empty, which loads no renderer at all. Supply
+# xenos on a first run, but never override an explicit flag or a saved config.
+case " $* " in
+    *" --gpu_plugin"*) exec "$BIN" "$@" ;;
+esac
+if [ -f "$CVAR_CFG" ]; then
+    exec "$BIN" "$@"
+fi
+exec "$BIN" --gpu_plugin=xenos "$@"

--- a/packaging/container/Dockerfile
+++ b/packaging/container/Dockerfile
@@ -1,0 +1,153 @@
+# Build image for a low-glibc-floor reNut, with the rexglue SDK baked in.
+#
+# The problem this solves: an AppImage bundles libraries but not libc, so the
+# binary inherits whatever glibc the build host has. Building on CachyOS
+# (glibc 2.43) yields an AppImage that runs only on CachyOS-era distros. None of
+# the >2.28 symbols are features the source asks for -- pthread_rwlock_*@2.34 is
+# the libpthread/libc merge, __isoc23_strtoul@2.38 is the C23 strtol family,
+# sqrtf@2.43 is the errno-setting variant, strlcat@2.38 is feature-detected by
+# SDL -- so they all resolve downward on their own once the build simply happens
+# against an older glibc. No source changes are required.
+#
+# The catch is that an old distro also means an old libstdc++, and this is a
+# C++23 codebase. Hence the split: glibc comes from the old base image, while
+# the C++ toolchain is layered on top at a modern version. clang++ takes its
+# libstdc++ headers from the highest GCC installation it finds, so g++-13
+# supplies <expected>/<print>/etc. while libc stays back at the base version.
+# packaging/make-appimage.sh then bundles *this image's* libstdc++, so the
+# player's machine never needs a matching one.
+#
+# The SDK is compiled in stage two and copied into the final image, so building
+# reNut against it costs nothing -- pull or load the image and the SDK is
+# already there. Only bumping SDK_REF requires paying for that stage again.
+#
+# Default base is Ubuntu 22.04 (glibc 2.35). Override to go lower, e.g.
+#   --build-arg BASE=ubuntu:20.04 --build-arg CODENAME=focal \
+#   --build-arg PYTHON_VENV=python3.8-venv        (glibc 2.31)
+# The further back you go, the likelier apt.llvm.org or the toolchain PPA has
+# stopped publishing for that release -- check before assuming a failure is ours.
+
+# ---------------------------------------------------------------- toolchain --
+ARG BASE=ubuntu:22.04
+FROM ${BASE} AS toolchain
+
+ARG LLVM_VERSION=20
+ARG GCC_VERSION=13
+# Distro codename, used for the apt.llvm.org, Kitware and LunarG repo URLs.
+ARG CODENAME=jammy
+# The SDK build wants a venv module: python3.10 on jammy, python3.8 on focal.
+ARG PYTHON_VENV=python3.10-venv
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      wget gnupg lsb-release ca-certificates software-properties-common \
+ && rm -rf /var/lib/apt/lists/*
+
+# CMake, from Kitware. The distro package is too old -- reNut's CMakeLists.txt
+# requires 3.25 and jammy ships 3.22.
+RUN wget -qO- https://apt.kitware.com/keys/kitware-archive-latest.asc \
+      | gpg --dearmor -o /etc/apt/trusted.gpg.d/kitware.gpg \
+ && echo "deb https://apt.kitware.com/ubuntu/ ${CODENAME} main" \
+      > /etc/apt/sources.list.d/kitware.list
+
+# clang, via the same llvm.sh flow as .github/workflows/_build-platform.yaml.
+RUN wget -qO /tmp/llvm.sh https://apt.llvm.org/llvm.sh \
+ && chmod +x /tmp/llvm.sh \
+ && /tmp/llvm.sh ${LLVM_VERSION} \
+ && apt-get install -y --no-install-recommends \
+      clang-${LLVM_VERSION} lld-${LLVM_VERSION} \
+ && update-alternatives --install /usr/bin/clang   clang   /usr/bin/clang-${LLVM_VERSION}   200 \
+ && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${LLVM_VERSION} 200 \
+ && rm -rf /var/lib/apt/lists/* /tmp/llvm.sh
+
+# A C++23-capable libstdc++ on top of the old glibc.
+RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends g++-${GCC_VERSION} \
+ && rm -rf /var/lib/apt/lists/*
+
+# Vulkan SDK, from LunarG.
+RUN wget -qO- https://packages.lunarg.com/lunarg-signing-key-pub.asc \
+      | tee /etc/apt/trusted.gpg.d/lunarg.asc >/dev/null \
+ && wget -qO /etc/apt/sources.list.d/lunarg-vulkan-${CODENAME}.list \
+      http://packages.lunarg.com/vulkan/lunarg-vulkan-${CODENAME}.list \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends vulkan-sdk \
+ && rm -rf /var/lib/apt/lists/*
+
+# Build dependencies, mirroring the CI workflow's list, plus imagemagick and
+# file for packaging/make-appimage.sh.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      cmake ninja-build build-essential git curl unzip zip autoconf ${PYTHON_VENV} \
+      libgtk-3-dev libx11-xcb-dev libxss-dev \
+      libasound2-dev libpulse-dev libpipewire-0.3-dev \
+      imagemagick file desktop-file-utils \
+ && rm -rf /var/lib/apt/lists/*
+
+ENV CC=clang CXX=clang++
+
+# -------------------------------------------------------------------- sdk ----
+# Expensive and cached: this layer only reruns when SDK_REF changes.
+FROM toolchain AS sdk
+
+ARG SDK_REPO=https://github.com/rexglue/rexglue-sdk.git
+ARG SDK_REF=nightly-20260809-f5c85215
+
+RUN git clone --recursive --depth 1 --branch ${SDK_REF} ${SDK_REPO} /tmp/rexglue-sdk \
+ && cd /tmp/rexglue-sdk \
+ && cmake --preset linux-amd64 \
+ && cmake --build --preset linux-amd64-relwithdebinfo --target install --parallel \
+ && mkdir -p /opt \
+ && mv out/install/linux-amd64 /opt/rexglue-sdk \
+ && rm -rf /tmp/rexglue-sdk
+
+# ----------------------------------------------------------- extract-xiso ----
+# Bundled into the AppImage so the first-run flow in packaging/AppRun can pull
+# game data out of a disc image without the user installing anything.
+#
+# This fork rather than XboxDev/extract-xiso: upstream targets original Xbox
+# XISO images and documents no XGD2/XGD3 support, where 360 discs put the
+# XDVDFS header at a different offset. This one carries somsky's XGD3 patches.
+FROM toolchain AS extract-xiso
+
+ARG XISO_REPO=https://github.com/rikyperdana/extract-xiso.git
+ARG XISO_REF=master
+
+# The repo ships a prebuilt binary and that is what we use. Building from source
+# here fails anyway -- the bundled libftp is compiled without -fPIE while
+# Ubuntu's gcc defaults to PIE, so the link dies on an R_X86_64_32 relocation.
+RUN git clone --depth 1 --branch ${XISO_REF} ${XISO_REPO} /tmp/extract-xiso \
+ && install -Dm755 /tmp/extract-xiso/extract-xiso /opt/extract-xiso/extract-xiso \
+ && rm -rf /tmp/extract-xiso
+
+# A prebuilt binary carries whatever glibc it was linked against, so check it
+# against this image rather than trusting it. Today it needs only 2.15, well
+# under any base we would pick, but a future update to the fork could silently
+# raise the AppImage's floor and undo the point of this whole image.
+#
+# Kept as its own RUN, and written with if/exit rather than a && || chain, so a
+# failure stops the build here instead of surfacing as a confusing COPY error in
+# the final stage.
+RUN need=$(objdump -T /opt/extract-xiso/extract-xiso \
+             | grep -oE 'GLIBC_[0-9.]+' | sed 's/GLIBC_//' | sort -V | tail -n 1); \
+    have=$(ldd --version | head -n 1 | grep -oE '[0-9]+\.[0-9]+$'); \
+    if [ "$(printf '%s\n%s\n' "$need" "$have" | sort -V | tail -n 1)" != "$have" ]; then \
+        echo "error: extract-xiso needs glibc $need, image provides $have" >&2; \
+        exit 1; \
+    fi; \
+    echo "extract-xiso ok: needs glibc $need, image provides $have"
+
+# ------------------------------------------------------------------ final ----
+FROM toolchain AS final
+
+# The built SDK only, without the source tree or object files behind it.
+COPY --from=sdk /opt/rexglue-sdk /opt/rexglue-sdk
+COPY --from=extract-xiso /opt/extract-xiso /opt/extract-xiso
+
+# Where reNut's generated/rexglue.cmake find_package() call will look.
+ENV CMAKE_PREFIX_PATH=/opt/rexglue-sdk
+# appimagetool is itself an AppImage and there is no FUSE in here.
+ENV APPIMAGE_EXTRACT_AND_RUN=1
+
+WORKDIR /src/reNut

--- a/packaging/container/README.md
+++ b/packaging/container/README.md
@@ -1,0 +1,105 @@
+# Low-glibc build container
+
+Builds reNut against an old glibc so the AppImage runs on distros other than
+bleeding-edge ones. The rexglue SDK is compiled **into the image**, so building
+reNut against it is cheap and nobody has to build the SDK themselves.
+
+## Why this exists
+
+An AppImage bundles libraries but not libc, so the binary inherits whatever
+glibc the build host has. Built on CachyOS (glibc 2.43), the result runs on
+almost nothing else.
+
+There were two separate floors, and they move independently:
+
+| Floor | Cause | Fix |
+| --- | --- | --- |
+| `GLIBC_2.43` | build host's libc | this container |
+| `GLIBCXX_3.4.35` | build host's libstdc++ headers | bundled by `make-appimage.sh` |
+
+The second one is easy to miss and was in practice the stricter of the two:
+`librexruntimerd.so` called the C++20 atomic-wait symbols behind
+`std::atomic::wait`/`latch`/`barrier`, which only a GCC 15-or-newer libstdc++
+exports. Ubuntu 24.04 and Debian 13 have new enough glibc but too old a
+libstdc++, so they failed regardless of the glibc number.
+`packaging/make-appimage.sh` now stages `libstdc++.so.6` and `libgcc_s.so.1`
+next to the binary unconditionally, which removes that floor everywhere —
+including on host builds that never touch this container.
+
+None of the glibc symbols above 2.28 are features the source actually asks for.
+`pthread_rwlock_*@2.34` is the libpthread/libc merge, `__isoc23_strtoul@2.38` is
+the C23 strtol family, `sqrtf@2.43` is the errno-setting variant, and
+`strlcat@2.38` is feature-detected by SDL. They are all chosen by the build
+host, which is why building against an older glibc fixes them with no source
+changes — and why the `polyfill-glibc` symbol rewriting in `make-appimage.sh`
+was only ever treating symptoms.
+
+## Usage
+
+```sh
+packaging/container/build.sh image      # once: toolchain + SDK (slow)
+packaging/container/build.sh all        # per change: build + package (fast)
+```
+
+Output lands in `dist/reNut-x86_64.AppImage`. The container builds into
+`out/container/` rather than `out/`, so it will not fight with a host build over
+the same CMake cache.
+
+Packaging runs *inside* the container deliberately. `make-appimage.sh` bundles
+whichever libstdc++ `$CXX` points at, so running that step on the host would
+re-import the host's newer libstdc++ and undo the exercise.
+
+## Sharing the image
+
+Contributors should never build the SDK. Publish the image once and have them
+pull it:
+
+```sh
+docker tag renut-build:jammy ghcr.io/<owner>/renut-build:jammy
+docker push ghcr.io/<owner>/renut-build:jammy
+```
+
+```sh
+RENUT_IMAGE=ghcr.io/<owner>/renut-build:jammy packaging/container/build.sh all
+```
+
+Or, without a registry: `docker save renut-build:jammy | zstd > renut-build.tar.zst`
+and `zstd -d < renut-build.tar.zst | docker load`.
+
+Rebuild the image only when `SDK_REF` changes — that is the one argument that
+invalidates the expensive layer.
+
+## Choosing the floor
+
+Default is Ubuntu 22.04, giving **glibc 2.35**: Ubuntu 22.04+, Debian 12+,
+Fedora 36+, and current SteamOS. To go lower:
+
+```sh
+BASE=ubuntu:20.04 CODENAME=focal PYTHON_VENV=python3.8-venv \
+  RENUT_IMAGE=renut-build:focal packaging/container/build.sh image
+```
+
+That targets glibc 2.31 and covers essentially every distro still receiving
+updates. The tradeoff is that the further back you go, the likelier
+`apt.llvm.org` or the `ubuntu-toolchain-r` PPA has stopped publishing for that
+release — check that before assuming a failure is ours.
+
+One confusing detail if you go looking: the bundled `libstdc++.so.6` reports
+`GLIBCXX_3.4.35`, which is *not* evidence that a newer host libstdc++ leaked in.
+Installing `g++-13` also pulls the toolchain PPA's libstdc++6 runtime, which is
+built from a newer GCC but still against the base image's glibc. Compiled code
+needs 3.4.32 (GCC 13's headers) and the bundled runtime provides 3.4.35, so it
+is satisfied. The reliable provenance check is the *glibc* requirement of the
+bundled library — 2.34 from the container, versus 2.38 from a CachyOS host.
+
+Verify what you actually produced:
+
+```sh
+objdump -T out/container/build/linux-amd64-relwithdebinfo/renut \
+  | grep -oE 'GLIBC_[0-9.]+' | sort -uV | tail -1
+```
+
+## Unrelated floor worth knowing
+
+The SDK presets set `-march=x86-64-v2`, which is a *CPU* requirement (roughly
+Nehalem and newer), not a distro one. Nothing here changes it.

--- a/packaging/container/build.sh
+++ b/packaging/container/build.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+#
+# Builds reNut against an old glibc inside Docker and packages the AppImage.
+#
+# The SDK is already compiled inside the image (see Dockerfile), so nobody has
+# to build it -- the first 'image' run pays for it once, or you skip even that
+# by loading an image someone else published.
+#
+# Usage:
+#   packaging/container/build.sh image      # build the toolchain+SDK image
+#   packaging/container/build.sh build      # compile reNut inside it
+#   packaging/container/build.sh appimage   # package dist/reNut-x86_64.AppImage
+#   packaging/container/build.sh all        # build + appimage
+#   packaging/container/build.sh shell      # interactive shell in the image
+#
+# Env:
+#   RENUT_IMAGE   image tag                       (default renut-build:jammy)
+#   BASE          base image                      (default ubuntu:22.04)
+#   CODENAME      matching distro codename        (default jammy)
+#   PYTHON_VENV   matching venv package           (default python3.10-venv)
+#   SDK_REF       rexglue-sdk git tag/branch/SHA  (default pinned below)
+#
+# The container writes to out/container/ rather than out/, so it never fights
+# with a host build over the same CMake cache -- the two use different compilers
+# and different sysroots, and a shared cache would produce confusing failures.
+# dist/ is shared, because that is the artifact you actually ship.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+IMAGE="${RENUT_IMAGE:-renut-build:jammy}"
+BASE="${BASE:-ubuntu:22.04}"
+CODENAME="${CODENAME:-jammy}"
+PYTHON_VENV="${PYTHON_VENV:-python3.10-venv}"
+SDK_REF="${SDK_REF:-nightly-20260809-f5c85215}"
+
+PRESET=linux-amd64-relwithdebinfo
+CONTAINER_OUT="$REPO_ROOT/out/container"
+
+# The runtime shared libraries, which the build does not place next to the
+# executable itself. renut has RUNPATH=$ORIGIN and make-appimage.sh reads them
+# out of the build directory, so they are copied there after each build.
+LIBS=(librexruntimerd.so librexgpu-xenosrd.so libTracyClientrd.so)
+
+die() { printf 'error: %s\n' "$1" >&2; exit 1; }
+
+DOCKER="${DOCKER:-docker}"
+
+command -v "$DOCKER" >/dev/null 2>&1 \
+  || die "docker is not installed (Arch/CachyOS: sudo pacman -S docker && sudo systemctl enable --now docker)"
+
+$DOCKER info >/dev/null 2>&1 || die "cannot reach the docker daemon.
+  Either add yourself to the docker group (note that this grants root-equivalent
+  access to the machine):
+      sudo usermod -aG docker \$USER   # then log out and back in, or: newgrp docker
+  or run this script under sudo, which is handled:
+      sudo -E $0 ${1:-all}"
+
+# Under sudo, id -u is 0, which would leave root-owned artifacts in the source
+# tree. SUDO_UID/SUDO_GID name the invoking user, so prefer them when present.
+RUN_UID="${SUDO_UID:-$(id -u)}"
+RUN_GID="${SUDO_GID:-$(id -g)}"
+
+have_image() { $DOCKER image inspect "$IMAGE" >/dev/null 2>&1; }
+
+# 'all' deliberately does not rebuild the image -- that is the slow step and it
+# rarely needs redoing. The cost is that a Dockerfile edit silently does nothing
+# until someone reruns 'image', so say so rather than let it pass unnoticed.
+warn_if_image_stale() {
+  local created created_epoch dockerfile_epoch
+  created=$($DOCKER image inspect -f '{{.Created}}' "$IMAGE" 2>/dev/null) || return 0
+  created_epoch=$(date -d "$created" +%s 2>/dev/null) || return 0
+  dockerfile_epoch=$(stat -c %Y "$REPO_ROOT/packaging/container/Dockerfile" 2>/dev/null) || return 0
+  if (( dockerfile_epoch > created_epoch )); then
+    printf 'warning: Dockerfile has changed since %s was built.\n' "$IMAGE" >&2
+    printf "         run '%s image' to pick up those changes.\n" "$0" >&2
+  fi
+}
+
+build_image() {
+  echo "==> building $IMAGE (base=$BASE, sdk=$SDK_REF)"
+  echo "    the SDK compiles in here; expect this to take a while the first time"
+  $DOCKER build \
+    --build-arg "BASE=$BASE" \
+    --build-arg "CODENAME=$CODENAME" \
+    --build-arg "PYTHON_VENV=$PYTHON_VENV" \
+    --build-arg "SDK_REF=$SDK_REF" \
+    -t "$IMAGE" \
+    "$REPO_ROOT/packaging/container"
+}
+
+# Runs as the invoking user so build artifacts are not left root-owned on the
+# host. That leaves HOME pointing at a directory this user cannot write, which
+# CMake and git both dislike, so redirect it.
+run_in_container() {
+  mkdir -p "$CONTAINER_OUT"
+  # Under sudo the mkdir above runs as root, but the container runs as the
+  # invoking user and would then have nowhere to write. Hand the directory over.
+  # Recursive so a directory left behind by an earlier run repairs itself.
+  if [[ -n "${SUDO_UID:-}" ]]; then
+    chown -R "$RUN_UID:$RUN_GID" "$CONTAINER_OUT"
+  fi
+  $DOCKER run --rm -i \
+    --user "$RUN_UID:$RUN_GID" \
+    -e HOME=/tmp \
+    -v "$REPO_ROOT":/src/reNut \
+    -v "$CONTAINER_OUT":/src/reNut/out \
+    -w /src/reNut \
+    "$@"
+}
+
+cmd_build() {
+  have_image || die "image $IMAGE not found -- run '$0 image' first"
+  warn_if_image_stale
+  echo "==> configuring and building reNut (glibc floor set by $BASE)"
+  run_in_container "$IMAGE" bash -euc "
+    cmake --preset $PRESET -DCMAKE_PREFIX_PATH=/opt/rexglue-sdk
+    cmake --build --preset $PRESET --parallel
+    for lib in ${LIBS[*]}; do
+      cp /opt/rexglue-sdk/lib/\$lib out/build/$PRESET/\$lib
+    done
+  "
+}
+
+cmd_appimage() {
+  have_image || die "image $IMAGE not found -- run '$0 image' first"
+  warn_if_image_stale
+  [[ -x "$CONTAINER_OUT/build/$PRESET/renut" ]] \
+    || die "no container-built renut -- run '$0 build' first"
+  echo "==> packaging AppImage"
+  # Packaged inside the container on purpose: make-appimage.sh bundles the
+  # libstdc++ that ${CXX} points at, and that has to be the image's GCC 13 one.
+  # Running this step on the host would re-import the host's glibc 2.38
+  # libstdc++ and undo the whole exercise.
+  run_in_container "$IMAGE" \
+    packaging/make-appimage.sh "/src/reNut/out/build/$PRESET"
+}
+
+case "${1:-all}" in
+  image)    build_image ;;
+  build)    cmd_build ;;
+  appimage) cmd_appimage ;;
+  all)      cmd_build; cmd_appimage ;;
+  shell)    have_image || die "image $IMAGE not found -- run '$0 image' first"
+            run_in_container -t "$IMAGE" bash ;;
+  *)        die "unknown command '${1}' (image|build|appimage|all|shell)" ;;
+esac

--- a/packaging/make-appimage.sh
+++ b/packaging/make-appimage.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+#
+# Builds dist/reNut-x86_64.AppImage from an existing reNut build.
+#
+# Prerequisites: a completed build (linux-amd64-release is preferred over
+# relwithdebinfo, though this script strips either), ImageMagick for the icon,
+# and network access on first run to fetch appimagetool.
+#
+# Usage:
+#   packaging/make-appimage.sh [build-dir]
+#   RENUT_LOWER_GLIBC=1 packaging/make-appimage.sh    # see "glibc floor" below
+#
+# Why this needs no LD_LIBRARY_PATH or library-rewriting:
+#   renut is linked with RUNPATH=$ORIGIN, so the three rexglue .so files are
+#   found simply by sitting next to the binary -- which is also where the GPU
+#   plugin is dlopen'd from. libstdc++/libgcc ride along the same way (see
+#   "C++ runtime floor" below); everything else it links (libc, X11, xcb) is
+#   deliberately left to the host.
+#
+# Why it works on a read-only mount:
+#   renut writes its config to $XDG_CONFIG_HOME/renut and its logs to
+#   $XDG_STATE_HOME/renut (see src/renut_engine/linuxfixes/xdg_paths.h). Before
+#   that change it wrote both next to the executable, which cannot work inside
+#   an AppImage.
+#
+# There are two portability floors here, and they move independently.
+#
+# C++ runtime floor (handled unconditionally, below):
+#   clang++ compiles against whichever libstdc++ headers the build host's GCC
+#   installs, so on a bleeding-edge host librexruntimerd.so ends up calling
+#   GLIBCXX_3.4.35 symbols -- the C++20 atomic-wait machinery behind
+#   std::atomic::wait/latch/barrier, which only a GCC 15-or-newer libstdc++
+#   exports. That is a *stricter* limit than the glibc one, and it is easy to
+#   miss: Ubuntu 24.04 and Debian 13 both have new enough glibc but too old a
+#   libstdc++. So libstdc++.so.6 and libgcc_s.so.1 are staged next to renut and
+#   resolved through the same RUNPATH=$ORIGIN. Bundling a *newer* libstdc++ is
+#   safe -- Mesa/GL drivers dlopen'd later need older versions and a newer one
+#   satisfies them. The reverse would not hold, so never bundle an older one.
+#
+# glibc floor:
+#   The resulting AppImage inherits the build host's glibc requirement -- an
+#   AppImage bundles libraries, not libc. Building on a bleeding-edge distro
+#   therefore produces an AppImage that only runs on bleeding-edge distros.
+#   Setting RENUT_LOWER_GLIBC=1 runs polyfill-glibc to remap five float math
+#   symbols (sqrtf/acosf/asinf/atan2f/log10f) from their GLIBC_2.43 versions to
+#   the ABI-identical GLIBC_2.2.5 ones, which lowers the floor to 2.38 with no
+#   rebuild. Going below 2.38 currently does not work: polyfill-glibc crashes on
+#   librexruntimerd.so when targeting 2.34+, and targeting 2.32 yields a renut
+#   that segfaults in its own static initialisers. None of the symbols above
+#   2.28 are features the source actually asks for -- they are all picked by the
+#   build host -- so the real fix for anything lower is to build against an older
+#   glibc instead of rewriting symbols afterwards. See packaging/container/.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="${1:-$REPO_ROOT/out/build/linux-amd64-relwithdebinfo}"
+WORK_DIR="$REPO_ROOT/out/appimage"
+APP_DIR="$WORK_DIR/renut.AppDir"
+DIST_DIR="$REPO_ROOT/dist"
+OUTPUT="$DIST_DIR/reNut-x86_64.AppImage"
+
+LIBS=(librexruntimerd.so librexgpu-xenosrd.so libTracyClientrd.so)
+
+die() { printf 'error: %s\n' "$1" >&2; exit 1; }
+
+[[ -x "$BUILD_DIR/renut" ]] || die "no renut binary in $BUILD_DIR (build first)"
+for lib in "${LIBS[@]}"; do
+  [[ -f "$BUILD_DIR/$lib" ]] || die "missing $lib in $BUILD_DIR"
+done
+command -v magick >/dev/null 2>&1 || command -v convert >/dev/null 2>&1 \
+  || die "ImageMagick is required to convert icon/app.ico"
+
+rm -rf "$APP_DIR"
+mkdir -p "$APP_DIR/usr/bin" "$DIST_DIR"
+
+echo "==> staging binaries"
+cp "$BUILD_DIR/renut" "$APP_DIR/usr/bin/"
+for lib in "${LIBS[@]}"; do cp "$BUILD_DIR/$lib" "$APP_DIR/usr/bin/"; done
+
+echo "==> stripping"
+strip --strip-unneeded "$APP_DIR/usr/bin/renut" "$APP_DIR/usr/bin/"*.so 2>/dev/null || true
+
+if [[ "${RENUT_LOWER_GLIBC:-0}" == "1" ]]; then
+  echo "==> lowering glibc floor (2.43 -> 2.38)"
+  command -v polyfill-glibc >/dev/null 2>&1 \
+    || die "RENUT_LOWER_GLIBC=1 needs polyfill-glibc on PATH (github.com/corsix/polyfill-glibc)"
+  renames="$WORK_DIR/renames.txt"
+  cat > "$renames" <<'RENAMES'
+// glibc 2.43 added new symbol versions for these float math functions. The
+// GLIBC_2.2.5 versions are ABI-identical (they additionally set errno, which is
+// what every binary built before 2.43 already relied on), so binding to them is
+// safe and removes the hard 2.43 requirement.
+sqrtf@GLIBC_2.43   libm.so.6::sqrtf@GLIBC_2.2.5
+acosf@GLIBC_2.43   libm.so.6::acosf@GLIBC_2.2.5
+asinf@GLIBC_2.43   libm.so.6::asinf@GLIBC_2.2.5
+atan2f@GLIBC_2.43  libm.so.6::atan2f@GLIBC_2.2.5
+log10f@GLIBC_2.43  libm.so.6::log10f@GLIBC_2.2.5
+RENAMES
+  for f in "$APP_DIR/usr/bin/renut" "$APP_DIR/usr/bin/"*.so; do
+    polyfill-glibc --rename-dynamic-symbols="$renames" "$f"
+  done
+fi
+
+echo "==> bundling C++ runtime"
+# Deliberately staged after the strip and polyfill-glibc loops above: those glob
+# *.so, which does not match *.so.N, so these arrive verbatim as the toolchain
+# shipped them. They need at most GLIBC_2.38 themselves (libstdc++ 2.38, libgcc
+# 2.35), so they never raise the floor reported at the end.
+for lib in libstdc++.so.6 libgcc_s.so.1; do
+  src="$("${CXX:-clang++}" -print-file-name="$lib")"
+  [[ -f "$src" ]] || die "could not locate $lib via ${CXX:-clang++} -print-file-name"
+  cp -L "$src" "$APP_DIR/usr/bin/$lib"
+done
+
+echo "==> bundling extract-xiso"
+# Used by AppRun's first-run flow to extract game data from a disc image the
+# user owns. Optional: AppRun skips that flow entirely when the binary is
+# absent, falling back to renut's built-in path wizard. Prefer the copy the
+# build container produces, since a host-built one would carry the host's glibc
+# requirement into the AppImage.
+xiso=""
+if [[ -x /opt/extract-xiso/extract-xiso ]]; then
+  xiso=/opt/extract-xiso/extract-xiso
+elif command -v extract-xiso >/dev/null 2>&1; then
+  xiso="$(command -v extract-xiso)"
+fi
+if [[ -n "$xiso" ]]; then
+  cp "$xiso" "$APP_DIR/usr/bin/extract-xiso"
+  strip --strip-unneeded "$APP_DIR/usr/bin/extract-xiso" 2>/dev/null || true
+else
+  echo "    warning: extract-xiso not found, first-run ISO extraction will be"
+  echo "             unavailable in this build (the in-app wizard still works)"
+fi
+
+echo "==> icon"
+ico="$REPO_ROOT/icon/app.ico"
+if command -v magick >/dev/null 2>&1; then
+  magick "$ico[0]" -resize 256x256 "$APP_DIR/renut.png"
+else
+  convert "$ico[0]" -resize 256x256 "$APP_DIR/renut.png"
+fi
+cp "$APP_DIR/renut.png" "$APP_DIR/.DirIcon"
+
+echo "==> AppRun + desktop entry"
+# Kept as a real file rather than a heredoc so it can be shellchecked and diffed
+# on its own. It handles the first-run disc extraction as well as the launch.
+cp "$REPO_ROOT/packaging/AppRun" "$APP_DIR/AppRun"
+chmod +x "$APP_DIR/AppRun"
+
+cat > "$APP_DIR/renut.desktop" <<'DESKTOP'
+[Desktop Entry]
+Type=Application
+Name=reNut
+Comment=Xbox 360 game recompilation
+Exec=renut
+Icon=renut
+Categories=Game;
+Terminal=false
+DESKTOP
+
+echo "==> fetching appimagetool if needed"
+tool="$WORK_DIR/appimagetool"
+if [[ ! -x "$tool" ]]; then
+  curl -sSL -o "$tool" \
+    https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
+  chmod +x "$tool"
+fi
+
+echo "==> packaging"
+ARCH=x86_64 "$tool" "$APP_DIR" "$OUTPUT"
+
+echo
+echo "built: $OUTPUT"
+echo "  size:        $(du -h "$OUTPUT" | cut -f1)"
+# Every staged file, bundled C++ runtime included -- all of it has to load on the
+# target. GLIBC_ cannot match GLIBCXX_ here, since the pattern needs a digit
+# straight after the underscore.
+echo "  glibc floor: $(objdump -T "$APP_DIR/usr/bin/"* 2>/dev/null \
+                        | grep -oE 'GLIBC_[0-9.]+' | sort -uV | tail -1)"
+echo "  libstdc++:   bundled, $(objdump -T "$APP_DIR/usr/bin/libstdc++.so.6" 2>/dev/null \
+                        | grep -oE 'GLIBCXX_[0-9.]+' | sort -uV | tail -1) (host floor removed)"

--- a/src/renut_app.h
+++ b/src/renut_app.h
@@ -9,10 +9,27 @@
 #include "renut_engine/Timer.h"
 #include "renut_engine/Fps.h"
 #include "renut_engine/hooks.h"
+#include <rex/cvar.h>
 #include <rex/ui/window.h>
-//#include <rex/discord_rpc.h>
+#ifdef _WIN32
+#include <rex/discord_rpc.h>
+#endif
 #include <functional>
 #include <string>
+#ifndef _WIN32
+#include "renut_engine/linuxfixes/xdg_paths.h"
+// DebugHubOverlayDialog (Performance/A-B-benchmark/Native-shader tabs, see
+// debug_hub_overlay.h) resolves plugin symbols with dlopen/dlsym, which has
+// no equivalent included here for Windows yet -- keep it out of Windows
+// builds rather than add an untested LoadLibrary path. The native renderer
+// it debugs is Linux-only in practice today anyway.
+#include "renut_engine/overlays/debug_hub_overlay.h"
+
+// Defined in the SDK (src/core/logging.cpp) at global scope. When non-empty it
+// takes precedence over the exe-relative logs/ directory that rex_app.cpp would
+// otherwise hardcode.
+REXCVAR_DECLARE(std::string, log_file);
+#endif
 
 class RenutApp : public rex::ReXApp {
 public:
@@ -24,20 +41,53 @@ public:
         return std::unique_ptr<RenutApp>(new RenutApp(ctx, "renut", PPCImageConfig));
     }
 
+#ifndef _WIN32
+    // Runs before the SDK loads the config and before logging is initialised
+    // (rex_app.cpp:146), which is the only point where both destinations can
+    // still be redirected.
+    //
+    // Without this, renut writes <exe_dir>/renut.toml and <exe_dir>/logs/ --
+    // fine in a build tree, fatal inside a read-only AppImage/Flatpak mount.
+    void OnConfigurePaths(rex::PathConfig& paths) override {
+        namespace lf = renut::linuxfixes;
 
-    // void OnPostSetup() override {
-    //     rex::discord_rpc::Presence rpc;
+        // ~/.config/renut/renut.toml, migrating any existing exe-relative copy.
+        paths.config_path = lf::ResolveWithMigration(lf::ConfigDir(),
+                                                     std::string(GetName()) + ".toml");
 
-    //     rpc.details_ = "";
-    //     rpc.state_ = "";
-    //     rpc.large_image_key_ = "e242d6b6-c34e-47a1-8c2a-5297fe33bce7";
-    //     rpc.large_image_text_ = "renut";
+        // ~/.local/state/renut/logs/renut_NNN.log. Setting log_file is the only
+        // way to move the log directory, since rex_app.cpp hardcodes exe_dir/logs
+        // whenever this cvar is empty -- so we do the sequential numbering that
+        // the SDK would otherwise have done for us.
+        if (REXCVAR_GET(log_file).empty()) {
+            auto log_path = lf::NextSequentialLog(lf::LogDir(), std::string(GetName()));
+            if (!log_path.empty()) {
+                REXCVAR_SET(log_file, log_path.string());
+            }
+            // If the state dir could not be created we leave the cvar empty and
+            // let the SDK fall back to its exe-relative default.
+        }
+    }
+#endif
 
-    //     //rex::discord_rpc::Start(Application ID, Settings);
-    //     rex::discord_rpc::Start("1520303728047951892", rpc);
+     void OnPostSetup() override {
+    #ifdef _WIN32
+        rex::discord_rpc::Presence rpc;
 
-    //     rex::cvar::LoadConfig("renut.toml"); 
-    // }
+        rpc.details_ = "";
+        rpc.state_ = "";
+        rpc.large_image_key_ = "e242d6b6-c34e-47a1-8c2a-5297fe33bce7";
+        rpc.large_image_text_ = "renut";
+
+        //rex::discord_rpc::Start(Application ID, Settings);
+        rex::discord_rpc::Start("1520303728047951892", rpc);
+
+        rex::cvar::LoadConfig("renut.toml");
+    #endif
+        rex::cvar::SetFlagByName("gpu_allow_invalid_fetch_constants", "true");
+        rex::cvar::SetFlagByName("readback_resolve", "none");
+        rex::cvar::SetFlagByName("readback_memexport", "false");
+     }
 
     void OnCreateDialogs(rex::ui::ImGuiDrawer* drawer) override {
         //drawer->AddDialog(new FpsOverlayDialog(drawer));
@@ -45,6 +95,9 @@ public:
         fps_dialog_->fpsManager = &fpsManager;
         drawer->AddDialog(fps_dialog_.get());
         drawer->AddDialog(new RenuLogOverlayDialog(drawer));
+#ifndef _WIN32
+        drawer->AddDialog(new DebugHubOverlayDialog(drawer));
+#endif
         path_wizard_ = new PathSetupWizard(drawer);
         drawer->AddDialog(path_wizard_);
 
@@ -63,6 +116,12 @@ public:
         const rex::PathConfig& defaults,
         std::function<void(rex::PathConfig)> resume) override
     {
+        if (!path_wizard_) {
+            RNUT_WARN("path setup wizard unavailable (no graphics/ImGui surface); "
+                      "using default paths");
+            return defaults;
+        }
+
         path_wizard_->Init(app_name_, defaults, [resume](rex::PathConfig resolved) {
             resume(resolved);
             });

--- a/src/renut_app.h
+++ b/src/renut_app.h
@@ -16,14 +16,19 @@
 #endif
 #include <functional>
 #include <string>
+// DebugHubOverlayDialog (Performance/A-B-benchmark/Native-shader tabs) used
+// to be Linux-only here (its plugin-symbol lookups used dlopen/dlsym with no
+// Windows equivalent) -- fixed 2026-08-19 via dl_compat.h's cross-platform
+// shim (see debug_hub_overlay.h), so it's available on both platforms now.
+// The Native-Shaders/A-B-Benchmark tabs still gracefully report "not
+// available" wherever the nativevk plugin isn't loaded (Windows builds
+// included, since that plugin remains Linux-only in practice) -- only the
+// Performance tab, which needs no plugin symbol lookup at all, actually
+// gained real functionality on Windows from this change.
+#include "renut_engine/overlays/debug_hub_overlay.h"
+
 #ifndef _WIN32
 #include "renut_engine/linuxfixes/xdg_paths.h"
-// DebugHubOverlayDialog (Performance/A-B-benchmark/Native-shader tabs, see
-// debug_hub_overlay.h) resolves plugin symbols with dlopen/dlsym, which has
-// no equivalent included here for Windows yet -- keep it out of Windows
-// builds rather than add an untested LoadLibrary path. The native renderer
-// it debugs is Linux-only in practice today anyway.
-#include "renut_engine/overlays/debug_hub_overlay.h"
 
 // Defined in the SDK (src/core/logging.cpp) at global scope. When non-empty it
 // takes precedence over the exe-relative logs/ directory that rex_app.cpp would
@@ -95,9 +100,7 @@ public:
         fps_dialog_->fpsManager = &fpsManager;
         drawer->AddDialog(fps_dialog_.get());
         drawer->AddDialog(new RenuLogOverlayDialog(drawer));
-#ifndef _WIN32
         drawer->AddDialog(new DebugHubOverlayDialog(drawer));
-#endif
         path_wizard_ = new PathSetupWizard(drawer);
         drawer->AddDialog(path_wizard_);
 

--- a/src/renut_engine/FPS.cpp
+++ b/src/renut_engine/FPS.cpp
@@ -58,3 +58,18 @@ void FPSCounter::Tick(){
     averageFps = 1000.0f / averageMs;
 }
 
+// Hooked from config/renut_hooks.toml (frame-timing instrumentation points
+// used by the native-renderer trace panel, see trace_stats.cpp) -- currently
+// no-ops, the hooks exist so the addresses are wired for future use.
+void appMainDrawStart() {
+}
+
+void appMainDrawend() {
+}
+
+void appMainTickPreDrawStart() {
+}
+
+void appMainTickPreDrawend() {
+}
+

--- a/src/renut_engine/FPS.cpp
+++ b/src/renut_engine/FPS.cpp
@@ -2,6 +2,7 @@
 #include "Fps.h"
 #include <renut_engine/hooks.h>
 #include <renut_engine/Timer.h>
+#include <renut_engine/nativevk_phase0.h>
 #include <rex/hook.h>
 
 //CPU Time
@@ -59,12 +60,18 @@ void FPSCounter::Tick(){
 }
 
 // Hooked from config/renut_hooks.toml (frame-timing instrumentation points
-// used by the native-renderer trace panel, see trace_stats.cpp) -- currently
-// no-ops, the hooks exist so the addresses are wired for future use.
+// used by the native-renderer trace panel, see trace_stats.cpp). Also the
+// real per-frame boundary for nativevk_phase0's D3D9-hook draw-count
+// validation (docs/ai/archive/native-renderer-rewrite-plan.md Phase 0) --
+// this wraps the guest's ENTIRE draw submission (REX_HOOK_RAW(appMainDraw)
+// above), matching exactly what the SDK's own real "draws" trace stat
+// (trace_stats.cpp) is scoped to, so the two counts are directly comparable.
 void appMainDrawStart() {
+    renut::nativevk_phase0::FrameStart();
 }
 
 void appMainDrawend() {
+    renut::nativevk_phase0::FrameEnd();
 }
 
 void appMainTickPreDrawStart() {

--- a/src/renut_engine/cvar_menu.cpp
+++ b/src/renut_engine/cvar_menu.cpp
@@ -1,3 +1,37 @@
+// =============================================================================
+// cvar_menu.cpp
+//
+// Lets you edit every reNut cvar from inside the game's pause menu (selectable
+// ON/OFF or value next to each), instead of the F4 overlay. It adds a dedicated
+// "reNut Settings" tab/section to the pause section strip; its content is a
+// categorized, collapsible list ("[-]/[+] Category" headers + indented cvars).
+//
+// How it plugs into the game's XUI pause menu (all addresses from IDA):
+//   Content list (the rows within a section):
+//   * sub_825A89B0  - content-list builder. Fills dword_82FA32F8[] with item
+//                     type-IDs and dword_82FA32F4 with the count, then the tail
+//                     inserts that many XUI list rows.
+//   * sub_825A96C8  - per-item label callback.
+//   * sub_825A8D68  - selection/dispatch callback.
+//   * sub_825A76E0  - pause input handler; its "activate item" dispatch is a
+//                     jump table bounded to modes 0..7.
+//   Section strip (the tabs):
+//   * sub_825A6708  - strip builder. Fills dword_82FA32C4[] (section ids) +
+//                     dword_82FA32C0 (count).
+//   * sub_825A8110  - per-tab icon callback (off_82E51538[2*id]).
+//   * sub_825A7CF0  - selected-section title text (off_82E5153C[2*id]).
+//   * sub_825A7D90  - section switch / setMode(obj, id); jump table id<=7.
+//
+// In cvar mode we NEVER store rows in the guest item array: the injection hook
+// writes only the COUNT, and the label/dispatch overrides source everything
+// from the host-side model (g_cats -> g_rows). Section id 8 = "reNut Settings"
+// (game uses 0..7); its icon reuses section 0's. Because sub_825A76E0's activate
+// dispatch is bounded to modes 0..7, we present mode 0 while our section is
+// active so A-press routes to sub_825A8D68 (our toggle).
+//
+// See: https://github.com/rexglue/rexglue-sdk/wiki/Function-Overrides
+// =============================================================================
+
 #include <rex/hook.h>
 #include <rex/cvar.h>
 #include <rex/logging.h>
@@ -6,12 +40,18 @@
 #include <algorithm>
 #include <cstdint>
 #include <cstdlib>
+#include <filesystem>
 #include <fstream>
 #include <optional>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+
+#ifndef _WIN32
+// Keeps renut.toml out of the working directory so it survives an AppImage.
+#include "linuxfixes/xdg_paths.h"
+#endif
 
 #if defined(_MSC_VER)
 #include <stdlib.h>
@@ -326,7 +366,25 @@ static void ApplyCvarChange(const CvarRow& row, bool forward) {
 // cvars are appended. Commands are never written (they have no value). This is
 // why we don't use rex::cvar::SaveConfig(), which truncates the whole file.
 // -----------------------------------------------------------------------------
-static constexpr const char* kRenutConfigPath = "renut.toml";
+// Resolved once, on first use.
+//
+// This must not stay a bare relative path on Linux. A relative name resolves
+// against the process working directory, which for an AppImage is wherever the
+// user happened to launch it from -- so the cvar config was being created next
+// to the .AppImage and never found again. Running the build-dir binary hid this,
+// because there the working directory is the build directory.
+//
+// Windows keeps the executable-relative behaviour, matching path_config_store.h.
+static const std::filesystem::path& RenutConfigPath() {
+#ifdef _WIN32
+  static const std::filesystem::path path{"renut.toml"};
+#else
+  // Also migrates a copy sitting beside the executable from before this change.
+  static const std::filesystem::path path =
+      renut::linuxfixes::ResolveWithMigration(renut::linuxfixes::ConfigDir(), "renut.toml");
+#endif
+  return path;
+}
 
 static std::string TomlQuote(const std::string& s) {
   std::string out = "\"";
@@ -347,8 +405,8 @@ static std::string TrimWs(const std::string& s) {
   return s.substr(b, e - b + 1);
 }
 
-// Not static: the controls overlay (overlays/mnk_controls_dialog.h) persists
-// rebinds through this too.
+// Declared in overlays/mnk_controls_dialog.h, which calls it from the controls
+// overlay. Deliberately not static: a second translation unit needs it.
 void RenutSaveConfig() {
   // desired[name] = formatted TOML value, for every value cvar != its default.
   // managed = every value-cvar name, so we can update or drop its existing line.
@@ -367,7 +425,7 @@ void RenutSaveConfig() {
   std::vector<std::string> out;
   bool fileExisted = false;
   {
-    std::ifstream in(kRenutConfigPath);
+    std::ifstream in(RenutConfigPath());
     if (in) {
       fileExisted = true;
       std::string line;
@@ -408,9 +466,9 @@ void RenutSaveConfig() {
   for (const auto& kv : added)
     out.push_back(kv.first + " = " + kv.second);
 
-  std::ofstream f(kRenutConfigPath, std::ios::trunc);
+  std::ofstream f(RenutConfigPath(), std::ios::trunc);
   if (!f) {
-    REXLOG_ERROR("RenutSaveConfig: failed to open {}", kRenutConfigPath);
+    REXLOG_ERROR("RenutSaveConfig: failed to open {}", RenutConfigPath().string());
     return;
   }
   for (const auto& l : out)

--- a/src/renut_engine/fixes/mullhwucrash.cpp
+++ b/src/renut_engine/fixes/mullhwucrash.cpp
@@ -249,7 +249,7 @@ loc_82277D1C:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v8,8,3
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v8.f32), 57), 8));
@@ -302,7 +302,7 @@ loc_82277DB8:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v8,4,2
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v8.f32), 78), 4));
@@ -355,7 +355,7 @@ loc_82277E0C:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v9,2,1
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v9.f32), 147), 2));
@@ -499,7 +499,7 @@ loc_82277E5C:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v8,8,3
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v8.f32), 57), 8));
@@ -552,7 +552,7 @@ loc_82277F5C:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v8,4,2
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v8.f32), 78), 4));
@@ -605,7 +605,7 @@ loc_82277FB0:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v9,2,1
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v9.f32), 147), 2));
@@ -712,7 +712,7 @@ loc_82278024:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v8,8,3
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v8.f32), 57), 8));
@@ -765,7 +765,7 @@ loc_822780B4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v8,4,2
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v8.f32), 78), 4));
@@ -818,7 +818,7 @@ loc_82278108:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v9,2,1
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v9.f32), 147), 2));
@@ -1033,7 +1033,7 @@ loc_82278238:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v8,8,3
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v8.f32), 57), 8));
@@ -1086,7 +1086,7 @@ loc_822782C8:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v8,4,2
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v8.f32), 78), 4));
@@ -1139,7 +1139,7 @@ loc_8227831C:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v9,2,1
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v9.f32), 147), 2));
@@ -1640,7 +1640,7 @@ loc_829A1E74:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v8,8,3
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v8.f32), 57), 8));
@@ -1693,7 +1693,7 @@ loc_829A1F0C:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v8,4,2
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v8.f32), 78), 4));
@@ -1746,7 +1746,7 @@ loc_829A1F60:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v9,2,1
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v9.f32), 147), 2));
@@ -1888,7 +1888,7 @@ loc_829A1FB0:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v8,8,3
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v8.f32), 57), 8));
@@ -1941,7 +1941,7 @@ loc_829A20AC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v8,4,2
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v8.f32), 78), 4));
@@ -1994,7 +1994,7 @@ loc_829A2100:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v9,2,1
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v9.f32), 147), 2));
@@ -2099,7 +2099,7 @@ loc_829A2174:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v8,8,3
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v8.f32), 57), 8));
@@ -2152,7 +2152,7 @@ loc_829A2200:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v8,4,2
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v8.f32), 78), 4));
@@ -2205,7 +2205,7 @@ loc_829A2254:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v9,2,1
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v9.f32), 147), 2));
@@ -2418,7 +2418,7 @@ loc_829A2384:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v8,8,3
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v8.f32), 57), 8));
@@ -2471,7 +2471,7 @@ loc_829A2410:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v8,4,2
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v8.f32), 78), 4));
@@ -2524,7 +2524,7 @@ loc_829A2464:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v9,2,1
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v9.f32), 147), 2));
@@ -3113,7 +3113,7 @@ loc_829A2B0C:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v7,v8,v31
 	{
@@ -3122,7 +3122,7 @@ loc_829A2B0C:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 loc_829A2C10:
 	// vor v28,v29,v29
@@ -3230,7 +3230,7 @@ loc_829A2C30:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v8,v28
 	{
@@ -3239,7 +3239,7 @@ loc_829A2C30:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 loc_829A2CAC:
 	// lwz r11,24(r31)
@@ -3341,7 +3341,7 @@ loc_829A2CC4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v8,v8,v3
 	{
@@ -3350,7 +3350,7 @@ loc_829A2CC4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 loc_829A2D3C:
 	// lwz r11,24(r31)
@@ -3675,7 +3675,7 @@ loc_829A2D50:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v31,v8,v30
 	{
@@ -3684,7 +3684,7 @@ loc_829A2D50:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v8,v29
 	{
@@ -3693,7 +3693,7 @@ loc_829A2D50:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v29,v8,v20
 	{
@@ -3702,7 +3702,7 @@ loc_829A2D50:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 loc_829A2F78:
 	// addi r11,r11,2
@@ -3826,7 +3826,7 @@ loc_829A2F94:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v31,v8,v30
 	{
@@ -3835,7 +3835,7 @@ loc_829A2F94:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v8,v29
 	{
@@ -3844,7 +3844,7 @@ loc_829A2F94:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v29,v8,v20
 	{
@@ -3853,7 +3853,7 @@ loc_829A2F94:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 loc_829A303C:
 	// lwz r11,24(r31)
@@ -3977,7 +3977,7 @@ loc_829A305C:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v31,v8,v31
 	{
@@ -3986,7 +3986,7 @@ loc_829A305C:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v8,v30
 	{
@@ -3995,7 +3995,7 @@ loc_829A305C:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v8,v8,v29
 	{
@@ -4004,7 +4004,7 @@ loc_829A305C:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 loc_829A3100:
 	// lwz r11,24(r31)
@@ -4258,7 +4258,7 @@ loc_829A3180:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v31,v8,v30
 	{
@@ -4267,7 +4267,7 @@ loc_829A3180:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v8,v29
 	{
@@ -4276,7 +4276,7 @@ loc_829A3180:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v29,v8,v19
 	{
@@ -4285,7 +4285,7 @@ loc_829A3180:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 loc_829A32AC:
 	// addi r11,r11,2
@@ -4413,7 +4413,7 @@ loc_829A32C8:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v31,v8,v30
 	{
@@ -4422,7 +4422,7 @@ loc_829A32C8:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v8,v29
 	{
@@ -4431,7 +4431,7 @@ loc_829A32C8:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v29,v8,v19
 	{
@@ -4440,7 +4440,7 @@ loc_829A32C8:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 loc_829A3378:
 	// lwz r11,24(r31)
@@ -4564,7 +4564,7 @@ loc_829A3398:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v31,v8,v31
 	{
@@ -4573,7 +4573,7 @@ loc_829A3398:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v8,v30
 	{
@@ -4582,7 +4582,7 @@ loc_829A3398:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v8,v8,v29
 	{
@@ -4591,7 +4591,7 @@ loc_829A3398:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 loc_829A343C:
 	// lwz r11,24(r31)
@@ -4929,7 +4929,7 @@ loc_829A354C:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v31,v8,v30
 	{
@@ -4938,7 +4938,7 @@ loc_829A354C:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v8,v29
 	{
@@ -4947,7 +4947,7 @@ loc_829A354C:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v29,v8,v20
 	{
@@ -4956,7 +4956,7 @@ loc_829A354C:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 loc_829A3678:
 	// addi r11,r11,2
@@ -5084,7 +5084,7 @@ loc_829A3694:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v31,v8,v30
 	{
@@ -5093,7 +5093,7 @@ loc_829A3694:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v8,v29
 	{
@@ -5102,7 +5102,7 @@ loc_829A3694:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v29,v8,v20
 	{
@@ -5111,7 +5111,7 @@ loc_829A3694:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 loc_829A3744:
 	// lwz r11,24(r31)
@@ -5235,7 +5235,7 @@ loc_829A3764:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v31,v8,v31
 	{
@@ -5244,7 +5244,7 @@ loc_829A3764:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v8,v30
 	{
@@ -5253,7 +5253,7 @@ loc_829A3764:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v8,v8,v29
 	{
@@ -5262,7 +5262,7 @@ loc_829A3764:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 loc_829A3808:
 	// lwz r11,24(r31)
@@ -5750,7 +5750,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// lvx128 v49,r5,r7
 	ea = (ctx.r5.u32 + ctx.r7.u32) & ~0xF;
@@ -5771,7 +5771,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v31,v49,v62
 	{
@@ -5820,7 +5820,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vcsxwfp128 v25,v44,0
 	simde_mm_store_ps(ctx.v25.f32, simde_mm_cvtepi32_ps(simde_mm_load_si128((simde__m128i*)ctx.v44.u32)));
@@ -5831,7 +5831,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// li r5,112
 	ctx.r5.s64 = 112;
@@ -5975,7 +5975,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vmaddfp v17,v5,v25,v19
 	simde_mm_store_ps(ctx.v17.f32, simde_mm_add_ps(simde_mm_mul_ps(simde_mm_load_ps(ctx.v5.f32), simde_mm_load_ps(ctx.v25.f32)), simde_mm_load_ps(ctx.v19.f32)));
@@ -5988,7 +5988,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vor v1,v14,v14
 	simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_load_si128((simde__m128i*)ctx.v14.u8));
@@ -6001,7 +6001,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vmaddfp v14,v5,v24,v18
 	simde_mm_store_ps(ctx.v14.f32, simde_mm_add_ps(simde_mm_mul_ps(simde_mm_load_ps(ctx.v5.f32), simde_mm_load_ps(ctx.v24.f32)), simde_mm_load_ps(ctx.v18.f32)));
@@ -6025,7 +6025,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v13,v2,v1
 	temp.s64 = int64_t(ctx.v2.s32[0]) - int64_t(ctx.v1.s32[0]);
@@ -6043,7 +6043,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v29,v3,v26
 	temp.s64 = int64_t(ctx.v3.s32[0]) - int64_t(ctx.v26.s32[0]);
@@ -6084,7 +6084,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vctsxs v24,v24,0
 	simde_mm_store_si128((simde__m128i*)ctx.v24.s32, rex::ppc::simde_mm_vctsxs(simde_mm_load_ps(ctx.v24.f32)));
@@ -6106,7 +6106,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vor v29,v23,v23
 	simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_load_si128((simde__m128i*)ctx.v23.u8));
@@ -6131,7 +6131,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v25,v31,v25
 	temp.s64 = int64_t(ctx.v31.s32[0]) - int64_t(ctx.v25.s32[0]);
@@ -6149,7 +6149,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v21,v21,v2
 	temp.s64 = int64_t(ctx.v21.s32[0]) - int64_t(ctx.v2.s32[0]);
@@ -6170,7 +6170,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v16,v15,v16
 	{
@@ -6179,7 +6179,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v20,v20,v1
 	temp.s64 = int64_t(ctx.v20.s32[0]) - int64_t(ctx.v1.s32[0]);
@@ -6216,7 +6216,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v31,v31,v15
 	{
@@ -6225,7 +6225,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// li r6,-16
 	ctx.r6.s64 = -16;
@@ -6259,7 +6259,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vor v2,v17,v17
 	simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_load_si128((simde__m128i*)ctx.v17.u8));
@@ -6277,7 +6277,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vor128 v63,v0,v0
 	simde_mm_store_si128((simde__m128i*)ctx.v63.u8, simde_mm_load_si128((simde__m128i*)ctx.v0.u8));
@@ -6288,7 +6288,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vor v13,v16,v16
 	simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_load_si128((simde__m128i*)ctx.v16.u8));
@@ -6306,7 +6306,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v16,v19,v15
 	{
@@ -6315,7 +6315,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v3,v3,v13
 	{
@@ -6324,7 +6324,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v15,v13,v60
 	{
@@ -6347,7 +6347,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v2,v16,v0
 	{
@@ -6356,7 +6356,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v31,v3,v15
 	{
@@ -6365,7 +6365,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// lvx128 v3,r0,r7
 	ea = (ctx.r7.u32) & ~0xF;
@@ -6377,7 +6377,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v13,v0
 	{
@@ -6386,7 +6386,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vor v13,v14,v14
 	simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_load_si128((simde__m128i*)ctx.v14.u8));
@@ -6397,7 +6397,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v1,v17,v0
 	{
@@ -6406,7 +6406,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsraw128 v31,v30,v43
 	ctx.v31.s32[0] = ctx.v30.s32[0] >> (ctx.v43.u8[0] & 0x1F);
@@ -6435,7 +6435,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v18,v13,v2
 	{
@@ -6444,7 +6444,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v19,v23,v29
 	{
@@ -6453,7 +6453,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v0,v25,v28
 	{
@@ -6462,7 +6462,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vor128 v62,v4,v4
 	simde_mm_store_si128((simde__m128i*)ctx.v62.u8, simde_mm_load_si128((simde__m128i*)ctx.v4.u8));
@@ -6488,7 +6488,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsraw128 v58,v0,v43
 	ctx.v58.s32[0] = ctx.v0.s32[0] >> (ctx.v43.u8[0] & 0x1F);
@@ -6502,7 +6502,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v14,v3,v1
 	{
@@ -6511,7 +6511,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vmrghw128 v52,v61,v57
 	simde_mm_store_si128((simde__m128i*)ctx.v52.u32, simde_mm_unpackhi_epi32(simde_mm_load_si128((simde__m128i*)ctx.v57.u32), simde_mm_load_si128((simde__m128i*)ctx.v61.u32)));
@@ -6522,7 +6522,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vmrglw128 v50,v61,v57
 	simde_mm_store_si128((simde__m128i*)ctx.v50.u32, simde_mm_unpacklo_epi32(simde_mm_load_si128((simde__m128i*)ctx.v57.u32), simde_mm_load_si128((simde__m128i*)ctx.v61.u32)));
@@ -6720,7 +6720,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vmrghw128 v44,v59,v57
 	simde_mm_store_si128((simde__m128i*)ctx.v44.u32, simde_mm_unpackhi_epi32(simde_mm_load_si128((simde__m128i*)ctx.v57.u32), simde_mm_load_si128((simde__m128i*)ctx.v59.u32)));
@@ -6796,7 +6796,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v27,v27,v25
 	temp.s64 = int64_t(ctx.v27.s32[0]) - int64_t(ctx.v25.s32[0]);
@@ -6816,7 +6816,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddfp v18,v1,v29
 	simde_mm_store_ps(ctx.v18.f32, simde_mm_add_ps(simde_mm_load_ps(ctx.v1.f32), simde_mm_load_ps(ctx.v29.f32)));
@@ -6840,7 +6840,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddfp v4,v19,v21
 	simde_mm_store_ps(ctx.v4.f32, simde_mm_add_ps(simde_mm_load_ps(ctx.v19.f32), simde_mm_load_ps(ctx.v21.f32)));
@@ -6973,7 +6973,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v2,v13,v7
 	{
@@ -6982,7 +6982,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vor v11,v26,v26
 	simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_load_si128((simde__m128i*)ctx.v26.u8));
@@ -7012,7 +7012,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v21,v27,v13
 	{
@@ -7021,7 +7021,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v24,v10,v4
 	temp.s64 = int64_t(ctx.v10.s32[0]) - int64_t(ctx.v4.s32[0]);
@@ -7048,7 +7048,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v4,v10,v4
 	{
@@ -7057,7 +7057,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vor v9,v24,v24
 	simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_load_si128((simde__m128i*)ctx.v24.u8));
@@ -7084,7 +7084,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v20,v12,v10
 	{
@@ -7093,7 +7093,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v30,v12,v10
 	temp.s64 = int64_t(ctx.v12.s32[0]) - int64_t(ctx.v10.s32[0]);
@@ -7173,7 +7173,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v7,v16,v17
 	{
@@ -7182,7 +7182,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v29,v10,v38
 	{
@@ -7198,7 +7198,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v28,v10,v39
 	{
@@ -7214,7 +7214,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v26,v9,v60
 	{
@@ -7230,7 +7230,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v25,v7,v60
 	{
@@ -7246,7 +7246,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vor v13,v27,v27
 	simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_load_si128((simde__m128i*)ctx.v27.u8));
@@ -7257,7 +7257,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v23,v9,v25
 	{
@@ -7266,7 +7266,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v9,v10,v12
 	{
@@ -7275,7 +7275,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v29,v11,v13
 	{
@@ -7284,7 +7284,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v22,v13,v60
 	{
@@ -7317,7 +7317,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v17,v9,v19
 	{
@@ -7326,7 +7326,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v16,v24,v0
 	{
@@ -7335,7 +7335,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v15,v23,v0
 	{
@@ -7344,7 +7344,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v14,v18,v0
 	{
@@ -7353,7 +7353,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v5,v17,v0
 	{
@@ -7362,7 +7362,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v12,v6,v13
 	{
@@ -7371,7 +7371,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v10,v8,v11
 	{
@@ -7380,7 +7380,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v10.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v10.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v13,v6,v13
 	temp.s64 = int64_t(ctx.v6.s32[0]) - int64_t(ctx.v13.s32[0]);
@@ -7431,7 +7431,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v28,v12,v2
 	{
@@ -7440,7 +7440,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v27,v9,v7
 	{
@@ -7449,7 +7449,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v26,v0,v8
 	{
@@ -7458,7 +7458,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v25,v31,v6
 	{
@@ -7467,7 +7467,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v24,v30,v5
 	{
@@ -7476,7 +7476,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsraw128 v46,v29,v40
 	ctx.v46.s32[0] = ctx.v29.s32[0] >> (ctx.v40.u8[0] & 0x1F);
@@ -7517,7 +7517,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v22,v13,v1
 	{
@@ -7526,7 +7526,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vpkswus128 v38,v43,v44
 	simde_mm_store_si128((simde__m128i*)ctx.v38.u16, simde_mm_packus_epi32(simde_mm_load_si128((simde__m128i*)ctx.v44.s32), simde_mm_load_si128((simde__m128i*)ctx.v43.s32)));
@@ -7951,7 +7951,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vmulfp128 v49,v9,v57
 	simde_mm_store_ps(ctx.v49.f32, simde_mm_mul_ps(simde_mm_load_ps(ctx.v9.f32), simde_mm_load_ps(ctx.v57.f32)));
@@ -8000,7 +8000,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v3,v12,v3
 	{
@@ -8009,7 +8009,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vor v11,v30,v30
 	simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_load_si128((simde__m128i*)ctx.v30.u8));
@@ -8031,7 +8031,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v12,v11,v4
 	{
@@ -8040,7 +8040,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v11,v11,v4
 	temp.s64 = int64_t(ctx.v11.s32[0]) - int64_t(ctx.v4.s32[0]);
@@ -8058,7 +8058,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v0,v0,v1
 	temp.s64 = int64_t(ctx.v0.s32[0]) - int64_t(ctx.v1.s32[0]);
@@ -8104,7 +8104,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v26,v27
 	{
@@ -8113,7 +8113,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v22,v0,v3
 	temp.s64 = int64_t(ctx.v0.s32[0]) - int64_t(ctx.v3.s32[0]);
@@ -8134,7 +8134,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v20,v4,v31
 	{
@@ -8143,7 +8143,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v3,v12,v30
 	{
@@ -8152,7 +8152,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v19,v30,v55
 	{
@@ -8177,7 +8177,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v11,v12
 	{
@@ -8186,7 +8186,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// lvx128 v11,r7,r31
 	ea = (ctx.r7.u32 + ctx.r31.u32) & ~0xF;
@@ -8219,7 +8219,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v14,v30,v18
 	{
@@ -8228,7 +8228,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// li r4,16
 	ctx.r4.s64 = 16;
@@ -8254,7 +8254,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v3,v2,v12
 	{
@@ -8263,7 +8263,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v2,v2,v12
 	temp.s64 = int64_t(ctx.v2.s32[0]) - int64_t(ctx.v12.s32[0]);
@@ -8296,7 +8296,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v30,v1,v12
 	temp.s64 = int64_t(ctx.v1.s32[0]) - int64_t(ctx.v12.s32[0]);
@@ -8382,7 +8382,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v11,v28,v11
 	{
@@ -8391,7 +8391,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vmaddfp v27,v9,v4,v0
 	simde_mm_store_ps(ctx.v27.f32, simde_mm_add_ps(simde_mm_mul_ps(simde_mm_load_ps(ctx.v9.f32), simde_mm_load_ps(ctx.v4.f32)), simde_mm_load_ps(ctx.v0.f32)));
@@ -8506,7 +8506,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v3,v10,v9
 	{
@@ -8515,7 +8515,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v8,v7,v6
 	temp.s64 = int64_t(ctx.v7.s32[0]) - int64_t(ctx.v6.s32[0]);
@@ -8544,7 +8544,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vor v6,v14,v14
 	simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_load_si128((simde__m128i*)ctx.v14.u8));
@@ -8564,7 +8564,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// li r6,112
 	ctx.r6.s64 = 112;
@@ -8582,7 +8582,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// li r31,144
 	ctx.r31.s64 = 144;
@@ -8604,7 +8604,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// li r29,176
 	ctx.r29.s64 = 176;
@@ -8626,7 +8626,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// li r27,208
 	ctx.r27.s64 = 208;
@@ -8719,7 +8719,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v6,v23,v24
 	{
@@ -8728,7 +8728,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v5,v21,v22
 	{
@@ -8737,7 +8737,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v16,v19,v20
 	{
@@ -8746,7 +8746,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v15,v17,v18
 	{
@@ -8755,7 +8755,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v4,v0,v6
 	{
@@ -8764,7 +8764,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v1,v10,v5
 	{
@@ -8773,7 +8773,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v14,v6,v55
 	{
@@ -8800,7 +8800,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v1,v1,v0
 	{
@@ -8809,7 +8809,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v9,v6
 	{
@@ -8818,7 +8818,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v29,v8,v5
 	{
@@ -8827,7 +8827,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v24,v6,v55
 	{
@@ -8860,7 +8860,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v21,v29,v23
 	{
@@ -8869,7 +8869,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v20,v4,v13
 	{
@@ -8878,7 +8878,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v19,v1,v13
 	{
@@ -8887,7 +8887,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v18,v22,v13
 	{
@@ -8896,7 +8896,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v17,v21,v13
 	{
@@ -8905,7 +8905,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v9,v11,v10
 	{
@@ -8914,7 +8914,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v8,v12,v0
 	temp.s64 = int64_t(ctx.v12.s32[0]) - int64_t(ctx.v0.s32[0]);
@@ -8932,7 +8932,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v10,v11,v10
 	temp.s64 = int64_t(ctx.v11.s32[0]) - int64_t(ctx.v10.s32[0]);
@@ -8978,7 +8978,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v15,v9,v7
 	{
@@ -8987,7 +8987,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v14,v0,v12
 	{
@@ -8996,7 +8996,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v29,v11,v13
 	{
@@ -9005,7 +9005,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v28,v6,v1
 	{
@@ -9014,7 +9014,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v27,v5,v30
 	{
@@ -9023,7 +9023,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v26,v8,v2
 	{
@@ -9032,7 +9032,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v25,v10,v31
 	{
@@ -9041,7 +9041,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v24,v8,v2
 	temp.s64 = int64_t(ctx.v8.s32[0]) - int64_t(ctx.v2.s32[0]);
@@ -9376,7 +9376,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vcsxwfp128 v31,v48,0
 	simde_mm_store_ps(ctx.v31.f32, simde_mm_cvtepi32_ps(simde_mm_load_si128((simde__m128i*)ctx.v48.u32)));
@@ -9399,7 +9399,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// li r9,208
 	ctx.r9.s64 = 208;
@@ -9449,7 +9449,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vmulfp128 v29,v12,v47
 	simde_mm_store_ps(ctx.v29.f32, simde_mm_mul_ps(simde_mm_load_ps(ctx.v12.f32), simde_mm_load_ps(ctx.v47.f32)));
@@ -9460,7 +9460,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vcsxwfp128 v25,v41,0
 	simde_mm_store_ps(ctx.v25.f32, simde_mm_cvtepi32_ps(simde_mm_load_si128((simde__m128i*)ctx.v41.u32)));
@@ -9606,7 +9606,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v28,v28,v1
 	{
@@ -9615,7 +9615,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vor v3,v14,v14
 	simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_load_si128((simde__m128i*)ctx.v14.u8));
@@ -9643,7 +9643,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vctsxs v19,v16,0
 	simde_mm_store_si128((simde__m128i*)ctx.v19.s32, rex::ppc::simde_mm_vctsxs(simde_mm_load_ps(ctx.v16.f32)));
@@ -9665,7 +9665,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v17,v3,v1
 	temp.s64 = int64_t(ctx.v3.s32[0]) - int64_t(ctx.v1.s32[0]);
@@ -9683,7 +9683,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v1,v2,v30
 	{
@@ -9692,7 +9692,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v3,v2,v30
 	temp.s64 = int64_t(ctx.v2.s32[0]) - int64_t(ctx.v30.s32[0]);
@@ -9714,7 +9714,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v21,v21,v24
 	temp.s64 = int64_t(ctx.v21.s32[0]) - int64_t(ctx.v24.s32[0]);
@@ -9767,7 +9767,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v16,v1,v40
 	{
@@ -9790,7 +9790,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// stvx128 v18,r0,r4
 	ea = (ctx.r4.u32) & ~0xF;
@@ -9802,7 +9802,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v20,v20,v23
 	temp.s64 = int64_t(ctx.v20.s32[0]) - int64_t(ctx.v23.s32[0]);
@@ -9820,7 +9820,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// lvx128 v16,r0,r4
 	ea = (ctx.r4.u32) & ~0xF;
@@ -9839,7 +9839,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// stvx128 v30,r0,r24
 	ea = (ctx.r24.u32) & ~0xF;
@@ -9860,7 +9860,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v24,v1,v23
 	{
@@ -9869,7 +9869,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v26,v22
 	{
@@ -9878,7 +9878,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vor v1,v15,v15
 	simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_load_si128((simde__m128i*)ctx.v15.u8));
@@ -9898,7 +9898,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v16,v2,v61
 	{
@@ -9914,7 +9914,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v15,v1,v61
 	{
@@ -9930,7 +9930,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v24,v18,v14
 	{
@@ -9939,7 +9939,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v1,v13,v16
 	{
@@ -9948,7 +9948,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v23,v2,v15
 	{
@@ -9957,7 +9957,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v18,v3,v0
 	{
@@ -9966,7 +9966,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v15,v24,v0
 	{
@@ -9975,7 +9975,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v16,v1,v0
 	{
@@ -9984,7 +9984,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v14,v23,v0
 	{
@@ -9993,7 +9993,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v3,v26,v22
 	temp.s64 = int64_t(ctx.v26.s32[0]) - int64_t(ctx.v22.s32[0]);
@@ -10023,7 +10023,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v2,v31,v19
 	temp.s64 = int64_t(ctx.v31.s32[0]) - int64_t(ctx.v19.s32[0]);
@@ -10054,7 +10054,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v14,v1,v26
 	temp.s64 = int64_t(ctx.v1.s32[0]) - int64_t(ctx.v26.s32[0]);
@@ -10081,7 +10081,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// lvx128 v3,r11,r4
 	ea = (ctx.r11.u32 + ctx.r4.u32) & ~0xF;
@@ -10093,7 +10093,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v28,v30,v25
 	{
@@ -10102,7 +10102,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v23,v21,v23
 	temp.s64 = int64_t(ctx.v21.s32[0]) - int64_t(ctx.v23.s32[0]);
@@ -10120,7 +10120,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v16,v31,v24
 	{
@@ -10129,7 +10129,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v15,v2,v29
 	{
@@ -10138,7 +10138,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v30,v30,v25
 	temp.s64 = int64_t(ctx.v30.s32[0]) - int64_t(ctx.v25.s32[0]);
@@ -10156,7 +10156,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsraw128 v33,v28,v60
 	ctx.v33.s32[0] = ctx.v28.s32[0] >> (ctx.v60.u8[0] & 0x1F);
@@ -10388,7 +10388,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vcsxwfp128 v23,v36,0
 	simde_mm_store_ps(ctx.v23.f32, simde_mm_cvtepi32_ps(simde_mm_load_si128((simde__m128i*)ctx.v36.u32)));
@@ -10408,7 +10408,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vmaddfp v18,v12,v18,v13
 	simde_mm_store_ps(ctx.v18.f32, simde_mm_add_ps(simde_mm_mul_ps(simde_mm_load_ps(ctx.v12.f32), simde_mm_load_ps(ctx.v18.f32)), simde_mm_load_ps(ctx.v13.f32)));
@@ -10437,7 +10437,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v27,v3,v22
 	{
@@ -10446,7 +10446,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v3,v3,v22
 	temp.s64 = int64_t(ctx.v3.s32[0]) - int64_t(ctx.v22.s32[0]);
@@ -10624,7 +10624,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v31,v11,v5
 	{
@@ -10633,7 +10633,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vor v7,v20,v20
 	simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_load_si128((simde__m128i*)ctx.v20.u8));
@@ -10646,7 +10646,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v4,v10,v4
 	{
@@ -10655,7 +10655,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vor v9,v17,v17
 	simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_load_si128((simde__m128i*)ctx.v17.u8));
@@ -10678,7 +10678,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v15,v10,v9
 	{
@@ -10687,7 +10687,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v14,v12,v13
 	{
@@ -10696,7 +10696,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v30,v12,v13
 	temp.s64 = int64_t(ctx.v12.s32[0]) - int64_t(ctx.v13.s32[0]);
@@ -10714,7 +10714,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vor v13,v16,v16
 	simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_load_si128((simde__m128i*)ctx.v16.u8));
@@ -10810,7 +10810,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v9,v23,v24
 	{
@@ -10819,7 +10819,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v18,v21,v22
 	{
@@ -10828,7 +10828,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v17,v19,v20
 	{
@@ -10837,7 +10837,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v5,v13,v7
 	{
@@ -10846,7 +10846,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v16,v7,v61
 	{
@@ -10862,7 +10862,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vor v7,v18,v18
 	simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_load_si128((simde__m128i*)ctx.v18.u8));
@@ -10887,7 +10887,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v28,v10,v12
 	{
@@ -10896,7 +10896,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsraw128 v11,v44,v61
 	ctx.v11.s32[0] = ctx.v44.s32[0] >> (ctx.v61.u8[0] & 0x1F);
@@ -10924,7 +10924,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v12,v6,v13
 	{
@@ -10933,7 +10933,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v10,v8,v11
 	{
@@ -10942,7 +10942,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v10.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v10.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v22,v29,v15
 	{
@@ -10951,7 +10951,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v24,v9,v26
 	{
@@ -10960,7 +10960,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v21,v28,v25
 	{
@@ -10969,7 +10969,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v23,v5,v0
 	{
@@ -10978,7 +10978,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v19,v22,v0
 	{
@@ -10987,7 +10987,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v20,v24,v0
 	{
@@ -10996,7 +10996,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v18,v21,v0
 	{
@@ -11005,7 +11005,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v17,v12,v1
 	{
@@ -11014,7 +11014,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v16,v10,v4
 	{
@@ -11023,7 +11023,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v0,v8,v11
 	temp.s64 = int64_t(ctx.v8.s32[0]) - int64_t(ctx.v11.s32[0]);
@@ -11084,7 +11084,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v14,v11,v8
 	{
@@ -11093,7 +11093,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v29,v30,v6
 	{
@@ -11102,7 +11102,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// stvx128 v42,r0,r25
 	ea = (ctx.r25.u32) & ~0xF;
@@ -11114,7 +11114,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// stvx128 v41,r25,r10
 	ea = (ctx.r25.u32 + ctx.r10.u32) & ~0xF;
@@ -11126,7 +11126,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v26,v0,v2
 	{
@@ -11135,7 +11135,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v25,v13,v31
 	temp.s64 = int64_t(ctx.v13.s32[0]) - int64_t(ctx.v31.s32[0]);
@@ -11433,7 +11433,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vmulfp128 v46,v10,v54
 	simde_mm_store_ps(ctx.v46.f32, simde_mm_mul_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_load_ps(ctx.v54.f32)));
@@ -11484,7 +11484,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v12,v3
 	{
@@ -11493,7 +11493,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vor v11,v29,v29
 	simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_load_si128((simde__m128i*)ctx.v29.u8));
@@ -11506,7 +11506,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v29,v0,v1
 	temp.s64 = int64_t(ctx.v0.s32[0]) - int64_t(ctx.v1.s32[0]);
@@ -11524,7 +11524,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v11,v11,v4
 	temp.s64 = int64_t(ctx.v11.s32[0]) - int64_t(ctx.v4.s32[0]);
@@ -11542,7 +11542,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v22,v3,v31
 	temp.s64 = int64_t(ctx.v3.s32[0]) - int64_t(ctx.v31.s32[0]);
@@ -11588,7 +11588,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v1,v26,v27
 	{
@@ -11597,7 +11597,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v2,v0,v2
 	temp.s64 = int64_t(ctx.v0.s32[0]) - int64_t(ctx.v2.s32[0]);
@@ -11618,7 +11618,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v28,v12,v1
 	{
@@ -11627,7 +11627,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v20,v1,v51
 	{
@@ -11645,7 +11645,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v3,v11,v12
 	{
@@ -11654,7 +11654,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// lvx128 v11,r7,r4
 	ea = (ctx.r7.u32 + ctx.r4.u32) & ~0xF;
@@ -11673,7 +11673,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v16,v3,v18
 	{
@@ -11682,7 +11682,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsraw128 v12,v17,v49
 	ctx.v12.s32[0] = ctx.v17.s32[0] >> (ctx.v49.u8[0] & 0x1F);
@@ -11698,7 +11698,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v15,v29,v30
 	temp.s64 = int64_t(ctx.v29.s32[0]) - int64_t(ctx.v30.s32[0]);
@@ -11716,7 +11716,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v1,v4,v12
 	{
@@ -11725,7 +11725,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v31,v4,v12
 	temp.s64 = int64_t(ctx.v4.s32[0]) - int64_t(ctx.v12.s32[0]);
@@ -11772,7 +11772,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsraw128 v35,v1,v49
 	ctx.v35.s32[0] = ctx.v1.s32[0] >> (ctx.v49.u8[0] & 0x1F);
@@ -11864,7 +11864,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v11,v27,v11
 	{
@@ -11873,7 +11873,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vmaddfp v26,v9,v1,v0
 	simde_mm_store_ps(ctx.v26.f32, simde_mm_add_ps(simde_mm_mul_ps(simde_mm_load_ps(ctx.v9.f32), simde_mm_load_ps(ctx.v1.f32)), simde_mm_load_ps(ctx.v0.f32)));
@@ -11969,7 +11969,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsraw128 v5,v37,v51
 	ctx.v5.s32[0] = ctx.v37.s32[0] >> (ctx.v51.u8[0] & 0x1F);
@@ -12008,7 +12008,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// li r7,80
 	ctx.r7.s64 = 80;
@@ -12030,7 +12030,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vor v7,v2,v2
 	simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_load_si128((simde__m128i*)ctx.v2.u8));
@@ -12043,7 +12043,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsraw128 v0,v36,v51
 	ctx.v0.s32[0] = ctx.v36.s32[0] >> (ctx.v51.u8[0] & 0x1F);
@@ -12057,7 +12057,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsraw128 v10,v34,v51
 	ctx.v10.s32[0] = ctx.v34.s32[0] >> (ctx.v51.u8[0] & 0x1F);
@@ -12071,7 +12071,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v23,v12,v0
 	{
@@ -12080,7 +12080,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v22,v12,v0
 	temp.s64 = int64_t(ctx.v12.s32[0]) - int64_t(ctx.v0.s32[0]);
@@ -12098,7 +12098,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v24,v11,v10
 	temp.s64 = int64_t(ctx.v11.s32[0]) - int64_t(ctx.v10.s32[0]);
@@ -12194,7 +12194,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v2,v18,v19
 	{
@@ -12203,7 +12203,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v1,v16,v17
 	{
@@ -12212,7 +12212,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v31,v14,v15
 	{
@@ -12221,7 +12221,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsraw128 v6,v32,v51
 	ctx.v6.s32[0] = ctx.v32.s32[0] >> (ctx.v51.u8[0] & 0x1F);
@@ -12240,7 +12240,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v27,v10,v2
 	{
@@ -12249,7 +12249,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vor v0,v1,v1
 	simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_load_si128((simde__m128i*)ctx.v1.u8));
@@ -12262,7 +12262,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v31,v11,v6
 	{
@@ -12271,7 +12271,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v9,v9,v0
 	{
@@ -12280,7 +12280,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v21,v0,v51
 	{
@@ -12303,7 +12303,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v20,v10,v51
 	{
@@ -12326,7 +12326,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v17,v1,v4
 	{
@@ -12335,7 +12335,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v16,v9,v21
 	{
@@ -12344,7 +12344,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v0,v27,v19
 	{
@@ -12353,7 +12353,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v15,v8,v20
 	{
@@ -12362,7 +12362,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v14,v28,v25
 	{
@@ -12371,7 +12371,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsraw128 v63,v18,v48
 	ctx.v63.s32[0] = ctx.v18.s32[0] >> (ctx.v48.u8[0] & 0x1F);
@@ -12390,7 +12390,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v2,v0,v13
 	{
@@ -12399,7 +12399,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v28,v15,v13
 	{
@@ -12408,7 +12408,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v27,v14,v13
 	{
@@ -12417,7 +12417,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vpkswss128 v61,v62,v63
 	simde_mm_store_si128((simde__m128i*)ctx.v61.s16, simde_mm_packs_epi32(simde_mm_load_si128((simde__m128i*)ctx.v63.s32), simde_mm_load_si128((simde__m128i*)ctx.v62.s32)));
@@ -12477,7 +12477,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v24,v9,v6
 	{
@@ -12486,7 +12486,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v23,v8,v5
 	{
@@ -12495,7 +12495,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v25,v10,v7
 	{
@@ -12504,7 +12504,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v22,v11,v29
 	{
@@ -12513,7 +12513,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v21,v12,v30
 	{
@@ -12522,7 +12522,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v20,v11,v29
 	temp.s64 = int64_t(ctx.v11.s32[0]) - int64_t(ctx.v29.s32[0]);
@@ -12813,7 +12813,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// li r9,32
 	ctx.r9.s64 = 32;
@@ -12862,7 +12862,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// li r29,32
 	ctx.r29.s64 = 32;
@@ -12881,7 +12881,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddfp128 v39,v1,v31
 	simde_mm_store_ps(ctx.v39.f32, simde_mm_add_ps(simde_mm_load_ps(ctx.v1.f32), simde_mm_load_ps(ctx.v31.f32)));
@@ -12914,7 +12914,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vspltisw128 v34,2
 	simde_mm_store_si128((simde__m128i*)ctx.v34.u32, simde_mm_set1_epi32(int(0x2)));
@@ -13043,7 +13043,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vmaddfp v23,v4,v23,v19
 	simde_mm_store_ps(ctx.v23.f32, simde_mm_add_ps(simde_mm_mul_ps(simde_mm_load_ps(ctx.v4.f32), simde_mm_load_ps(ctx.v23.f32)), simde_mm_load_ps(ctx.v19.f32)));
@@ -13087,7 +13087,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v28,v25,v2
 	{
@@ -13096,7 +13096,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vctsxs v24,v15,0
 	simde_mm_store_si128((simde__m128i*)ctx.v24.s32, rex::ppc::simde_mm_vctsxs(simde_mm_load_ps(ctx.v15.f32)));
@@ -13111,7 +13111,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vor v1,v18,v18
 	simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_load_si128((simde__m128i*)ctx.v18.u8));
@@ -13124,7 +13124,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vor v25,v17,v17
 	simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_load_si128((simde__m128i*)ctx.v17.u8));
@@ -13144,7 +13144,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vctsxs v22,v16,0
 	simde_mm_store_si128((simde__m128i*)ctx.v22.s32, rex::ppc::simde_mm_vctsxs(simde_mm_load_ps(ctx.v16.f32)));
@@ -13215,7 +13215,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// stvx128 v18,r0,r4
 	ea = (ctx.r4.u32) & ~0xF;
@@ -13236,7 +13236,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v19,v30,v22
 	temp.s64 = int64_t(ctx.v30.s32[0]) - int64_t(ctx.v22.s32[0]);
@@ -13254,7 +13254,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// lvx128 v16,r0,r11
 	ea = (ctx.r11.u32) & ~0xF;
@@ -13269,7 +13269,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v15,v17,v14
 	{
@@ -13278,7 +13278,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v24,v31,v21
 	{
@@ -13287,7 +13287,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v16,v3,v33
 	{
@@ -13319,7 +13319,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// li r4,-16
 	ctx.r4.s64 = -16;
@@ -13330,7 +13330,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vor v2,v15,v15
 	simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_load_si128((simde__m128i*)ctx.v15.u8));
@@ -13341,7 +13341,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vor v1,v16,v16
 	simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_load_si128((simde__m128i*)ctx.v16.u8));
@@ -13359,7 +13359,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v20,v2,v59
 	{
@@ -13382,7 +13382,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v15,v1,v59
 	{
@@ -13398,7 +13398,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v13,v13,v20
 	{
@@ -13407,7 +13407,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v16,v21,v30
 	{
@@ -13416,7 +13416,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v2,v15
 	{
@@ -13425,7 +13425,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v20,v3,v0
 	{
@@ -13434,7 +13434,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v21,v13,v0
 	{
@@ -13443,7 +13443,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vor v3,v7,v7
 	simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_load_si128((simde__m128i*)ctx.v7.u8));
@@ -13454,7 +13454,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsraw128 v30,v20,v36
 	ctx.v30.s32[0] = ctx.v20.s32[0] >> (ctx.v36.u8[0] & 0x1F);
@@ -13473,7 +13473,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v22,v29,v23
 	{
@@ -13482,7 +13482,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v13,v29,v23
 	temp.s64 = int64_t(ctx.v29.s32[0]) - int64_t(ctx.v23.s32[0]);
@@ -13514,7 +13514,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// lvx128 v3,r5,r4
 	ea = (ctx.r5.u32 + ctx.r4.u32) & ~0xF;
@@ -13526,7 +13526,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v17,v31,v28
 	temp.s64 = int64_t(ctx.v31.s32[0]) - int64_t(ctx.v28.s32[0]);
@@ -13544,7 +13544,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vor v2,v4,v4
 	simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_load_si128((simde__m128i*)ctx.v4.u8));
@@ -13555,7 +13555,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsraw128 v1,v1,v36
 	ctx.v1.s32[0] = ctx.v1.s32[0] >> (ctx.v36.u8[0] & 0x1F);
@@ -13578,7 +13578,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsraw128 v56,v31,v36
 	ctx.v56.s32[0] = ctx.v31.s32[0] >> (ctx.v36.u8[0] & 0x1F);
@@ -13607,7 +13607,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v19,v18,v29
 	{
@@ -13616,7 +13616,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v25,v24,v25
 	temp.s64 = int64_t(ctx.v24.s32[0]) - int64_t(ctx.v25.s32[0]);
@@ -13636,7 +13636,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vmrghw128 v47,v56,v53
 	simde_mm_store_si128((simde__m128i*)ctx.v47.u32, simde_mm_unpackhi_epi32(simde_mm_load_si128((simde__m128i*)ctx.v53.u32), simde_mm_load_si128((simde__m128i*)ctx.v56.u32)));
@@ -13795,7 +13795,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vmrghw128 v42,v49,v47
 	simde_mm_store_si128((simde__m128i*)ctx.v42.u32, simde_mm_unpackhi_epi32(simde_mm_load_si128((simde__m128i*)ctx.v47.u32), simde_mm_load_si128((simde__m128i*)ctx.v49.u32)));
@@ -13864,7 +13864,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v27,v27,v25
 	temp.s64 = int64_t(ctx.v27.s32[0]) - int64_t(ctx.v25.s32[0]);
@@ -13889,7 +13889,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddfp v17,v1,v29
 	simde_mm_store_ps(ctx.v17.f32, simde_mm_add_ps(simde_mm_load_ps(ctx.v1.f32), simde_mm_load_ps(ctx.v29.f32)));
@@ -13917,7 +13917,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddfp v7,v28,v24
 	simde_mm_store_ps(ctx.v7.f32, simde_mm_add_ps(simde_mm_load_ps(ctx.v28.f32), simde_mm_load_ps(ctx.v24.f32)));
@@ -14044,7 +14044,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsraw128 v13,v60,v59
 	ctx.v13.s32[0] = ctx.v60.s32[0] >> (ctx.v59.u8[0] & 0x1F);
@@ -14067,7 +14067,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsraw128 v5,v55,v59
 	ctx.v5.s32[0] = ctx.v55.s32[0] >> (ctx.v59.u8[0] & 0x1F);
@@ -14111,7 +14111,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v5,v9,v5
 	{
@@ -14120,7 +14120,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vor v7,v21,v21
 	simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_load_si128((simde__m128i*)ctx.v21.u8));
@@ -14138,7 +14138,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v11,v4,v11
 	temp.s64 = int64_t(ctx.v4.s32[0]) - int64_t(ctx.v11.s32[0]);
@@ -14156,7 +14156,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v18,v12,v10
 	{
@@ -14165,7 +14165,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v4,v12,v10
 	temp.s64 = int64_t(ctx.v12.s32[0]) - int64_t(ctx.v10.s32[0]);
@@ -14183,7 +14183,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v31,v27,v13
 	temp.s64 = int64_t(ctx.v27.s32[0]) - int64_t(ctx.v13.s32[0]);
@@ -14256,7 +14256,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v28,v10,v33
 	{
@@ -14272,7 +14272,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v26,v29,v16
 	{
@@ -14281,7 +14281,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v27,v10,v34
 	{
@@ -14297,7 +14297,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v13,v9
 	{
@@ -14306,7 +14306,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v25,v9,v59
 	{
@@ -14324,7 +14324,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v24,v7,v59
 	{
@@ -14340,7 +14340,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v11,v11,v9
 	{
@@ -14349,7 +14349,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v21,v9,v59
 	{
@@ -14365,7 +14365,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v10.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v10.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v22,v12,v59
 	{
@@ -14381,7 +14381,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v16,v11,v21
 	{
@@ -14390,7 +14390,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsraw128 v12,v56,v59
 	ctx.v12.s32[0] = ctx.v56.s32[0] >> (ctx.v59.u8[0] & 0x1F);
@@ -14404,7 +14404,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsraw128 v13,v57,v59
 	ctx.v13.s32[0] = ctx.v57.s32[0] >> (ctx.v59.u8[0] & 0x1F);
@@ -14418,7 +14418,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v15,v23,v0
 	{
@@ -14427,7 +14427,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v10,v8,v12
 	{
@@ -14436,7 +14436,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v10.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v10.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v14,v20,v0
 	{
@@ -14445,7 +14445,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v29,v19,v0
 	{
@@ -14454,7 +14454,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v11,v6,v13
 	{
@@ -14463,7 +14463,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v0,v6,v13
 	temp.s64 = int64_t(ctx.v6.s32[0]) - int64_t(ctx.v13.s32[0]);
@@ -14514,7 +14514,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v27,v11,v3
 	{
@@ -14523,7 +14523,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v26,v9,v7
 	{
@@ -14532,7 +14532,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v25,v12,v8
 	{
@@ -14541,7 +14541,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v24,v31,v6
 	{
@@ -14550,7 +14550,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v23,v4,v30
 	{
@@ -14559,7 +14559,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsraw128 v53,v28,v35
 	ctx.v53.s32[0] = ctx.v28.s32[0] >> (ctx.v35.u8[0] & 0x1F);
@@ -14573,7 +14573,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v19,v0,v1
 	temp.s64 = int64_t(ctx.v0.s32[0]) - int64_t(ctx.v1.s32[0]);
@@ -14591,7 +14591,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v20,v13,v5
 	temp.s64 = int64_t(ctx.v13.s32[0]) - int64_t(ctx.v5.s32[0]);
@@ -14934,7 +14934,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// lvx128 v62,r29,r27
 	ea = (ctx.r29.u32 + ctx.r27.u32) & ~0xF;
@@ -14952,7 +14952,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v6,v0,v6
 	temp.s64 = int64_t(ctx.v0.s32[0]) - int64_t(ctx.v6.s32[0]);
@@ -15002,7 +15002,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v21,v11,v5
 	temp.s64 = int64_t(ctx.v11.s32[0]) - int64_t(ctx.v5.s32[0]);
@@ -15020,7 +15020,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vctsxs v11,v23,0
 	simde_mm_store_si128((simde__m128i*)ctx.v11.s32, rex::ppc::simde_mm_vctsxs(simde_mm_load_ps(ctx.v23.f32)));
@@ -15031,7 +15031,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// li r6,48
 	ctx.r6.s64 = 48;
@@ -15076,7 +15076,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v18,v12,v5
 	temp.s64 = int64_t(ctx.v12.s32[0]) - int64_t(ctx.v5.s32[0]);
@@ -15103,7 +15103,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsraw128 v44,v19,v50
 	ctx.v44.s32[0] = ctx.v19.s32[0] >> (ctx.v50.u8[0] & 0x1F);
@@ -15124,7 +15124,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v15,v7,v8
 	temp.s64 = int64_t(ctx.v7.s32[0]) - int64_t(ctx.v8.s32[0]);
@@ -15142,7 +15142,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v11,v6,v11
 	temp.s64 = int64_t(ctx.v6.s32[0]) - int64_t(ctx.v11.s32[0]);
@@ -15198,7 +15198,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v5,v6,v7
 	{
@@ -15207,7 +15207,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v7,v12,v8
 	{
@@ -15216,7 +15216,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v4,v8,v51
 	{
@@ -15234,7 +15234,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v11,v11,v12
 	{
@@ -15243,7 +15243,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v2,v12,v51
 	{
@@ -15259,7 +15259,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v31,v11,v2
 	{
@@ -15268,7 +15268,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsraw128 v12,v1,v50
 	ctx.v12.s32[0] = ctx.v1.s32[0] >> (ctx.v50.u8[0] & 0x1F);
@@ -15282,7 +15282,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v29,v10,v12
 	{
@@ -15291,7 +15291,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v28,v10,v12
 	temp.s64 = int64_t(ctx.v10.s32[0]) - int64_t(ctx.v12.s32[0]);
@@ -15327,7 +15327,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v26,v9,v13
 	temp.s64 = int64_t(ctx.v9.s32[0]) - int64_t(ctx.v13.s32[0]);
@@ -15385,7 +15385,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vmrglw128 v53,v33,v58
 	simde_mm_store_si128((simde__m128i*)ctx.v53.u32, simde_mm_unpacklo_epi32(simde_mm_load_si128((simde__m128i*)ctx.v58.u32), simde_mm_load_si128((simde__m128i*)ctx.v33.u32)));
@@ -15413,7 +15413,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vcsxwfp128 v50,v24,0
 	simde_mm_store_ps(ctx.v50.f32, simde_mm_cvtepi32_ps(simde_mm_load_si128((simde__m128i*)ctx.v24.u32)));
@@ -15482,7 +15482,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v2,v13,v11
 	temp.s64 = int64_t(ctx.v13.s32[0]) - int64_t(ctx.v11.s32[0]);
@@ -15500,7 +15500,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v24,v2,v0
 	{
@@ -15509,7 +15509,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v29,v9,v7
 	{
@@ -15518,7 +15518,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v28,v9,v7
 	temp.s64 = int64_t(ctx.v9.s32[0]) - int64_t(ctx.v7.s32[0]);
@@ -15536,7 +15536,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v3,v12,v10
 	temp.s64 = int64_t(ctx.v12.s32[0]) - int64_t(ctx.v10.s32[0]);
@@ -15554,7 +15554,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v26,v8,v6
 	temp.s64 = int64_t(ctx.v8.s32[0]) - int64_t(ctx.v6.s32[0]);
@@ -15572,7 +15572,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v3,v0
 	{
@@ -15581,7 +15581,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v25,v29,v0
 	{
@@ -15590,7 +15590,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v23,v27,v0
 	{
@@ -15599,7 +15599,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v22,v26,v0
 	{
@@ -15608,7 +15608,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v21,v28,v0
 	{
@@ -15617,7 +15617,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsraw128 v42,v1,v62
 	ctx.v42.s32[0] = ctx.v1.s32[0] >> (ctx.v62.u8[0] & 0x1F);
@@ -15747,7 +15747,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v10.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v10.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v9,v0,v12
 	temp.s64 = int64_t(ctx.v0.s32[0]) - int64_t(ctx.v12.s32[0]);
@@ -15787,7 +15787,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// lvx128 v62,r4,r30
 	ea = (ctx.r4.u32 + ctx.r30.u32) & ~0xF;
@@ -15882,7 +15882,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v28,v13,v9
 	temp.s64 = int64_t(ctx.v13.s32[0]) - int64_t(ctx.v9.s32[0]);
@@ -15900,7 +15900,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v26,v29,v0
 	{
@@ -15909,7 +15909,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v27,v12,v8
 	temp.s64 = int64_t(ctx.v12.s32[0]) - int64_t(ctx.v8.s32[0]);
@@ -15927,7 +15927,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v23,v12,v8
 	{
@@ -15936,7 +15936,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v22,v10,v6
 	temp.s64 = int64_t(ctx.v10.s32[0]) - int64_t(ctx.v6.s32[0]);
@@ -15954,7 +15954,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v20,v11,v7
 	temp.s64 = int64_t(ctx.v11.s32[0]) - int64_t(ctx.v7.s32[0]);
@@ -15977,7 +15977,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v18,v24,v0
 	{
@@ -15986,7 +15986,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v17,v23,v0
 	{
@@ -15995,7 +15995,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// li r7,64
 	ctx.r7.s64 = 64;
@@ -16006,7 +16006,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// lvx128 v5,r4,r3
 	ea = (ctx.r4.u32 + ctx.r3.u32) & ~0xF;
@@ -16018,7 +16018,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// li r6,16
 	ctx.r6.s64 = 16;
@@ -16029,7 +16029,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// li r3,-112
 	ctx.r3.s64 = -112;
@@ -16177,7 +16177,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddfp v26,v11,v10
 	simde_mm_store_ps(ctx.v26.f32, simde_mm_add_ps(simde_mm_load_ps(ctx.v11.f32), simde_mm_load_ps(ctx.v10.f32)));
@@ -16188,7 +16188,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddfp v24,v13,v9
 	simde_mm_store_ps(ctx.v24.f32, simde_mm_add_ps(simde_mm_load_ps(ctx.v13.f32), simde_mm_load_ps(ctx.v9.f32)));
@@ -16276,7 +16276,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// li r4,192
 	ctx.r4.s64 = 192;
@@ -16305,7 +16305,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vor v13,v16,v16
 	simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_load_si128((simde__m128i*)ctx.v16.u8));
@@ -16323,7 +16323,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v7,v7,v11
 	temp.s64 = int64_t(ctx.v7.s32[0]) - int64_t(ctx.v11.s32[0]);
@@ -16341,7 +16341,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v0,v13,v9
 	{
@@ -16350,7 +16350,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v13,v13,v9
 	temp.s64 = int64_t(ctx.v13.s32[0]) - int64_t(ctx.v9.s32[0]);
@@ -16407,7 +16407,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v9,v4,v9
 	{
@@ -16416,7 +16416,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v31,v12,v8
 	temp.s64 = int64_t(ctx.v12.s32[0]) - int64_t(ctx.v8.s32[0]);
@@ -16434,7 +16434,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v29,v11,v6
 	{
@@ -16443,7 +16443,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v12,v0,v9
 	{
@@ -16452,7 +16452,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v28,v9,v59
 	{
@@ -16484,7 +16484,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v13,v13,v0
 	{
@@ -16493,7 +16493,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v25,v0,v59
 	{
@@ -16517,7 +16517,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsraw128 v36,v31,v45
 	ctx.v36.s32[0] = ctx.v31.s32[0] >> (ctx.v45.u8[0] & 0x1F);
@@ -16531,7 +16531,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsraw128 v35,v27,v45
 	ctx.v35.s32[0] = ctx.v27.s32[0] >> (ctx.v45.u8[0] & 0x1F);
@@ -16556,7 +16556,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// stvx128 v35,r11,r3
 	ea = (ctx.r11.u32 + ctx.r3.u32) & ~0xF;
@@ -16568,7 +16568,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v20,v10,v0
 	temp.s64 = int64_t(ctx.v10.s32[0]) - int64_t(ctx.v0.s32[0]);
@@ -16601,7 +16601,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v18,v7,v0
 	temp.s64 = int64_t(ctx.v7.s32[0]) - int64_t(ctx.v0.s32[0]);
@@ -16680,7 +16680,7 @@ REX_HOOK_RAW(sub_82A929B8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// lvx128 v57,r5,r8
 	ea = (ctx.r5.u32 + ctx.r8.u32) & ~0xF;
@@ -16770,7 +16770,7 @@ REX_HOOK_RAW(sub_82A929B8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v4,v11,v8
 	temp.s64 = int64_t(ctx.v11.s32[0]) - int64_t(ctx.v8.s32[0]);
@@ -16788,7 +16788,7 @@ REX_HOOK_RAW(sub_82A929B8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v2,v9,v7
 	temp.s64 = int64_t(ctx.v9.s32[0]) - int64_t(ctx.v7.s32[0]);
@@ -16806,7 +16806,7 @@ REX_HOOK_RAW(sub_82A929B8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v31,v4,v12
 	{
@@ -16815,7 +16815,7 @@ REX_HOOK_RAW(sub_82A929B8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v3,v12
 	{
@@ -16824,7 +16824,7 @@ REX_HOOK_RAW(sub_82A929B8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v29,v2,v12
 	{
@@ -16833,7 +16833,7 @@ REX_HOOK_RAW(sub_82A929B8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsraw128 v51,v1,v60
 	ctx.v51.s32[0] = ctx.v1.s32[0] >> (ctx.v60.u8[0] & 0x1F);
@@ -16880,7 +16880,7 @@ REX_HOOK_RAW(sub_82A929B8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v27,v11,v12
 	temp.s64 = int64_t(ctx.v11.s32[0]) - int64_t(ctx.v12.s32[0]);
@@ -16924,7 +16924,7 @@ REX_HOOK_RAW(sub_82A929B8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v21,v12,v10
 	{
@@ -16933,7 +16933,7 @@ REX_HOOK_RAW(sub_82A929B8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v20,v12,v10
 	temp.s64 = int64_t(ctx.v12.s32[0]) - int64_t(ctx.v10.s32[0]);
@@ -16960,7 +16960,7 @@ REX_HOOK_RAW(sub_82A929B8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v17,v21,v0
 	{
@@ -16969,7 +16969,7 @@ REX_HOOK_RAW(sub_82A929B8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v16,v20,v0
 	{
@@ -16978,7 +16978,7 @@ REX_HOOK_RAW(sub_82A929B8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v15,v19,v0
 	{
@@ -16987,7 +16987,7 @@ REX_HOOK_RAW(sub_82A929B8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsraw128 v36,v18,v62
 	ctx.v36.s32[0] = ctx.v18.s32[0] >> (ctx.v62.u8[0] & 0x1F);
@@ -17123,7 +17123,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vmulfp128 v49,v9,v57
 	simde_mm_store_ps(ctx.v49.f32, simde_mm_mul_ps(simde_mm_load_ps(ctx.v9.f32), simde_mm_load_ps(ctx.v57.f32)));
@@ -17172,7 +17172,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v3,v12,v3
 	{
@@ -17181,7 +17181,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vor v11,v30,v30
 	simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_load_si128((simde__m128i*)ctx.v30.u8));
@@ -17203,7 +17203,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v12,v11,v4
 	{
@@ -17212,7 +17212,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v11,v11,v4
 	temp.s64 = int64_t(ctx.v11.s32[0]) - int64_t(ctx.v4.s32[0]);
@@ -17230,7 +17230,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v0,v0,v1
 	temp.s64 = int64_t(ctx.v0.s32[0]) - int64_t(ctx.v1.s32[0]);
@@ -17276,7 +17276,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v26,v27
 	{
@@ -17285,7 +17285,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v22,v0,v3
 	temp.s64 = int64_t(ctx.v0.s32[0]) - int64_t(ctx.v3.s32[0]);
@@ -17306,7 +17306,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v20,v4,v31
 	{
@@ -17315,7 +17315,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v3,v12,v30
 	{
@@ -17324,7 +17324,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v19,v30,v55
 	{
@@ -17361,7 +17361,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v17,v12,v55
 	{
@@ -17382,7 +17382,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v15,v11,v17
 	{
@@ -17391,7 +17391,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v14,v16,v13
 	{
@@ -17400,7 +17400,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vspltisw128 v42,0
 	simde_mm_store_si128((simde__m128i*)ctx.v42.u32, simde_mm_set1_epi32(int(0x0)));
@@ -17411,7 +17411,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsraw128 v41,v22,v54
 	ctx.v41.s32[0] = ctx.v22.s32[0] >> (ctx.v54.u8[0] & 0x1F);
@@ -17440,7 +17440,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v3,v2,v12
 	temp.s64 = int64_t(ctx.v2.s32[0]) - int64_t(ctx.v12.s32[0]);
@@ -17458,7 +17458,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v1,v1,v11
 	temp.s64 = int64_t(ctx.v1.s32[0]) - int64_t(ctx.v11.s32[0]);
@@ -17554,7 +17554,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v11,v27,v31
 	{
@@ -17563,7 +17563,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vmaddfp v26,v10,v4,v0
 	simde_mm_store_ps(ctx.v26.f32, simde_mm_add_ps(simde_mm_mul_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_load_ps(ctx.v4.f32)), simde_mm_load_ps(ctx.v0.f32)));
@@ -17696,7 +17696,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v1,v0,v8
 	{
@@ -17705,7 +17705,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v2,v7,v6
 	{
@@ -17714,7 +17714,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v28,v5,v4
 	{
@@ -17723,7 +17723,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vor v7,v31,v31
 	simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_load_si128((simde__m128i*)ctx.v31.u8));
@@ -17749,7 +17749,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsraw128 v10,v35,v55
 	ctx.v10.s32[0] = ctx.v35.s32[0] >> (ctx.v55.u8[0] & 0x1F);
@@ -17763,7 +17763,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v25,v12,v0
 	temp.s64 = int64_t(ctx.v12.s32[0]) - int64_t(ctx.v0.s32[0]);
@@ -17781,7 +17781,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v23,v11,v10
 	{
@@ -17790,7 +17790,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v22,v11,v10
 	temp.s64 = int64_t(ctx.v11.s32[0]) - int64_t(ctx.v10.s32[0]);
@@ -17872,7 +17872,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v4,v18,v19
 	{
@@ -17881,7 +17881,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v17,v9,v60
 	{
@@ -17904,7 +17904,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsraw128 v7,v36,v55
 	ctx.v7.s32[0] = ctx.v36.s32[0] >> (ctx.v55.u8[0] & 0x1F);
@@ -17923,7 +17923,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v21,v5,v55
 	{
@@ -17939,7 +17939,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v5,v10,v4
 	{
@@ -17948,7 +17948,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vor v10,v26,v26
 	simde_mm_store_si128((simde__m128i*)ctx.v10.u8, simde_mm_load_si128((simde__m128i*)ctx.v26.u8));
@@ -17959,7 +17959,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v11,v6
 	{
@@ -17968,7 +17968,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vor v0,v27,v27
 	simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_load_si128((simde__m128i*)ctx.v27.u8));
@@ -17979,7 +17979,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v20,v4,v55
 	{
@@ -18002,7 +18002,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v18,v31,v3
 	{
@@ -18011,7 +18011,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v9,v9,v0
 	{
@@ -18020,7 +18020,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v17,v0,v55
 	{
@@ -18036,7 +18036,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v10.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v10.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v15,v5,v20
 	{
@@ -18045,7 +18045,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v14,v29,v21
 	{
@@ -18054,7 +18054,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsraw128 v33,v19,v52
 	ctx.v33.s32[0] = ctx.v19.s32[0] >> (ctx.v52.u8[0] & 0x1F);
@@ -18073,7 +18073,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v9,v15,v13
 	{
@@ -18082,7 +18082,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v21,v10,v13
 	{
@@ -18091,7 +18091,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v8,v14,v13
 	{
@@ -18100,7 +18100,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vpkswus128 v63,v32,v33
 	simde_mm_store_si128((simde__m128i*)ctx.v63.u16, simde_mm_packus_epi32(simde_mm_load_si128((simde__m128i*)ctx.v33.s32), simde_mm_load_si128((simde__m128i*)ctx.v32.s32)));
@@ -18129,7 +18129,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsraw128 v13,v8,v54
 	ctx.v13.s32[0] = ctx.v8.s32[0] >> (ctx.v54.u8[0] & 0x1F);
@@ -18193,7 +18193,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v19,v12,v11
 	{
@@ -18202,7 +18202,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v18,v6,v4
 	{
@@ -18211,7 +18211,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v17,v7,v5
 	{
@@ -18220,7 +18220,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v16,v8,v10
 	{
@@ -18229,7 +18229,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v15,v9,v1
 	{
@@ -18238,7 +18238,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsraw128 v61,v19,v52
 	ctx.v61.s32[0] = ctx.v19.s32[0] >> (ctx.v52.u8[0] & 0x1F);
@@ -18853,7 +18853,7 @@ REX_HOOK_RAW(sub_82AC46D8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v31,v7,v11
 	temp.s64 = int64_t(ctx.v7.s32[0]) - int64_t(ctx.v11.s32[0]);
@@ -18874,7 +18874,7 @@ REX_HOOK_RAW(sub_82AC46D8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v29,v6,v9
 	{
@@ -18883,7 +18883,7 @@ REX_HOOK_RAW(sub_82AC46D8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v28,v8,v12
 	{
@@ -18892,7 +18892,7 @@ REX_HOOK_RAW(sub_82AC46D8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v27,v8,v12
 	temp.s64 = int64_t(ctx.v8.s32[0]) - int64_t(ctx.v12.s32[0]);
@@ -19404,7 +19404,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vmrghw128 v34,v37,v36
 	simde_mm_store_si128((simde__m128i*)ctx.v34.u32, simde_mm_unpackhi_epi32(simde_mm_load_si128((simde__m128i*)ctx.v36.u32), simde_mm_load_si128((simde__m128i*)ctx.v37.u32)));
@@ -19417,7 +19417,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v13,v10,v11
 	{
@@ -19426,7 +19426,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vspltisw128 v33,5
 	simde_mm_store_si128((simde__m128i*)ctx.v33.u32, simde_mm_set1_epi32(int(0x5)));
@@ -19482,7 +19482,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// rlwinm r7,r11,1,0,30
 	ctx.r7.u64 = __builtin_rotateleft64(ctx.r11.u32 | (ctx.r11.u64 << 32), 1) & 0xFFFFFFFE;
@@ -19493,7 +19493,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// rlwinm r5,r11,2,0,29
 	ctx.r5.u64 = __builtin_rotateleft64(ctx.r11.u32 | (ctx.r11.u64 << 32), 2) & 0xFFFFFFFC;
@@ -19543,7 +19543,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v27,v34,v60
 	{
@@ -19573,7 +19573,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v23,v6,v4
 	{
@@ -19582,7 +19582,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v21,v11,v60
 	{
@@ -19600,7 +19600,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v19,v29,v12
 	{
@@ -19609,7 +19609,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vor v11,v28,v28
 	simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_load_si128((simde__m128i*)ctx.v28.u8));
@@ -19620,7 +19620,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v12,v24,v25
 	{
@@ -19629,7 +19629,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v10,v26,v27
 	{
@@ -19638,7 +19638,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v10.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v10.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v17,v13,v13
 	{
@@ -19647,7 +19647,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v15,v8,v9
 	{
@@ -19656,7 +19656,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v14,v8,v52
 	{
@@ -19672,7 +19672,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v2,v6,v22
 	temp.s64 = int64_t(ctx.v6.s32[0]) - int64_t(ctx.v22.s32[0]);
@@ -19708,7 +19708,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v11,v12,v10
 	{
@@ -19717,7 +19717,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v7,v12,v10
 	temp.s64 = int64_t(ctx.v12.s32[0]) - int64_t(ctx.v10.s32[0]);
@@ -19744,7 +19744,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v26,v9,v60
 	{
@@ -19760,7 +19760,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v27,v6,v31
 	temp.s64 = int64_t(ctx.v6.s32[0]) - int64_t(ctx.v31.s32[0]);
@@ -19778,7 +19778,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v8,v12,v30
 	temp.s64 = int64_t(ctx.v12.s32[0]) - int64_t(ctx.v30.s32[0]);
@@ -19815,7 +19815,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v10,v6,v13
 	{
@@ -19824,7 +19824,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v10.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v10.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v9,v11,v8
 	{
@@ -19833,7 +19833,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v5,v29,v0
 	temp.s64 = int64_t(ctx.v29.s32[0]) - int64_t(ctx.v0.s32[0]);
@@ -19865,7 +19865,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v4,v5,v23
 	temp.s64 = int64_t(ctx.v5.s32[0]) - int64_t(ctx.v23.s32[0]);
@@ -19883,7 +19883,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v5,v5,v16
 	temp.s64 = int64_t(ctx.v5.s32[0]) - int64_t(ctx.v16.s32[0]);
@@ -19924,7 +19924,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vpkswss128 v63,v32,v32
 	simde_mm_store_si128((simde__m128i*)ctx.v63.s16, simde_mm_packs_epi32(simde_mm_load_si128((simde__m128i*)ctx.v32.s32), simde_mm_load_si128((simde__m128i*)ctx.v32.s32)));
@@ -19935,7 +19935,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v11,v4,v0
 	{
@@ -19944,7 +19944,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v8,v7,v12
 	temp.s64 = int64_t(ctx.v7.s32[0]) - int64_t(ctx.v12.s32[0]);
@@ -19962,7 +19962,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v12,v7,v12
 	{
@@ -19971,7 +19971,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v13,v3,v13
 	{
@@ -19980,7 +19980,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v21,v8,v11
 	{
@@ -19989,7 +19989,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// stvewx128 v63,r0,r10
 	ea = (ctx.r10.u32) & ~0x3;
@@ -20001,7 +20001,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsraw128 v62,v21,v53
 	ctx.v62.s32[0] = ctx.v21.s32[0] >> (ctx.v53.u8[0] & 0x1F);
@@ -20025,7 +20025,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v18,v6,v13
 	temp.s64 = int64_t(ctx.v6.s32[0]) - int64_t(ctx.v13.s32[0]);
@@ -20315,7 +20315,7 @@ REX_HOOK_RAW(sub_82AC4DA8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v2,v13,v11
 	temp.s64 = int64_t(ctx.v13.s32[0]) - int64_t(ctx.v11.s32[0]);
@@ -20333,7 +20333,7 @@ REX_HOOK_RAW(sub_82AC4DA8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v31,v12,v10
 	temp.s64 = int64_t(ctx.v12.s32[0]) - int64_t(ctx.v10.s32[0]);
@@ -20450,7 +20450,7 @@ REX_HOOK_RAW(sub_82AC4DA8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vcfpsxws128 v13,v49,0
 	simde_mm_store_si128((simde__m128i*)ctx.v13.s32, rex::ppc::simde_mm_vctsxs(simde_mm_load_ps(ctx.v49.f32)));
@@ -20461,7 +20461,7 @@ REX_HOOK_RAW(sub_82AC4DA8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v11,v11,v25
 	{
@@ -20470,7 +20470,7 @@ REX_HOOK_RAW(sub_82AC4DA8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v23,v12,v0
 	temp.s64 = int64_t(ctx.v12.s32[0]) - int64_t(ctx.v0.s32[0]);
@@ -20493,7 +20493,7 @@ REX_HOOK_RAW(sub_82AC4DA8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v21,v11,v13
 	temp.s64 = int64_t(ctx.v11.s32[0]) - int64_t(ctx.v13.s32[0]);
@@ -26261,7 +26261,7 @@ loc_82D37458:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v25,v31,v13
 	{
@@ -26270,7 +26270,7 @@ loc_82D37458:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v24,v30,v12
 	{
@@ -26279,7 +26279,7 @@ loc_82D37458:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v23,v27,v11
 	{
@@ -26288,7 +26288,7 @@ loc_82D37458:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v22,v26,v24
 	{
@@ -26297,7 +26297,7 @@ loc_82D37458:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v21,v25,v23
 	{
@@ -26306,7 +26306,7 @@ loc_82D37458:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v20,v22,v29
 	{
@@ -26315,7 +26315,7 @@ loc_82D37458:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v19,v21,v29
 	{
@@ -26324,7 +26324,7 @@ loc_82D37458:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsraw128 v38,v20,v59
 	ctx.v38.s32[0] = ctx.v20.s32[0] >> (ctx.v59.u8[0] & 0x1F);
@@ -26420,7 +26420,7 @@ loc_82D37514:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vupkhsb128 v10,v58,v96
 	simde_mm_store_si128((simde__m128i*)ctx.v10.s32, simde_mm_cvtepi16_epi32(simde_mm_unpackhi_epi64(simde_mm_load_si128((simde__m128i*)ctx.v58.s16), simde_mm_load_si128((simde__m128i*)ctx.v58.s16))));
@@ -26431,7 +26431,7 @@ loc_82D37514:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vupklsb128 v9,v58,v96
 	simde_mm_store_si128((simde__m128i*)ctx.v9.s32, simde_mm_cvtepi16_epi32(simde_mm_load_si128((simde__m128i*)ctx.v58.s16)));
@@ -26470,7 +26470,7 @@ loc_82D37514:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v27,v2,v13
 	temp.s64 = int64_t(ctx.v2.s32[0]) - int64_t(ctx.v13.s32[0]);
@@ -26488,7 +26488,7 @@ loc_82D37514:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v25,v31,v0
 	temp.s64 = int64_t(ctx.v31.s32[0]) - int64_t(ctx.v0.s32[0]);
@@ -26506,7 +26506,7 @@ loc_82D37514:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v22,v12,v12
 	{
@@ -26515,7 +26515,7 @@ loc_82D37514:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v23,v27,v30
 	temp.s64 = int64_t(ctx.v27.s32[0]) - int64_t(ctx.v30.s32[0]);
@@ -26542,7 +26542,7 @@ loc_82D37514:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v19,v9,v61
 	{
@@ -26558,7 +26558,7 @@ loc_82D37514:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v17,v23,v7
 	temp.s64 = int64_t(ctx.v23.s32[0]) - int64_t(ctx.v7.s32[0]);
@@ -26576,7 +26576,7 @@ loc_82D37514:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v15,v10,v61
 	{
@@ -26592,7 +26592,7 @@ loc_82D37514:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v0,v21,v6
 	temp.s64 = int64_t(ctx.v21.s32[0]) - int64_t(ctx.v6.s32[0]);
@@ -26610,7 +26610,7 @@ loc_82D37514:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v12,v17,v18
 	temp.s64 = int64_t(ctx.v17.s32[0]) - int64_t(ctx.v18.s32[0]);
@@ -26628,7 +26628,7 @@ loc_82D37514:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v10,v0,v14
 	temp.s64 = int64_t(ctx.v0.s32[0]) - int64_t(ctx.v14.s32[0]);
@@ -26646,7 +26646,7 @@ loc_82D37514:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v7,v10,v11
 	{
@@ -26655,7 +26655,7 @@ loc_82D37514:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v6,v9,v29
 	{
@@ -26664,7 +26664,7 @@ loc_82D37514:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v5,v7,v29
 	{
@@ -26673,7 +26673,7 @@ loc_82D37514:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsraw128 v56,v6,v59
 	ctx.v56.s32[0] = ctx.v6.s32[0] >> (ctx.v59.u8[0] & 0x1F);
@@ -26732,7 +26732,7 @@ loc_82D375F4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vupkhsb128 v0,v52,v96
 	simde_mm_store_si128((simde__m128i*)ctx.v0.s32, simde_mm_cvtepi16_epi32(simde_mm_unpackhi_epi64(simde_mm_load_si128((simde__m128i*)ctx.v52.s16), simde_mm_load_si128((simde__m128i*)ctx.v52.s16))));
@@ -26747,7 +26747,7 @@ loc_82D375F4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vupkhsb128 v48,v51,v96
 	simde_mm_store_si128((simde__m128i*)ctx.v48.s32, simde_mm_cvtepi16_epi32(simde_mm_unpackhi_epi64(simde_mm_load_si128((simde__m128i*)ctx.v51.s16), simde_mm_load_si128((simde__m128i*)ctx.v51.s16))));
@@ -26758,7 +26758,7 @@ loc_82D375F4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v5,v0,v0
 	{
@@ -26767,7 +26767,7 @@ loc_82D375F4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vupkhsb128 v10,v50,v96
 	simde_mm_store_si128((simde__m128i*)ctx.v10.s32, simde_mm_cvtepi16_epi32(simde_mm_unpackhi_epi64(simde_mm_load_si128((simde__m128i*)ctx.v50.s16), simde_mm_load_si128((simde__m128i*)ctx.v50.s16))));
@@ -26778,7 +26778,7 @@ loc_82D375F4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vupklsb128 v9,v50,v96
 	simde_mm_store_si128((simde__m128i*)ctx.v9.s32, simde_mm_cvtepi16_epi32(simde_mm_load_si128((simde__m128i*)ctx.v50.s16)));
@@ -26817,7 +26817,7 @@ loc_82D375F4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v27,v2,v13
 	temp.s64 = int64_t(ctx.v2.s32[0]) - int64_t(ctx.v13.s32[0]);
@@ -26835,7 +26835,7 @@ loc_82D375F4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v25,v31,v0
 	temp.s64 = int64_t(ctx.v31.s32[0]) - int64_t(ctx.v0.s32[0]);
@@ -26885,7 +26885,7 @@ loc_82D375F4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v20,v9,v9
 	{
@@ -26894,7 +26894,7 @@ loc_82D375F4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v19,v9,v61
 	{
@@ -26910,7 +26910,7 @@ loc_82D375F4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v15,v10,v61
 	{
@@ -26944,7 +26944,7 @@ loc_82D375F4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v11,v15,v16
 	{
@@ -26953,7 +26953,7 @@ loc_82D375F4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v12,v17,v18
 	temp.s64 = int64_t(ctx.v17.s32[0]) - int64_t(ctx.v18.s32[0]);
@@ -26980,7 +26980,7 @@ loc_82D375F4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v7,v10,v11
 	{
@@ -26989,7 +26989,7 @@ loc_82D375F4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v6,v9,v29
 	{
@@ -26998,7 +26998,7 @@ loc_82D375F4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v5,v7,v29
 	{
@@ -27007,7 +27007,7 @@ loc_82D375F4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsraw128 v47,v6,v59
 	ctx.v47.s32[0] = ctx.v6.s32[0] >> (ctx.v59.u8[0] & 0x1F);
@@ -45642,7 +45642,7 @@ loc_82D3D6E4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vupkhsb128 v0,v57,v96
 	simde_mm_store_si128((simde__m128i*)ctx.v0.s32, simde_mm_cvtepi16_epi32(simde_mm_unpackhi_epi64(simde_mm_load_si128((simde__m128i*)ctx.v57.s16), simde_mm_load_si128((simde__m128i*)ctx.v57.s16))));
@@ -45653,7 +45653,7 @@ loc_82D3D6E4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vupklsb128 v12,v57,v96
 	simde_mm_store_si128((simde__m128i*)ctx.v12.s32, simde_mm_cvtepi16_epi32(simde_mm_load_si128((simde__m128i*)ctx.v57.s16)));
@@ -45664,7 +45664,7 @@ loc_82D3D6E4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vupkhsb128 v11,v56,v96
 	simde_mm_store_si128((simde__m128i*)ctx.v11.s32, simde_mm_cvtepi16_epi32(simde_mm_unpackhi_epi64(simde_mm_load_si128((simde__m128i*)ctx.v56.s16), simde_mm_load_si128((simde__m128i*)ctx.v56.s16))));
@@ -45675,7 +45675,7 @@ loc_82D3D6E4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vupklsb128 v10,v56,v96
 	simde_mm_store_si128((simde__m128i*)ctx.v10.s32, simde_mm_cvtepi16_epi32(simde_mm_load_si128((simde__m128i*)ctx.v56.s16)));
@@ -45754,7 +45754,7 @@ loc_82D3D6E4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v5,v9,v12
 	{
@@ -45763,7 +45763,7 @@ loc_82D3D6E4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v4,v8,v11
 	{
@@ -45772,7 +45772,7 @@ loc_82D3D6E4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v3,v7,v10
 	{
@@ -45781,7 +45781,7 @@ loc_82D3D6E4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v2,v23,v21
 	{
@@ -45790,7 +45790,7 @@ loc_82D3D6E4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v1,v26,v22
 	{
@@ -45799,7 +45799,7 @@ loc_82D3D6E4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v31,v6,v4
 	{
@@ -45808,7 +45808,7 @@ loc_82D3D6E4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v5,v3
 	{
@@ -45817,7 +45817,7 @@ loc_82D3D6E4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v29,v2,v25
 	{
@@ -45826,7 +45826,7 @@ loc_82D3D6E4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v28,v1,v25
 	{
@@ -45835,7 +45835,7 @@ loc_82D3D6E4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v27,v31,v25
 	{
@@ -45844,7 +45844,7 @@ loc_82D3D6E4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v26,v30,v25
 	{
@@ -45853,7 +45853,7 @@ loc_82D3D6E4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsraw128 v54,v29,v59
 	ctx.v54.s32[0] = ctx.v29.s32[0] >> (ctx.v59.u8[0] & 0x1F);
@@ -45972,7 +45972,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vupkhsb128 v42,v49,v96
 	simde_mm_store_si128((simde__m128i*)ctx.v42.s32, simde_mm_cvtepi16_epi32(simde_mm_unpackhi_epi64(simde_mm_load_si128((simde__m128i*)ctx.v49.s16), simde_mm_load_si128((simde__m128i*)ctx.v49.s16))));
@@ -45983,7 +45983,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vupkhsb128 v9,v44,v96
 	simde_mm_store_si128((simde__m128i*)ctx.v9.s32, simde_mm_cvtepi16_epi32(simde_mm_unpackhi_epi64(simde_mm_load_si128((simde__m128i*)ctx.v44.s16), simde_mm_load_si128((simde__m128i*)ctx.v44.s16))));
@@ -46030,7 +46030,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vupkhsb128 v38,v50,v96
 	simde_mm_store_si128((simde__m128i*)ctx.v38.s32, simde_mm_cvtepi16_epi32(simde_mm_unpackhi_epi64(simde_mm_load_si128((simde__m128i*)ctx.v50.s16), simde_mm_load_si128((simde__m128i*)ctx.v50.s16))));
@@ -46052,7 +46052,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v27,v31,v0
 	temp.s64 = int64_t(ctx.v31.s32[0]) - int64_t(ctx.v0.s32[0]);
@@ -46072,7 +46072,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v22,v29,v30
 	temp.s64 = int64_t(ctx.v29.s32[0]) - int64_t(ctx.v30.s32[0]);
@@ -46090,7 +46090,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v20,v27,v28
 	temp.s64 = int64_t(ctx.v27.s32[0]) - int64_t(ctx.v28.s32[0]);
@@ -46115,7 +46115,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vupklsb128 v10,v40,v96
 	simde_mm_store_si128((simde__m128i*)ctx.v10.s32, simde_mm_cvtepi16_epi32(simde_mm_load_si128((simde__m128i*)ctx.v40.s16)));
@@ -46126,7 +46126,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v18,v8,v61
 	{
@@ -46144,7 +46144,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vupkhsb128 v11,v40,v96
 	simde_mm_store_si128((simde__m128i*)ctx.v11.s32, simde_mm_cvtepi16_epi32(simde_mm_unpackhi_epi64(simde_mm_load_si128((simde__m128i*)ctx.v40.s16), simde_mm_load_si128((simde__m128i*)ctx.v40.s16))));
@@ -46164,7 +46164,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v15,v9,v61
 	{
@@ -46191,7 +46191,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v1,v5,v14
 	temp.s64 = int64_t(ctx.v5.s32[0]) - int64_t(ctx.v14.s32[0]);
@@ -46209,7 +46209,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v2,v6,v17
 	temp.s64 = int64_t(ctx.v6.s32[0]) - int64_t(ctx.v17.s32[0]);
@@ -46227,7 +46227,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v30,v12,v62
 	{
@@ -46250,7 +46250,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v27,v1,v3
 	{
@@ -46259,7 +46259,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v26,v30,v31
 	{
@@ -46268,7 +46268,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v23,v29,v12
 	temp.s64 = int64_t(ctx.v29.s32[0]) - int64_t(ctx.v12.s32[0]);
@@ -46286,7 +46286,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v21,v27,v25
 	{
@@ -46295,7 +46295,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v20,v10,v10
 	{
@@ -46304,7 +46304,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v19,v23,v26
 	temp.s64 = int64_t(ctx.v23.s32[0]) - int64_t(ctx.v26.s32[0]);
@@ -46332,7 +46332,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v17,v8,v61
 	{
@@ -46348,7 +46348,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vpkswss128 v12,v36,v37
 	simde_mm_store_si128((simde__m128i*)ctx.v12.s16, simde_mm_packs_epi32(simde_mm_load_si128((simde__m128i*)ctx.v37.s32), simde_mm_load_si128((simde__m128i*)ctx.v36.s32)));
@@ -46368,7 +46368,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v10,v17,v18
 	{
@@ -46377,7 +46377,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v10.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v10.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vminsh v8,v12,v24
 	simde_mm_store_si128((simde__m128i*)ctx.v8.s16, simde_mm_min_epi16(simde_mm_load_si128((simde__m128i*)ctx.v12.s16), simde_mm_load_si128((simde__m128i*)ctx.v24.s16)));
@@ -46399,7 +46399,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// stvlx v6,r5,r11
 	ea = ctx.r5.u32 + ctx.r11.u32;
@@ -46412,7 +46412,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v3,v0,v62
 	{
@@ -46439,7 +46439,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v31,v38,v63
 	{
@@ -46455,7 +46455,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v29,v2,v0
 	temp.s64 = int64_t(ctx.v2.s32[0]) - int64_t(ctx.v0.s32[0]);
@@ -46473,7 +46473,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v27,v9,v61
 	{
@@ -46489,7 +46489,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v23,v29,v30
 	temp.s64 = int64_t(ctx.v29.s32[0]) - int64_t(ctx.v30.s32[0]);
@@ -46512,7 +46512,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v21,v23,v31
 	temp.s64 = int64_t(ctx.v23.s32[0]) - int64_t(ctx.v31.s32[0]);
@@ -46539,7 +46539,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v18,v19,v25
 	{
@@ -46548,7 +46548,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsraw128 v34,v18,v59
 	ctx.v34.s32[0] = ctx.v18.s32[0] >> (ctx.v59.u8[0] & 0x1F);
@@ -46607,7 +46607,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vupklsb128 v54,v56,v96
 	simde_mm_store_si128((simde__m128i*)ctx.v54.s32, simde_mm_cvtepi16_epi32(simde_mm_load_si128((simde__m128i*)ctx.v56.s16)));
@@ -46618,7 +46618,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v5,v0,v0
 	{
@@ -46627,7 +46627,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vupkhsb128 v53,v56,v96
 	simde_mm_store_si128((simde__m128i*)ctx.v53.s32, simde_mm_cvtepi16_epi32(simde_mm_unpackhi_epi64(simde_mm_load_si128((simde__m128i*)ctx.v56.s16), simde_mm_load_si128((simde__m128i*)ctx.v56.s16))));
@@ -46638,7 +46638,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsldoi128 v52,v33,v57,4
 	simde_mm_store_si128((simde__m128i*)ctx.v52.u8, simde_mm_alignr_epi8(simde_mm_load_si128((simde__m128i*)ctx.v33.u8), simde_mm_load_si128((simde__m128i*)ctx.v57.u8), 12));
@@ -46685,7 +46685,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v29,v2,v12
 	temp.s64 = int64_t(ctx.v2.s32[0]) - int64_t(ctx.v12.s32[0]);
@@ -46705,7 +46705,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vupklsb128 v49,v51,v96
 	simde_mm_store_si128((simde__m128i*)ctx.v49.s32, simde_mm_cvtepi16_epi32(simde_mm_load_si128((simde__m128i*)ctx.v51.s16)));
@@ -46761,7 +46761,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vupkhsb128 v11,v33,v96
 	simde_mm_store_si128((simde__m128i*)ctx.v11.s32, simde_mm_cvtepi16_epi32(simde_mm_unpackhi_epi64(simde_mm_load_si128((simde__m128i*)ctx.v33.s16), simde_mm_load_si128((simde__m128i*)ctx.v33.s16))));
@@ -46772,7 +46772,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vupklsb128 v10,v33,v96
 	simde_mm_store_si128((simde__m128i*)ctx.v10.s32, simde_mm_cvtepi16_epi32(simde_mm_load_si128((simde__m128i*)ctx.v33.s16)));
@@ -46783,7 +46783,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v19,v8,v61
 	{
@@ -46819,7 +46819,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v16,v9,v61
 	{
@@ -46837,7 +46837,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v4,v14,v18
 	temp.s64 = int64_t(ctx.v14.s32[0]) - int64_t(ctx.v18.s32[0]);
@@ -46864,7 +46864,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v2,v12,v12
 	{
@@ -46873,7 +46873,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v1,v12,v62
 	{
@@ -46896,7 +46896,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v29,v3,v5
 	{
@@ -46905,7 +46905,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v28,v1,v2
 	{
@@ -46914,7 +46914,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v27,v31,v12
 	temp.s64 = int64_t(ctx.v31.s32[0]) - int64_t(ctx.v12.s32[0]);
@@ -46932,7 +46932,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v23,v29,v25
 	{
@@ -46941,7 +46941,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v22,v10,v10
 	{
@@ -46950,7 +46950,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v21,v49,v63
 	{
@@ -46985,7 +46985,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v18,v8,v61
 	{
@@ -47003,7 +47003,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v16,v20,v21
 	temp.s64 = int64_t(ctx.v20.s32[0]) - int64_t(ctx.v21.s32[0]);
@@ -47021,7 +47021,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v14,v18,v19
 	{
@@ -47030,7 +47030,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vminsh v12,v12,v24
 	simde_mm_store_si128((simde__m128i*)ctx.v12.s16, simde_mm_min_epi16(simde_mm_load_si128((simde__m128i*)ctx.v12.s16), simde_mm_load_si128((simde__m128i*)ctx.v24.s16)));
@@ -47052,7 +47052,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// stvlx v8,r5,r11
 	ea = ctx.r5.u32 + ctx.r11.u32;
@@ -47065,7 +47065,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v5,v0,v62
 	{
@@ -47092,7 +47092,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v2,v48,v63
 	{
@@ -47108,7 +47108,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v31,v4,v0
 	temp.s64 = int64_t(ctx.v4.s32[0]) - int64_t(ctx.v0.s32[0]);
@@ -47126,7 +47126,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vslw128 v29,v9,v61
 	{
@@ -47142,7 +47142,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v27,v31,v1
 	temp.s64 = int64_t(ctx.v31.s32[0]) - int64_t(ctx.v1.s32[0]);
@@ -47165,7 +47165,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsubsws v23,v27,v2
 	temp.s64 = int64_t(ctx.v27.s32[0]) - int64_t(ctx.v2.s32[0]);
@@ -47192,7 +47192,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vaddsws v20,v21,v25
 	{
@@ -47201,7 +47201,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
 	}
 	// vsraw128 v44,v20,v59
 	ctx.v44.s32[0] = ctx.v20.s32[0] >> (ctx.v59.u8[0] & 0x1F);

--- a/src/renut_engine/fixes/mullhwucrash.cpp
+++ b/src/renut_engine/fixes/mullhwucrash.cpp
@@ -249,7 +249,7 @@ loc_82277D1C:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v8,8,3
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v8.f32), 57), 8));
@@ -302,7 +302,7 @@ loc_82277DB8:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v8,4,2
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v8.f32), 78), 4));
@@ -355,7 +355,7 @@ loc_82277E0C:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v9,2,1
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v9.f32), 147), 2));
@@ -499,7 +499,7 @@ loc_82277E5C:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v8,8,3
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v8.f32), 57), 8));
@@ -552,7 +552,7 @@ loc_82277F5C:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v8,4,2
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v8.f32), 78), 4));
@@ -605,7 +605,7 @@ loc_82277FB0:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v9,2,1
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v9.f32), 147), 2));
@@ -712,7 +712,7 @@ loc_82278024:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v8,8,3
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v8.f32), 57), 8));
@@ -765,7 +765,7 @@ loc_822780B4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v8,4,2
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v8.f32), 78), 4));
@@ -818,7 +818,7 @@ loc_82278108:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v9,2,1
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v9.f32), 147), 2));
@@ -1033,7 +1033,7 @@ loc_82278238:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v8,8,3
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v8.f32), 57), 8));
@@ -1086,7 +1086,7 @@ loc_822782C8:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v8,4,2
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v8.f32), 78), 4));
@@ -1139,7 +1139,7 @@ loc_8227831C:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v9,2,1
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v9.f32), 147), 2));
@@ -1640,7 +1640,7 @@ loc_829A1E74:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v8,8,3
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v8.f32), 57), 8));
@@ -1693,7 +1693,7 @@ loc_829A1F0C:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v8,4,2
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v8.f32), 78), 4));
@@ -1746,7 +1746,7 @@ loc_829A1F60:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v9,2,1
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v9.f32), 147), 2));
@@ -1888,7 +1888,7 @@ loc_829A1FB0:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v8,8,3
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v8.f32), 57), 8));
@@ -1941,7 +1941,7 @@ loc_829A20AC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v8,4,2
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v8.f32), 78), 4));
@@ -1994,7 +1994,7 @@ loc_829A2100:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v9,2,1
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v9.f32), 147), 2));
@@ -2099,7 +2099,7 @@ loc_829A2174:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v8,8,3
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v8.f32), 57), 8));
@@ -2152,7 +2152,7 @@ loc_829A2200:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v8,4,2
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v8.f32), 78), 4));
@@ -2205,7 +2205,7 @@ loc_829A2254:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v9,2,1
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v9.f32), 147), 2));
@@ -2418,7 +2418,7 @@ loc_829A2384:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v8,8,3
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v8.f32), 57), 8));
@@ -2471,7 +2471,7 @@ loc_829A2410:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v8,4,2
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v8.f32), 78), 4));
@@ -2524,7 +2524,7 @@ loc_829A2464:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vrlimi128 v10,v9,2,1
 	simde_mm_store_ps(ctx.v10.f32, simde_mm_blend_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_permute_ps(simde_mm_load_ps(ctx.v9.f32), 147), 2));
@@ -3113,7 +3113,7 @@ loc_829A2B0C:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v7,v8,v31
 	{
@@ -3122,7 +3122,7 @@ loc_829A2B0C:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 loc_829A2C10:
 	// vor v28,v29,v29
@@ -3230,7 +3230,7 @@ loc_829A2C30:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v8,v28
 	{
@@ -3239,7 +3239,7 @@ loc_829A2C30:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 loc_829A2CAC:
 	// lwz r11,24(r31)
@@ -3341,7 +3341,7 @@ loc_829A2CC4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v8,v8,v3
 	{
@@ -3350,7 +3350,7 @@ loc_829A2CC4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 loc_829A2D3C:
 	// lwz r11,24(r31)
@@ -3675,7 +3675,7 @@ loc_829A2D50:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v31,v8,v30
 	{
@@ -3684,7 +3684,7 @@ loc_829A2D50:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v8,v29
 	{
@@ -3693,7 +3693,7 @@ loc_829A2D50:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v29,v8,v20
 	{
@@ -3702,7 +3702,7 @@ loc_829A2D50:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 loc_829A2F78:
 	// addi r11,r11,2
@@ -3826,7 +3826,7 @@ loc_829A2F94:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v31,v8,v30
 	{
@@ -3835,7 +3835,7 @@ loc_829A2F94:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v8,v29
 	{
@@ -3844,7 +3844,7 @@ loc_829A2F94:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v29,v8,v20
 	{
@@ -3853,7 +3853,7 @@ loc_829A2F94:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 loc_829A303C:
 	// lwz r11,24(r31)
@@ -3977,7 +3977,7 @@ loc_829A305C:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v31,v8,v31
 	{
@@ -3986,7 +3986,7 @@ loc_829A305C:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v8,v30
 	{
@@ -3995,7 +3995,7 @@ loc_829A305C:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v8,v8,v29
 	{
@@ -4004,7 +4004,7 @@ loc_829A305C:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 loc_829A3100:
 	// lwz r11,24(r31)
@@ -4258,7 +4258,7 @@ loc_829A3180:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v31,v8,v30
 	{
@@ -4267,7 +4267,7 @@ loc_829A3180:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v8,v29
 	{
@@ -4276,7 +4276,7 @@ loc_829A3180:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v29,v8,v19
 	{
@@ -4285,7 +4285,7 @@ loc_829A3180:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 loc_829A32AC:
 	// addi r11,r11,2
@@ -4413,7 +4413,7 @@ loc_829A32C8:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v31,v8,v30
 	{
@@ -4422,7 +4422,7 @@ loc_829A32C8:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v8,v29
 	{
@@ -4431,7 +4431,7 @@ loc_829A32C8:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v29,v8,v19
 	{
@@ -4440,7 +4440,7 @@ loc_829A32C8:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 loc_829A3378:
 	// lwz r11,24(r31)
@@ -4564,7 +4564,7 @@ loc_829A3398:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v31,v8,v31
 	{
@@ -4573,7 +4573,7 @@ loc_829A3398:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v8,v30
 	{
@@ -4582,7 +4582,7 @@ loc_829A3398:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v8,v8,v29
 	{
@@ -4591,7 +4591,7 @@ loc_829A3398:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 loc_829A343C:
 	// lwz r11,24(r31)
@@ -4929,7 +4929,7 @@ loc_829A354C:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v31,v8,v30
 	{
@@ -4938,7 +4938,7 @@ loc_829A354C:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v8,v29
 	{
@@ -4947,7 +4947,7 @@ loc_829A354C:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v29,v8,v20
 	{
@@ -4956,7 +4956,7 @@ loc_829A354C:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 loc_829A3678:
 	// addi r11,r11,2
@@ -5084,7 +5084,7 @@ loc_829A3694:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v31,v8,v30
 	{
@@ -5093,7 +5093,7 @@ loc_829A3694:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v8,v29
 	{
@@ -5102,7 +5102,7 @@ loc_829A3694:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v29,v8,v20
 	{
@@ -5111,7 +5111,7 @@ loc_829A3694:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 loc_829A3744:
 	// lwz r11,24(r31)
@@ -5235,7 +5235,7 @@ loc_829A3764:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v31,v8,v31
 	{
@@ -5244,7 +5244,7 @@ loc_829A3764:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v8,v30
 	{
@@ -5253,7 +5253,7 @@ loc_829A3764:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v8,v8,v29
 	{
@@ -5262,7 +5262,7 @@ loc_829A3764:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 loc_829A3808:
 	// lwz r11,24(r31)
@@ -5750,7 +5750,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// lvx128 v49,r5,r7
 	ea = (ctx.r5.u32 + ctx.r7.u32) & ~0xF;
@@ -5771,7 +5771,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v31,v49,v62
 	{
@@ -5820,7 +5820,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vcsxwfp128 v25,v44,0
 	simde_mm_store_ps(ctx.v25.f32, simde_mm_cvtepi32_ps(simde_mm_load_si128((simde__m128i*)ctx.v44.u32)));
@@ -5831,7 +5831,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// li r5,112
 	ctx.r5.s64 = 112;
@@ -5975,7 +5975,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vmaddfp v17,v5,v25,v19
 	simde_mm_store_ps(ctx.v17.f32, simde_mm_add_ps(simde_mm_mul_ps(simde_mm_load_ps(ctx.v5.f32), simde_mm_load_ps(ctx.v25.f32)), simde_mm_load_ps(ctx.v19.f32)));
@@ -5988,7 +5988,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vor v1,v14,v14
 	simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_load_si128((simde__m128i*)ctx.v14.u8));
@@ -6001,7 +6001,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vmaddfp v14,v5,v24,v18
 	simde_mm_store_ps(ctx.v14.f32, simde_mm_add_ps(simde_mm_mul_ps(simde_mm_load_ps(ctx.v5.f32), simde_mm_load_ps(ctx.v24.f32)), simde_mm_load_ps(ctx.v18.f32)));
@@ -6025,7 +6025,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v13,v2,v1
 	temp.s64 = int64_t(ctx.v2.s32[0]) - int64_t(ctx.v1.s32[0]);
@@ -6043,7 +6043,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v29,v3,v26
 	temp.s64 = int64_t(ctx.v3.s32[0]) - int64_t(ctx.v26.s32[0]);
@@ -6084,7 +6084,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vctsxs v24,v24,0
 	simde_mm_store_si128((simde__m128i*)ctx.v24.s32, rex::ppc::simde_mm_vctsxs(simde_mm_load_ps(ctx.v24.f32)));
@@ -6106,7 +6106,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vor v29,v23,v23
 	simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_load_si128((simde__m128i*)ctx.v23.u8));
@@ -6131,7 +6131,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v25,v31,v25
 	temp.s64 = int64_t(ctx.v31.s32[0]) - int64_t(ctx.v25.s32[0]);
@@ -6149,7 +6149,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v21,v21,v2
 	temp.s64 = int64_t(ctx.v21.s32[0]) - int64_t(ctx.v2.s32[0]);
@@ -6170,7 +6170,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v16,v15,v16
 	{
@@ -6179,7 +6179,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v20,v20,v1
 	temp.s64 = int64_t(ctx.v20.s32[0]) - int64_t(ctx.v1.s32[0]);
@@ -6216,7 +6216,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v31,v31,v15
 	{
@@ -6225,7 +6225,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// li r6,-16
 	ctx.r6.s64 = -16;
@@ -6259,7 +6259,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vor v2,v17,v17
 	simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_load_si128((simde__m128i*)ctx.v17.u8));
@@ -6277,7 +6277,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vor128 v63,v0,v0
 	simde_mm_store_si128((simde__m128i*)ctx.v63.u8, simde_mm_load_si128((simde__m128i*)ctx.v0.u8));
@@ -6288,7 +6288,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vor v13,v16,v16
 	simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_load_si128((simde__m128i*)ctx.v16.u8));
@@ -6306,7 +6306,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v16,v19,v15
 	{
@@ -6315,7 +6315,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v3,v3,v13
 	{
@@ -6324,7 +6324,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v15,v13,v60
 	{
@@ -6347,7 +6347,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v2,v16,v0
 	{
@@ -6356,7 +6356,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v31,v3,v15
 	{
@@ -6365,7 +6365,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// lvx128 v3,r0,r7
 	ea = (ctx.r7.u32) & ~0xF;
@@ -6377,7 +6377,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v13,v0
 	{
@@ -6386,7 +6386,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vor v13,v14,v14
 	simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_load_si128((simde__m128i*)ctx.v14.u8));
@@ -6397,7 +6397,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v1,v17,v0
 	{
@@ -6406,7 +6406,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsraw128 v31,v30,v43
 	ctx.v31.s32[0] = ctx.v30.s32[0] >> (ctx.v43.u8[0] & 0x1F);
@@ -6435,7 +6435,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v18,v13,v2
 	{
@@ -6444,7 +6444,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v19,v23,v29
 	{
@@ -6453,7 +6453,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v0,v25,v28
 	{
@@ -6462,7 +6462,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vor128 v62,v4,v4
 	simde_mm_store_si128((simde__m128i*)ctx.v62.u8, simde_mm_load_si128((simde__m128i*)ctx.v4.u8));
@@ -6488,7 +6488,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsraw128 v58,v0,v43
 	ctx.v58.s32[0] = ctx.v0.s32[0] >> (ctx.v43.u8[0] & 0x1F);
@@ -6502,7 +6502,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v14,v3,v1
 	{
@@ -6511,7 +6511,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vmrghw128 v52,v61,v57
 	simde_mm_store_si128((simde__m128i*)ctx.v52.u32, simde_mm_unpackhi_epi32(simde_mm_load_si128((simde__m128i*)ctx.v57.u32), simde_mm_load_si128((simde__m128i*)ctx.v61.u32)));
@@ -6522,7 +6522,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vmrglw128 v50,v61,v57
 	simde_mm_store_si128((simde__m128i*)ctx.v50.u32, simde_mm_unpacklo_epi32(simde_mm_load_si128((simde__m128i*)ctx.v57.u32), simde_mm_load_si128((simde__m128i*)ctx.v61.u32)));
@@ -6720,7 +6720,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vmrghw128 v44,v59,v57
 	simde_mm_store_si128((simde__m128i*)ctx.v44.u32, simde_mm_unpackhi_epi32(simde_mm_load_si128((simde__m128i*)ctx.v57.u32), simde_mm_load_si128((simde__m128i*)ctx.v59.u32)));
@@ -6796,7 +6796,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v27,v27,v25
 	temp.s64 = int64_t(ctx.v27.s32[0]) - int64_t(ctx.v25.s32[0]);
@@ -6816,7 +6816,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddfp v18,v1,v29
 	simde_mm_store_ps(ctx.v18.f32, simde_mm_add_ps(simde_mm_load_ps(ctx.v1.f32), simde_mm_load_ps(ctx.v29.f32)));
@@ -6840,7 +6840,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddfp v4,v19,v21
 	simde_mm_store_ps(ctx.v4.f32, simde_mm_add_ps(simde_mm_load_ps(ctx.v19.f32), simde_mm_load_ps(ctx.v21.f32)));
@@ -6973,7 +6973,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v2,v13,v7
 	{
@@ -6982,7 +6982,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vor v11,v26,v26
 	simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_load_si128((simde__m128i*)ctx.v26.u8));
@@ -7012,7 +7012,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v21,v27,v13
 	{
@@ -7021,7 +7021,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v24,v10,v4
 	temp.s64 = int64_t(ctx.v10.s32[0]) - int64_t(ctx.v4.s32[0]);
@@ -7048,7 +7048,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v4,v10,v4
 	{
@@ -7057,7 +7057,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vor v9,v24,v24
 	simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_load_si128((simde__m128i*)ctx.v24.u8));
@@ -7084,7 +7084,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v20,v12,v10
 	{
@@ -7093,7 +7093,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v30,v12,v10
 	temp.s64 = int64_t(ctx.v12.s32[0]) - int64_t(ctx.v10.s32[0]);
@@ -7173,7 +7173,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v7,v16,v17
 	{
@@ -7182,7 +7182,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v29,v10,v38
 	{
@@ -7198,7 +7198,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v28,v10,v39
 	{
@@ -7214,7 +7214,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v26,v9,v60
 	{
@@ -7230,7 +7230,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v25,v7,v60
 	{
@@ -7246,7 +7246,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vor v13,v27,v27
 	simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_load_si128((simde__m128i*)ctx.v27.u8));
@@ -7257,7 +7257,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v23,v9,v25
 	{
@@ -7266,7 +7266,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v9,v10,v12
 	{
@@ -7275,7 +7275,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v29,v11,v13
 	{
@@ -7284,7 +7284,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v22,v13,v60
 	{
@@ -7317,7 +7317,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v17,v9,v19
 	{
@@ -7326,7 +7326,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v16,v24,v0
 	{
@@ -7335,7 +7335,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v15,v23,v0
 	{
@@ -7344,7 +7344,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v14,v18,v0
 	{
@@ -7353,7 +7353,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v5,v17,v0
 	{
@@ -7362,7 +7362,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v12,v6,v13
 	{
@@ -7371,7 +7371,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v10,v8,v11
 	{
@@ -7380,7 +7380,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v10.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v10.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v13,v6,v13
 	temp.s64 = int64_t(ctx.v6.s32[0]) - int64_t(ctx.v13.s32[0]);
@@ -7431,7 +7431,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v28,v12,v2
 	{
@@ -7440,7 +7440,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v27,v9,v7
 	{
@@ -7449,7 +7449,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v26,v0,v8
 	{
@@ -7458,7 +7458,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v25,v31,v6
 	{
@@ -7467,7 +7467,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v24,v30,v5
 	{
@@ -7476,7 +7476,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsraw128 v46,v29,v40
 	ctx.v46.s32[0] = ctx.v29.s32[0] >> (ctx.v40.u8[0] & 0x1F);
@@ -7517,7 +7517,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v22,v13,v1
 	{
@@ -7526,7 +7526,7 @@ REX_HOOK_RAW(sub_82A90360) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vpkswus128 v38,v43,v44
 	simde_mm_store_si128((simde__m128i*)ctx.v38.u16, simde_mm_packus_epi32(simde_mm_load_si128((simde__m128i*)ctx.v44.s32), simde_mm_load_si128((simde__m128i*)ctx.v43.s32)));
@@ -7951,7 +7951,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vmulfp128 v49,v9,v57
 	simde_mm_store_ps(ctx.v49.f32, simde_mm_mul_ps(simde_mm_load_ps(ctx.v9.f32), simde_mm_load_ps(ctx.v57.f32)));
@@ -8000,7 +8000,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v3,v12,v3
 	{
@@ -8009,7 +8009,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vor v11,v30,v30
 	simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_load_si128((simde__m128i*)ctx.v30.u8));
@@ -8031,7 +8031,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v12,v11,v4
 	{
@@ -8040,7 +8040,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v11,v11,v4
 	temp.s64 = int64_t(ctx.v11.s32[0]) - int64_t(ctx.v4.s32[0]);
@@ -8058,7 +8058,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v0,v0,v1
 	temp.s64 = int64_t(ctx.v0.s32[0]) - int64_t(ctx.v1.s32[0]);
@@ -8104,7 +8104,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v26,v27
 	{
@@ -8113,7 +8113,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v22,v0,v3
 	temp.s64 = int64_t(ctx.v0.s32[0]) - int64_t(ctx.v3.s32[0]);
@@ -8134,7 +8134,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v20,v4,v31
 	{
@@ -8143,7 +8143,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v3,v12,v30
 	{
@@ -8152,7 +8152,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v19,v30,v55
 	{
@@ -8177,7 +8177,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v11,v12
 	{
@@ -8186,7 +8186,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// lvx128 v11,r7,r31
 	ea = (ctx.r7.u32 + ctx.r31.u32) & ~0xF;
@@ -8219,7 +8219,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v14,v30,v18
 	{
@@ -8228,7 +8228,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// li r4,16
 	ctx.r4.s64 = 16;
@@ -8254,7 +8254,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v3,v2,v12
 	{
@@ -8263,7 +8263,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v2,v2,v12
 	temp.s64 = int64_t(ctx.v2.s32[0]) - int64_t(ctx.v12.s32[0]);
@@ -8296,7 +8296,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v30,v1,v12
 	temp.s64 = int64_t(ctx.v1.s32[0]) - int64_t(ctx.v12.s32[0]);
@@ -8382,7 +8382,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v11,v28,v11
 	{
@@ -8391,7 +8391,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vmaddfp v27,v9,v4,v0
 	simde_mm_store_ps(ctx.v27.f32, simde_mm_add_ps(simde_mm_mul_ps(simde_mm_load_ps(ctx.v9.f32), simde_mm_load_ps(ctx.v4.f32)), simde_mm_load_ps(ctx.v0.f32)));
@@ -8506,7 +8506,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v3,v10,v9
 	{
@@ -8515,7 +8515,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v8,v7,v6
 	temp.s64 = int64_t(ctx.v7.s32[0]) - int64_t(ctx.v6.s32[0]);
@@ -8544,7 +8544,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vor v6,v14,v14
 	simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_load_si128((simde__m128i*)ctx.v14.u8));
@@ -8564,7 +8564,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// li r6,112
 	ctx.r6.s64 = 112;
@@ -8582,7 +8582,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// li r31,144
 	ctx.r31.s64 = 144;
@@ -8604,7 +8604,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// li r29,176
 	ctx.r29.s64 = 176;
@@ -8626,7 +8626,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// li r27,208
 	ctx.r27.s64 = 208;
@@ -8719,7 +8719,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v6,v23,v24
 	{
@@ -8728,7 +8728,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v5,v21,v22
 	{
@@ -8737,7 +8737,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v16,v19,v20
 	{
@@ -8746,7 +8746,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v15,v17,v18
 	{
@@ -8755,7 +8755,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v4,v0,v6
 	{
@@ -8764,7 +8764,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v1,v10,v5
 	{
@@ -8773,7 +8773,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v14,v6,v55
 	{
@@ -8800,7 +8800,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v1,v1,v0
 	{
@@ -8809,7 +8809,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v9,v6
 	{
@@ -8818,7 +8818,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v29,v8,v5
 	{
@@ -8827,7 +8827,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v24,v6,v55
 	{
@@ -8860,7 +8860,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v21,v29,v23
 	{
@@ -8869,7 +8869,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v20,v4,v13
 	{
@@ -8878,7 +8878,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v19,v1,v13
 	{
@@ -8887,7 +8887,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v18,v22,v13
 	{
@@ -8896,7 +8896,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v17,v21,v13
 	{
@@ -8905,7 +8905,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v9,v11,v10
 	{
@@ -8914,7 +8914,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v8,v12,v0
 	temp.s64 = int64_t(ctx.v12.s32[0]) - int64_t(ctx.v0.s32[0]);
@@ -8932,7 +8932,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v10,v11,v10
 	temp.s64 = int64_t(ctx.v11.s32[0]) - int64_t(ctx.v10.s32[0]);
@@ -8978,7 +8978,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v15,v9,v7
 	{
@@ -8987,7 +8987,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v14,v0,v12
 	{
@@ -8996,7 +8996,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v29,v11,v13
 	{
@@ -9005,7 +9005,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v28,v6,v1
 	{
@@ -9014,7 +9014,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v27,v5,v30
 	{
@@ -9023,7 +9023,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v26,v8,v2
 	{
@@ -9032,7 +9032,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v25,v10,v31
 	{
@@ -9041,7 +9041,7 @@ REX_HOOK_RAW(sub_82A90AA0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v24,v8,v2
 	temp.s64 = int64_t(ctx.v8.s32[0]) - int64_t(ctx.v2.s32[0]);
@@ -9376,7 +9376,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vcsxwfp128 v31,v48,0
 	simde_mm_store_ps(ctx.v31.f32, simde_mm_cvtepi32_ps(simde_mm_load_si128((simde__m128i*)ctx.v48.u32)));
@@ -9399,7 +9399,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// li r9,208
 	ctx.r9.s64 = 208;
@@ -9449,7 +9449,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vmulfp128 v29,v12,v47
 	simde_mm_store_ps(ctx.v29.f32, simde_mm_mul_ps(simde_mm_load_ps(ctx.v12.f32), simde_mm_load_ps(ctx.v47.f32)));
@@ -9460,7 +9460,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vcsxwfp128 v25,v41,0
 	simde_mm_store_ps(ctx.v25.f32, simde_mm_cvtepi32_ps(simde_mm_load_si128((simde__m128i*)ctx.v41.u32)));
@@ -9606,7 +9606,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v28,v28,v1
 	{
@@ -9615,7 +9615,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vor v3,v14,v14
 	simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_load_si128((simde__m128i*)ctx.v14.u8));
@@ -9643,7 +9643,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vctsxs v19,v16,0
 	simde_mm_store_si128((simde__m128i*)ctx.v19.s32, rex::ppc::simde_mm_vctsxs(simde_mm_load_ps(ctx.v16.f32)));
@@ -9665,7 +9665,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v17,v3,v1
 	temp.s64 = int64_t(ctx.v3.s32[0]) - int64_t(ctx.v1.s32[0]);
@@ -9683,7 +9683,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v1,v2,v30
 	{
@@ -9692,7 +9692,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v3,v2,v30
 	temp.s64 = int64_t(ctx.v2.s32[0]) - int64_t(ctx.v30.s32[0]);
@@ -9714,7 +9714,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v21,v21,v24
 	temp.s64 = int64_t(ctx.v21.s32[0]) - int64_t(ctx.v24.s32[0]);
@@ -9767,7 +9767,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v16,v1,v40
 	{
@@ -9790,7 +9790,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// stvx128 v18,r0,r4
 	ea = (ctx.r4.u32) & ~0xF;
@@ -9802,7 +9802,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v20,v20,v23
 	temp.s64 = int64_t(ctx.v20.s32[0]) - int64_t(ctx.v23.s32[0]);
@@ -9820,7 +9820,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// lvx128 v16,r0,r4
 	ea = (ctx.r4.u32) & ~0xF;
@@ -9839,7 +9839,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// stvx128 v30,r0,r24
 	ea = (ctx.r24.u32) & ~0xF;
@@ -9860,7 +9860,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v24,v1,v23
 	{
@@ -9869,7 +9869,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v26,v22
 	{
@@ -9878,7 +9878,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vor v1,v15,v15
 	simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_load_si128((simde__m128i*)ctx.v15.u8));
@@ -9898,7 +9898,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v16,v2,v61
 	{
@@ -9914,7 +9914,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v15,v1,v61
 	{
@@ -9930,7 +9930,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v24,v18,v14
 	{
@@ -9939,7 +9939,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v1,v13,v16
 	{
@@ -9948,7 +9948,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v23,v2,v15
 	{
@@ -9957,7 +9957,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v18,v3,v0
 	{
@@ -9966,7 +9966,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v15,v24,v0
 	{
@@ -9975,7 +9975,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v16,v1,v0
 	{
@@ -9984,7 +9984,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v14,v23,v0
 	{
@@ -9993,7 +9993,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v3,v26,v22
 	temp.s64 = int64_t(ctx.v26.s32[0]) - int64_t(ctx.v22.s32[0]);
@@ -10023,7 +10023,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v2,v31,v19
 	temp.s64 = int64_t(ctx.v31.s32[0]) - int64_t(ctx.v19.s32[0]);
@@ -10054,7 +10054,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v14,v1,v26
 	temp.s64 = int64_t(ctx.v1.s32[0]) - int64_t(ctx.v26.s32[0]);
@@ -10081,7 +10081,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// lvx128 v3,r11,r4
 	ea = (ctx.r11.u32 + ctx.r4.u32) & ~0xF;
@@ -10093,7 +10093,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v28,v30,v25
 	{
@@ -10102,7 +10102,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v23,v21,v23
 	temp.s64 = int64_t(ctx.v21.s32[0]) - int64_t(ctx.v23.s32[0]);
@@ -10120,7 +10120,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v16,v31,v24
 	{
@@ -10129,7 +10129,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v15,v2,v29
 	{
@@ -10138,7 +10138,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v30,v30,v25
 	temp.s64 = int64_t(ctx.v30.s32[0]) - int64_t(ctx.v25.s32[0]);
@@ -10156,7 +10156,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsraw128 v33,v28,v60
 	ctx.v33.s32[0] = ctx.v28.s32[0] >> (ctx.v60.u8[0] & 0x1F);
@@ -10388,7 +10388,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vcsxwfp128 v23,v36,0
 	simde_mm_store_ps(ctx.v23.f32, simde_mm_cvtepi32_ps(simde_mm_load_si128((simde__m128i*)ctx.v36.u32)));
@@ -10408,7 +10408,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vmaddfp v18,v12,v18,v13
 	simde_mm_store_ps(ctx.v18.f32, simde_mm_add_ps(simde_mm_mul_ps(simde_mm_load_ps(ctx.v12.f32), simde_mm_load_ps(ctx.v18.f32)), simde_mm_load_ps(ctx.v13.f32)));
@@ -10437,7 +10437,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v27,v3,v22
 	{
@@ -10446,7 +10446,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v3,v3,v22
 	temp.s64 = int64_t(ctx.v3.s32[0]) - int64_t(ctx.v22.s32[0]);
@@ -10624,7 +10624,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v31,v11,v5
 	{
@@ -10633,7 +10633,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vor v7,v20,v20
 	simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_load_si128((simde__m128i*)ctx.v20.u8));
@@ -10646,7 +10646,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v4,v10,v4
 	{
@@ -10655,7 +10655,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vor v9,v17,v17
 	simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_load_si128((simde__m128i*)ctx.v17.u8));
@@ -10678,7 +10678,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v15,v10,v9
 	{
@@ -10687,7 +10687,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v14,v12,v13
 	{
@@ -10696,7 +10696,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v30,v12,v13
 	temp.s64 = int64_t(ctx.v12.s32[0]) - int64_t(ctx.v13.s32[0]);
@@ -10714,7 +10714,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vor v13,v16,v16
 	simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_load_si128((simde__m128i*)ctx.v16.u8));
@@ -10810,7 +10810,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v9,v23,v24
 	{
@@ -10819,7 +10819,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v18,v21,v22
 	{
@@ -10828,7 +10828,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v17,v19,v20
 	{
@@ -10837,7 +10837,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v5,v13,v7
 	{
@@ -10846,7 +10846,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v16,v7,v61
 	{
@@ -10862,7 +10862,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vor v7,v18,v18
 	simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_load_si128((simde__m128i*)ctx.v18.u8));
@@ -10887,7 +10887,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v28,v10,v12
 	{
@@ -10896,7 +10896,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsraw128 v11,v44,v61
 	ctx.v11.s32[0] = ctx.v44.s32[0] >> (ctx.v61.u8[0] & 0x1F);
@@ -10924,7 +10924,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v12,v6,v13
 	{
@@ -10933,7 +10933,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v10,v8,v11
 	{
@@ -10942,7 +10942,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v10.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v10.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v22,v29,v15
 	{
@@ -10951,7 +10951,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v24,v9,v26
 	{
@@ -10960,7 +10960,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v21,v28,v25
 	{
@@ -10969,7 +10969,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v23,v5,v0
 	{
@@ -10978,7 +10978,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v19,v22,v0
 	{
@@ -10987,7 +10987,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v20,v24,v0
 	{
@@ -10996,7 +10996,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v18,v21,v0
 	{
@@ -11005,7 +11005,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v17,v12,v1
 	{
@@ -11014,7 +11014,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v16,v10,v4
 	{
@@ -11023,7 +11023,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v0,v8,v11
 	temp.s64 = int64_t(ctx.v8.s32[0]) - int64_t(ctx.v11.s32[0]);
@@ -11084,7 +11084,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v14,v11,v8
 	{
@@ -11093,7 +11093,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v29,v30,v6
 	{
@@ -11102,7 +11102,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// stvx128 v42,r0,r25
 	ea = (ctx.r25.u32) & ~0xF;
@@ -11114,7 +11114,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// stvx128 v41,r25,r10
 	ea = (ctx.r25.u32 + ctx.r10.u32) & ~0xF;
@@ -11126,7 +11126,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v26,v0,v2
 	{
@@ -11135,7 +11135,7 @@ REX_HOOK_RAW(sub_82A90F08) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v25,v13,v31
 	temp.s64 = int64_t(ctx.v13.s32[0]) - int64_t(ctx.v31.s32[0]);
@@ -11433,7 +11433,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vmulfp128 v46,v10,v54
 	simde_mm_store_ps(ctx.v46.f32, simde_mm_mul_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_load_ps(ctx.v54.f32)));
@@ -11484,7 +11484,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v12,v3
 	{
@@ -11493,7 +11493,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vor v11,v29,v29
 	simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_load_si128((simde__m128i*)ctx.v29.u8));
@@ -11506,7 +11506,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v29,v0,v1
 	temp.s64 = int64_t(ctx.v0.s32[0]) - int64_t(ctx.v1.s32[0]);
@@ -11524,7 +11524,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v11,v11,v4
 	temp.s64 = int64_t(ctx.v11.s32[0]) - int64_t(ctx.v4.s32[0]);
@@ -11542,7 +11542,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v22,v3,v31
 	temp.s64 = int64_t(ctx.v3.s32[0]) - int64_t(ctx.v31.s32[0]);
@@ -11588,7 +11588,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v1,v26,v27
 	{
@@ -11597,7 +11597,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v2,v0,v2
 	temp.s64 = int64_t(ctx.v0.s32[0]) - int64_t(ctx.v2.s32[0]);
@@ -11618,7 +11618,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v28,v12,v1
 	{
@@ -11627,7 +11627,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v20,v1,v51
 	{
@@ -11645,7 +11645,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v3,v11,v12
 	{
@@ -11654,7 +11654,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// lvx128 v11,r7,r4
 	ea = (ctx.r7.u32 + ctx.r4.u32) & ~0xF;
@@ -11673,7 +11673,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v16,v3,v18
 	{
@@ -11682,7 +11682,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsraw128 v12,v17,v49
 	ctx.v12.s32[0] = ctx.v17.s32[0] >> (ctx.v49.u8[0] & 0x1F);
@@ -11698,7 +11698,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v15,v29,v30
 	temp.s64 = int64_t(ctx.v29.s32[0]) - int64_t(ctx.v30.s32[0]);
@@ -11716,7 +11716,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v1,v4,v12
 	{
@@ -11725,7 +11725,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v31,v4,v12
 	temp.s64 = int64_t(ctx.v4.s32[0]) - int64_t(ctx.v12.s32[0]);
@@ -11772,7 +11772,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsraw128 v35,v1,v49
 	ctx.v35.s32[0] = ctx.v1.s32[0] >> (ctx.v49.u8[0] & 0x1F);
@@ -11864,7 +11864,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v11,v27,v11
 	{
@@ -11873,7 +11873,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vmaddfp v26,v9,v1,v0
 	simde_mm_store_ps(ctx.v26.f32, simde_mm_add_ps(simde_mm_mul_ps(simde_mm_load_ps(ctx.v9.f32), simde_mm_load_ps(ctx.v1.f32)), simde_mm_load_ps(ctx.v0.f32)));
@@ -11969,7 +11969,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsraw128 v5,v37,v51
 	ctx.v5.s32[0] = ctx.v37.s32[0] >> (ctx.v51.u8[0] & 0x1F);
@@ -12008,7 +12008,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// li r7,80
 	ctx.r7.s64 = 80;
@@ -12030,7 +12030,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vor v7,v2,v2
 	simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_load_si128((simde__m128i*)ctx.v2.u8));
@@ -12043,7 +12043,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsraw128 v0,v36,v51
 	ctx.v0.s32[0] = ctx.v36.s32[0] >> (ctx.v51.u8[0] & 0x1F);
@@ -12057,7 +12057,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsraw128 v10,v34,v51
 	ctx.v10.s32[0] = ctx.v34.s32[0] >> (ctx.v51.u8[0] & 0x1F);
@@ -12071,7 +12071,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v23,v12,v0
 	{
@@ -12080,7 +12080,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v22,v12,v0
 	temp.s64 = int64_t(ctx.v12.s32[0]) - int64_t(ctx.v0.s32[0]);
@@ -12098,7 +12098,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v24,v11,v10
 	temp.s64 = int64_t(ctx.v11.s32[0]) - int64_t(ctx.v10.s32[0]);
@@ -12194,7 +12194,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v2,v18,v19
 	{
@@ -12203,7 +12203,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v1,v16,v17
 	{
@@ -12212,7 +12212,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v31,v14,v15
 	{
@@ -12221,7 +12221,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsraw128 v6,v32,v51
 	ctx.v6.s32[0] = ctx.v32.s32[0] >> (ctx.v51.u8[0] & 0x1F);
@@ -12240,7 +12240,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v27,v10,v2
 	{
@@ -12249,7 +12249,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vor v0,v1,v1
 	simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_load_si128((simde__m128i*)ctx.v1.u8));
@@ -12262,7 +12262,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v31,v11,v6
 	{
@@ -12271,7 +12271,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v9,v9,v0
 	{
@@ -12280,7 +12280,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v21,v0,v51
 	{
@@ -12303,7 +12303,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v20,v10,v51
 	{
@@ -12326,7 +12326,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v17,v1,v4
 	{
@@ -12335,7 +12335,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v16,v9,v21
 	{
@@ -12344,7 +12344,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v0,v27,v19
 	{
@@ -12353,7 +12353,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v15,v8,v20
 	{
@@ -12362,7 +12362,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v14,v28,v25
 	{
@@ -12371,7 +12371,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsraw128 v63,v18,v48
 	ctx.v63.s32[0] = ctx.v18.s32[0] >> (ctx.v48.u8[0] & 0x1F);
@@ -12390,7 +12390,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v2,v0,v13
 	{
@@ -12399,7 +12399,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v28,v15,v13
 	{
@@ -12408,7 +12408,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v27,v14,v13
 	{
@@ -12417,7 +12417,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vpkswss128 v61,v62,v63
 	simde_mm_store_si128((simde__m128i*)ctx.v61.s16, simde_mm_packs_epi32(simde_mm_load_si128((simde__m128i*)ctx.v63.s32), simde_mm_load_si128((simde__m128i*)ctx.v62.s32)));
@@ -12477,7 +12477,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v24,v9,v6
 	{
@@ -12486,7 +12486,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v23,v8,v5
 	{
@@ -12495,7 +12495,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v25,v10,v7
 	{
@@ -12504,7 +12504,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v22,v11,v29
 	{
@@ -12513,7 +12513,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v21,v12,v30
 	{
@@ -12522,7 +12522,7 @@ REX_HOOK_RAW(sub_82A916E0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v20,v11,v29
 	temp.s64 = int64_t(ctx.v11.s32[0]) - int64_t(ctx.v29.s32[0]);
@@ -12813,7 +12813,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// li r9,32
 	ctx.r9.s64 = 32;
@@ -12862,7 +12862,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// li r29,32
 	ctx.r29.s64 = 32;
@@ -12881,7 +12881,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddfp128 v39,v1,v31
 	simde_mm_store_ps(ctx.v39.f32, simde_mm_add_ps(simde_mm_load_ps(ctx.v1.f32), simde_mm_load_ps(ctx.v31.f32)));
@@ -12914,7 +12914,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vspltisw128 v34,2
 	simde_mm_store_si128((simde__m128i*)ctx.v34.u32, simde_mm_set1_epi32(int(0x2)));
@@ -13043,7 +13043,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vmaddfp v23,v4,v23,v19
 	simde_mm_store_ps(ctx.v23.f32, simde_mm_add_ps(simde_mm_mul_ps(simde_mm_load_ps(ctx.v4.f32), simde_mm_load_ps(ctx.v23.f32)), simde_mm_load_ps(ctx.v19.f32)));
@@ -13087,7 +13087,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v28,v25,v2
 	{
@@ -13096,7 +13096,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vctsxs v24,v15,0
 	simde_mm_store_si128((simde__m128i*)ctx.v24.s32, rex::ppc::simde_mm_vctsxs(simde_mm_load_ps(ctx.v15.f32)));
@@ -13111,7 +13111,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vor v1,v18,v18
 	simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_load_si128((simde__m128i*)ctx.v18.u8));
@@ -13124,7 +13124,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vor v25,v17,v17
 	simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_load_si128((simde__m128i*)ctx.v17.u8));
@@ -13144,7 +13144,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vctsxs v22,v16,0
 	simde_mm_store_si128((simde__m128i*)ctx.v22.s32, rex::ppc::simde_mm_vctsxs(simde_mm_load_ps(ctx.v16.f32)));
@@ -13215,7 +13215,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// stvx128 v18,r0,r4
 	ea = (ctx.r4.u32) & ~0xF;
@@ -13236,7 +13236,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v19,v30,v22
 	temp.s64 = int64_t(ctx.v30.s32[0]) - int64_t(ctx.v22.s32[0]);
@@ -13254,7 +13254,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// lvx128 v16,r0,r11
 	ea = (ctx.r11.u32) & ~0xF;
@@ -13269,7 +13269,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v15,v17,v14
 	{
@@ -13278,7 +13278,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v24,v31,v21
 	{
@@ -13287,7 +13287,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v16,v3,v33
 	{
@@ -13319,7 +13319,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// li r4,-16
 	ctx.r4.s64 = -16;
@@ -13330,7 +13330,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vor v2,v15,v15
 	simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_load_si128((simde__m128i*)ctx.v15.u8));
@@ -13341,7 +13341,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vor v1,v16,v16
 	simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_load_si128((simde__m128i*)ctx.v16.u8));
@@ -13359,7 +13359,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v20,v2,v59
 	{
@@ -13382,7 +13382,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v15,v1,v59
 	{
@@ -13398,7 +13398,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v13,v13,v20
 	{
@@ -13407,7 +13407,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v16,v21,v30
 	{
@@ -13416,7 +13416,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v2,v15
 	{
@@ -13425,7 +13425,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v20,v3,v0
 	{
@@ -13434,7 +13434,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v21,v13,v0
 	{
@@ -13443,7 +13443,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vor v3,v7,v7
 	simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_load_si128((simde__m128i*)ctx.v7.u8));
@@ -13454,7 +13454,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsraw128 v30,v20,v36
 	ctx.v30.s32[0] = ctx.v20.s32[0] >> (ctx.v36.u8[0] & 0x1F);
@@ -13473,7 +13473,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v22,v29,v23
 	{
@@ -13482,7 +13482,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v13,v29,v23
 	temp.s64 = int64_t(ctx.v29.s32[0]) - int64_t(ctx.v23.s32[0]);
@@ -13514,7 +13514,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// lvx128 v3,r5,r4
 	ea = (ctx.r5.u32 + ctx.r4.u32) & ~0xF;
@@ -13526,7 +13526,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v17,v31,v28
 	temp.s64 = int64_t(ctx.v31.s32[0]) - int64_t(ctx.v28.s32[0]);
@@ -13544,7 +13544,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vor v2,v4,v4
 	simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_load_si128((simde__m128i*)ctx.v4.u8));
@@ -13555,7 +13555,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsraw128 v1,v1,v36
 	ctx.v1.s32[0] = ctx.v1.s32[0] >> (ctx.v36.u8[0] & 0x1F);
@@ -13578,7 +13578,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsraw128 v56,v31,v36
 	ctx.v56.s32[0] = ctx.v31.s32[0] >> (ctx.v36.u8[0] & 0x1F);
@@ -13607,7 +13607,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v19,v18,v29
 	{
@@ -13616,7 +13616,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v25,v24,v25
 	temp.s64 = int64_t(ctx.v24.s32[0]) - int64_t(ctx.v25.s32[0]);
@@ -13636,7 +13636,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vmrghw128 v47,v56,v53
 	simde_mm_store_si128((simde__m128i*)ctx.v47.u32, simde_mm_unpackhi_epi32(simde_mm_load_si128((simde__m128i*)ctx.v53.u32), simde_mm_load_si128((simde__m128i*)ctx.v56.u32)));
@@ -13795,7 +13795,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vmrghw128 v42,v49,v47
 	simde_mm_store_si128((simde__m128i*)ctx.v42.u32, simde_mm_unpackhi_epi32(simde_mm_load_si128((simde__m128i*)ctx.v47.u32), simde_mm_load_si128((simde__m128i*)ctx.v49.u32)));
@@ -13864,7 +13864,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v27,v27,v25
 	temp.s64 = int64_t(ctx.v27.s32[0]) - int64_t(ctx.v25.s32[0]);
@@ -13889,7 +13889,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddfp v17,v1,v29
 	simde_mm_store_ps(ctx.v17.f32, simde_mm_add_ps(simde_mm_load_ps(ctx.v1.f32), simde_mm_load_ps(ctx.v29.f32)));
@@ -13917,7 +13917,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddfp v7,v28,v24
 	simde_mm_store_ps(ctx.v7.f32, simde_mm_add_ps(simde_mm_load_ps(ctx.v28.f32), simde_mm_load_ps(ctx.v24.f32)));
@@ -14044,7 +14044,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsraw128 v13,v60,v59
 	ctx.v13.s32[0] = ctx.v60.s32[0] >> (ctx.v59.u8[0] & 0x1F);
@@ -14067,7 +14067,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsraw128 v5,v55,v59
 	ctx.v5.s32[0] = ctx.v55.s32[0] >> (ctx.v59.u8[0] & 0x1F);
@@ -14111,7 +14111,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v5,v9,v5
 	{
@@ -14120,7 +14120,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vor v7,v21,v21
 	simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_load_si128((simde__m128i*)ctx.v21.u8));
@@ -14138,7 +14138,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v11,v4,v11
 	temp.s64 = int64_t(ctx.v4.s32[0]) - int64_t(ctx.v11.s32[0]);
@@ -14156,7 +14156,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v18,v12,v10
 	{
@@ -14165,7 +14165,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v4,v12,v10
 	temp.s64 = int64_t(ctx.v12.s32[0]) - int64_t(ctx.v10.s32[0]);
@@ -14183,7 +14183,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v31,v27,v13
 	temp.s64 = int64_t(ctx.v27.s32[0]) - int64_t(ctx.v13.s32[0]);
@@ -14256,7 +14256,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v28,v10,v33
 	{
@@ -14272,7 +14272,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v26,v29,v16
 	{
@@ -14281,7 +14281,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v27,v10,v34
 	{
@@ -14297,7 +14297,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v13,v9
 	{
@@ -14306,7 +14306,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v25,v9,v59
 	{
@@ -14324,7 +14324,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v24,v7,v59
 	{
@@ -14340,7 +14340,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v11,v11,v9
 	{
@@ -14349,7 +14349,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v21,v9,v59
 	{
@@ -14365,7 +14365,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v10.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v10.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v22,v12,v59
 	{
@@ -14381,7 +14381,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v16,v11,v21
 	{
@@ -14390,7 +14390,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsraw128 v12,v56,v59
 	ctx.v12.s32[0] = ctx.v56.s32[0] >> (ctx.v59.u8[0] & 0x1F);
@@ -14404,7 +14404,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsraw128 v13,v57,v59
 	ctx.v13.s32[0] = ctx.v57.s32[0] >> (ctx.v59.u8[0] & 0x1F);
@@ -14418,7 +14418,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v15,v23,v0
 	{
@@ -14427,7 +14427,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v10,v8,v12
 	{
@@ -14436,7 +14436,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v10.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v10.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v14,v20,v0
 	{
@@ -14445,7 +14445,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v29,v19,v0
 	{
@@ -14454,7 +14454,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v11,v6,v13
 	{
@@ -14463,7 +14463,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v0,v6,v13
 	temp.s64 = int64_t(ctx.v6.s32[0]) - int64_t(ctx.v13.s32[0]);
@@ -14514,7 +14514,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v27,v11,v3
 	{
@@ -14523,7 +14523,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v26,v9,v7
 	{
@@ -14532,7 +14532,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v25,v12,v8
 	{
@@ -14541,7 +14541,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v24,v31,v6
 	{
@@ -14550,7 +14550,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v23,v4,v30
 	{
@@ -14559,7 +14559,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsraw128 v53,v28,v35
 	ctx.v53.s32[0] = ctx.v28.s32[0] >> (ctx.v35.u8[0] & 0x1F);
@@ -14573,7 +14573,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v19,v0,v1
 	temp.s64 = int64_t(ctx.v0.s32[0]) - int64_t(ctx.v1.s32[0]);
@@ -14591,7 +14591,7 @@ REX_HOOK_RAW(sub_82A91B38) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v20,v13,v5
 	temp.s64 = int64_t(ctx.v13.s32[0]) - int64_t(ctx.v5.s32[0]);
@@ -14934,7 +14934,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// lvx128 v62,r29,r27
 	ea = (ctx.r29.u32 + ctx.r27.u32) & ~0xF;
@@ -14952,7 +14952,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v6,v0,v6
 	temp.s64 = int64_t(ctx.v0.s32[0]) - int64_t(ctx.v6.s32[0]);
@@ -15002,7 +15002,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v21,v11,v5
 	temp.s64 = int64_t(ctx.v11.s32[0]) - int64_t(ctx.v5.s32[0]);
@@ -15020,7 +15020,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vctsxs v11,v23,0
 	simde_mm_store_si128((simde__m128i*)ctx.v11.s32, rex::ppc::simde_mm_vctsxs(simde_mm_load_ps(ctx.v23.f32)));
@@ -15031,7 +15031,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// li r6,48
 	ctx.r6.s64 = 48;
@@ -15076,7 +15076,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v18,v12,v5
 	temp.s64 = int64_t(ctx.v12.s32[0]) - int64_t(ctx.v5.s32[0]);
@@ -15103,7 +15103,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsraw128 v44,v19,v50
 	ctx.v44.s32[0] = ctx.v19.s32[0] >> (ctx.v50.u8[0] & 0x1F);
@@ -15124,7 +15124,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v15,v7,v8
 	temp.s64 = int64_t(ctx.v7.s32[0]) - int64_t(ctx.v8.s32[0]);
@@ -15142,7 +15142,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v11,v6,v11
 	temp.s64 = int64_t(ctx.v6.s32[0]) - int64_t(ctx.v11.s32[0]);
@@ -15198,7 +15198,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v5,v6,v7
 	{
@@ -15207,7 +15207,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v7,v12,v8
 	{
@@ -15216,7 +15216,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v4,v8,v51
 	{
@@ -15234,7 +15234,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v11,v11,v12
 	{
@@ -15243,7 +15243,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v2,v12,v51
 	{
@@ -15259,7 +15259,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v31,v11,v2
 	{
@@ -15268,7 +15268,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsraw128 v12,v1,v50
 	ctx.v12.s32[0] = ctx.v1.s32[0] >> (ctx.v50.u8[0] & 0x1F);
@@ -15282,7 +15282,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v29,v10,v12
 	{
@@ -15291,7 +15291,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v28,v10,v12
 	temp.s64 = int64_t(ctx.v10.s32[0]) - int64_t(ctx.v12.s32[0]);
@@ -15327,7 +15327,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v26,v9,v13
 	temp.s64 = int64_t(ctx.v9.s32[0]) - int64_t(ctx.v13.s32[0]);
@@ -15385,7 +15385,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vmrglw128 v53,v33,v58
 	simde_mm_store_si128((simde__m128i*)ctx.v53.u32, simde_mm_unpacklo_epi32(simde_mm_load_si128((simde__m128i*)ctx.v58.u32), simde_mm_load_si128((simde__m128i*)ctx.v33.u32)));
@@ -15413,7 +15413,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vcsxwfp128 v50,v24,0
 	simde_mm_store_ps(ctx.v50.f32, simde_mm_cvtepi32_ps(simde_mm_load_si128((simde__m128i*)ctx.v24.u32)));
@@ -15482,7 +15482,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v2,v13,v11
 	temp.s64 = int64_t(ctx.v13.s32[0]) - int64_t(ctx.v11.s32[0]);
@@ -15500,7 +15500,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v24,v2,v0
 	{
@@ -15509,7 +15509,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v29,v9,v7
 	{
@@ -15518,7 +15518,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v28,v9,v7
 	temp.s64 = int64_t(ctx.v9.s32[0]) - int64_t(ctx.v7.s32[0]);
@@ -15536,7 +15536,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v3,v12,v10
 	temp.s64 = int64_t(ctx.v12.s32[0]) - int64_t(ctx.v10.s32[0]);
@@ -15554,7 +15554,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v26,v8,v6
 	temp.s64 = int64_t(ctx.v8.s32[0]) - int64_t(ctx.v6.s32[0]);
@@ -15572,7 +15572,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v3,v0
 	{
@@ -15581,7 +15581,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v25,v29,v0
 	{
@@ -15590,7 +15590,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v23,v27,v0
 	{
@@ -15599,7 +15599,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v22,v26,v0
 	{
@@ -15608,7 +15608,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v21,v28,v0
 	{
@@ -15617,7 +15617,7 @@ REX_HOOK_RAW(sub_82A922C0) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsraw128 v42,v1,v62
 	ctx.v42.s32[0] = ctx.v1.s32[0] >> (ctx.v62.u8[0] & 0x1F);
@@ -15747,7 +15747,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v10.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v10.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v9,v0,v12
 	temp.s64 = int64_t(ctx.v0.s32[0]) - int64_t(ctx.v12.s32[0]);
@@ -15787,7 +15787,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// lvx128 v62,r4,r30
 	ea = (ctx.r4.u32 + ctx.r30.u32) & ~0xF;
@@ -15882,7 +15882,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v28,v13,v9
 	temp.s64 = int64_t(ctx.v13.s32[0]) - int64_t(ctx.v9.s32[0]);
@@ -15900,7 +15900,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v26,v29,v0
 	{
@@ -15909,7 +15909,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v27,v12,v8
 	temp.s64 = int64_t(ctx.v12.s32[0]) - int64_t(ctx.v8.s32[0]);
@@ -15927,7 +15927,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v23,v12,v8
 	{
@@ -15936,7 +15936,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v22,v10,v6
 	temp.s64 = int64_t(ctx.v10.s32[0]) - int64_t(ctx.v6.s32[0]);
@@ -15954,7 +15954,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v20,v11,v7
 	temp.s64 = int64_t(ctx.v11.s32[0]) - int64_t(ctx.v7.s32[0]);
@@ -15977,7 +15977,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v18,v24,v0
 	{
@@ -15986,7 +15986,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v17,v23,v0
 	{
@@ -15995,7 +15995,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// li r7,64
 	ctx.r7.s64 = 64;
@@ -16006,7 +16006,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// lvx128 v5,r4,r3
 	ea = (ctx.r4.u32 + ctx.r3.u32) & ~0xF;
@@ -16018,7 +16018,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// li r6,16
 	ctx.r6.s64 = 16;
@@ -16029,7 +16029,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// li r3,-112
 	ctx.r3.s64 = -112;
@@ -16177,7 +16177,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddfp v26,v11,v10
 	simde_mm_store_ps(ctx.v26.f32, simde_mm_add_ps(simde_mm_load_ps(ctx.v11.f32), simde_mm_load_ps(ctx.v10.f32)));
@@ -16188,7 +16188,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddfp v24,v13,v9
 	simde_mm_store_ps(ctx.v24.f32, simde_mm_add_ps(simde_mm_load_ps(ctx.v13.f32), simde_mm_load_ps(ctx.v9.f32)));
@@ -16276,7 +16276,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// li r4,192
 	ctx.r4.s64 = 192;
@@ -16305,7 +16305,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vor v13,v16,v16
 	simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_load_si128((simde__m128i*)ctx.v16.u8));
@@ -16323,7 +16323,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v7,v7,v11
 	temp.s64 = int64_t(ctx.v7.s32[0]) - int64_t(ctx.v11.s32[0]);
@@ -16341,7 +16341,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v0,v13,v9
 	{
@@ -16350,7 +16350,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v13,v13,v9
 	temp.s64 = int64_t(ctx.v13.s32[0]) - int64_t(ctx.v9.s32[0]);
@@ -16407,7 +16407,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v9,v4,v9
 	{
@@ -16416,7 +16416,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v31,v12,v8
 	temp.s64 = int64_t(ctx.v12.s32[0]) - int64_t(ctx.v8.s32[0]);
@@ -16434,7 +16434,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v29,v11,v6
 	{
@@ -16443,7 +16443,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v12,v0,v9
 	{
@@ -16452,7 +16452,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v28,v9,v59
 	{
@@ -16484,7 +16484,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v13,v13,v0
 	{
@@ -16493,7 +16493,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v25,v0,v59
 	{
@@ -16517,7 +16517,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsraw128 v36,v31,v45
 	ctx.v36.s32[0] = ctx.v31.s32[0] >> (ctx.v45.u8[0] & 0x1F);
@@ -16531,7 +16531,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsraw128 v35,v27,v45
 	ctx.v35.s32[0] = ctx.v27.s32[0] >> (ctx.v45.u8[0] & 0x1F);
@@ -16556,7 +16556,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// stvx128 v35,r11,r3
 	ea = (ctx.r11.u32 + ctx.r3.u32) & ~0xF;
@@ -16568,7 +16568,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v20,v10,v0
 	temp.s64 = int64_t(ctx.v10.s32[0]) - int64_t(ctx.v0.s32[0]);
@@ -16601,7 +16601,7 @@ REX_HOOK_RAW(sub_82A92628) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v18,v7,v0
 	temp.s64 = int64_t(ctx.v7.s32[0]) - int64_t(ctx.v0.s32[0]);
@@ -16680,7 +16680,7 @@ REX_HOOK_RAW(sub_82A929B8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// lvx128 v57,r5,r8
 	ea = (ctx.r5.u32 + ctx.r8.u32) & ~0xF;
@@ -16770,7 +16770,7 @@ REX_HOOK_RAW(sub_82A929B8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v4,v11,v8
 	temp.s64 = int64_t(ctx.v11.s32[0]) - int64_t(ctx.v8.s32[0]);
@@ -16788,7 +16788,7 @@ REX_HOOK_RAW(sub_82A929B8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v2,v9,v7
 	temp.s64 = int64_t(ctx.v9.s32[0]) - int64_t(ctx.v7.s32[0]);
@@ -16806,7 +16806,7 @@ REX_HOOK_RAW(sub_82A929B8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v31,v4,v12
 	{
@@ -16815,7 +16815,7 @@ REX_HOOK_RAW(sub_82A929B8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v3,v12
 	{
@@ -16824,7 +16824,7 @@ REX_HOOK_RAW(sub_82A929B8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v29,v2,v12
 	{
@@ -16833,7 +16833,7 @@ REX_HOOK_RAW(sub_82A929B8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsraw128 v51,v1,v60
 	ctx.v51.s32[0] = ctx.v1.s32[0] >> (ctx.v60.u8[0] & 0x1F);
@@ -16880,7 +16880,7 @@ REX_HOOK_RAW(sub_82A929B8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v27,v11,v12
 	temp.s64 = int64_t(ctx.v11.s32[0]) - int64_t(ctx.v12.s32[0]);
@@ -16924,7 +16924,7 @@ REX_HOOK_RAW(sub_82A929B8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v21,v12,v10
 	{
@@ -16933,7 +16933,7 @@ REX_HOOK_RAW(sub_82A929B8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v20,v12,v10
 	temp.s64 = int64_t(ctx.v12.s32[0]) - int64_t(ctx.v10.s32[0]);
@@ -16960,7 +16960,7 @@ REX_HOOK_RAW(sub_82A929B8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v17,v21,v0
 	{
@@ -16969,7 +16969,7 @@ REX_HOOK_RAW(sub_82A929B8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v16,v20,v0
 	{
@@ -16978,7 +16978,7 @@ REX_HOOK_RAW(sub_82A929B8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v15,v19,v0
 	{
@@ -16987,7 +16987,7 @@ REX_HOOK_RAW(sub_82A929B8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsraw128 v36,v18,v62
 	ctx.v36.s32[0] = ctx.v18.s32[0] >> (ctx.v62.u8[0] & 0x1F);
@@ -17123,7 +17123,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vmulfp128 v49,v9,v57
 	simde_mm_store_ps(ctx.v49.f32, simde_mm_mul_ps(simde_mm_load_ps(ctx.v9.f32), simde_mm_load_ps(ctx.v57.f32)));
@@ -17172,7 +17172,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v3,v12,v3
 	{
@@ -17181,7 +17181,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vor v11,v30,v30
 	simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_load_si128((simde__m128i*)ctx.v30.u8));
@@ -17203,7 +17203,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v12,v11,v4
 	{
@@ -17212,7 +17212,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v11,v11,v4
 	temp.s64 = int64_t(ctx.v11.s32[0]) - int64_t(ctx.v4.s32[0]);
@@ -17230,7 +17230,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v0,v0,v1
 	temp.s64 = int64_t(ctx.v0.s32[0]) - int64_t(ctx.v1.s32[0]);
@@ -17276,7 +17276,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v26,v27
 	{
@@ -17285,7 +17285,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v22,v0,v3
 	temp.s64 = int64_t(ctx.v0.s32[0]) - int64_t(ctx.v3.s32[0]);
@@ -17306,7 +17306,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v20,v4,v31
 	{
@@ -17315,7 +17315,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v3,v12,v30
 	{
@@ -17324,7 +17324,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v19,v30,v55
 	{
@@ -17361,7 +17361,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v17,v12,v55
 	{
@@ -17382,7 +17382,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v15,v11,v17
 	{
@@ -17391,7 +17391,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v14,v16,v13
 	{
@@ -17400,7 +17400,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vspltisw128 v42,0
 	simde_mm_store_si128((simde__m128i*)ctx.v42.u32, simde_mm_set1_epi32(int(0x0)));
@@ -17411,7 +17411,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsraw128 v41,v22,v54
 	ctx.v41.s32[0] = ctx.v22.s32[0] >> (ctx.v54.u8[0] & 0x1F);
@@ -17440,7 +17440,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v3,v2,v12
 	temp.s64 = int64_t(ctx.v2.s32[0]) - int64_t(ctx.v12.s32[0]);
@@ -17458,7 +17458,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v1,v1,v11
 	temp.s64 = int64_t(ctx.v1.s32[0]) - int64_t(ctx.v11.s32[0]);
@@ -17554,7 +17554,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v11,v27,v31
 	{
@@ -17563,7 +17563,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vmaddfp v26,v10,v4,v0
 	simde_mm_store_ps(ctx.v26.f32, simde_mm_add_ps(simde_mm_mul_ps(simde_mm_load_ps(ctx.v10.f32), simde_mm_load_ps(ctx.v4.f32)), simde_mm_load_ps(ctx.v0.f32)));
@@ -17696,7 +17696,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v1,v0,v8
 	{
@@ -17705,7 +17705,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v2,v7,v6
 	{
@@ -17714,7 +17714,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v28,v5,v4
 	{
@@ -17723,7 +17723,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vor v7,v31,v31
 	simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_load_si128((simde__m128i*)ctx.v31.u8));
@@ -17749,7 +17749,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsraw128 v10,v35,v55
 	ctx.v10.s32[0] = ctx.v35.s32[0] >> (ctx.v55.u8[0] & 0x1F);
@@ -17763,7 +17763,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v25,v12,v0
 	temp.s64 = int64_t(ctx.v12.s32[0]) - int64_t(ctx.v0.s32[0]);
@@ -17781,7 +17781,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v23,v11,v10
 	{
@@ -17790,7 +17790,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v22,v11,v10
 	temp.s64 = int64_t(ctx.v11.s32[0]) - int64_t(ctx.v10.s32[0]);
@@ -17872,7 +17872,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v4,v18,v19
 	{
@@ -17881,7 +17881,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v17,v9,v60
 	{
@@ -17904,7 +17904,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsraw128 v7,v36,v55
 	ctx.v7.s32[0] = ctx.v36.s32[0] >> (ctx.v55.u8[0] & 0x1F);
@@ -17923,7 +17923,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v21,v5,v55
 	{
@@ -17939,7 +17939,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v5,v10,v4
 	{
@@ -17948,7 +17948,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vor v10,v26,v26
 	simde_mm_store_si128((simde__m128i*)ctx.v10.u8, simde_mm_load_si128((simde__m128i*)ctx.v26.u8));
@@ -17959,7 +17959,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v11,v6
 	{
@@ -17968,7 +17968,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vor v0,v27,v27
 	simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_load_si128((simde__m128i*)ctx.v27.u8));
@@ -17979,7 +17979,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v20,v4,v55
 	{
@@ -18002,7 +18002,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v18,v31,v3
 	{
@@ -18011,7 +18011,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v9,v9,v0
 	{
@@ -18020,7 +18020,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v17,v0,v55
 	{
@@ -18036,7 +18036,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v10.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v10.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v15,v5,v20
 	{
@@ -18045,7 +18045,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v14,v29,v21
 	{
@@ -18054,7 +18054,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsraw128 v33,v19,v52
 	ctx.v33.s32[0] = ctx.v19.s32[0] >> (ctx.v52.u8[0] & 0x1F);
@@ -18073,7 +18073,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v9,v15,v13
 	{
@@ -18082,7 +18082,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v21,v10,v13
 	{
@@ -18091,7 +18091,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v8,v14,v13
 	{
@@ -18100,7 +18100,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v8.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vpkswus128 v63,v32,v33
 	simde_mm_store_si128((simde__m128i*)ctx.v63.u16, simde_mm_packus_epi32(simde_mm_load_si128((simde__m128i*)ctx.v33.s32), simde_mm_load_si128((simde__m128i*)ctx.v32.s32)));
@@ -18129,7 +18129,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsraw128 v13,v8,v54
 	ctx.v13.s32[0] = ctx.v8.s32[0] >> (ctx.v54.u8[0] & 0x1F);
@@ -18193,7 +18193,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v19,v12,v11
 	{
@@ -18202,7 +18202,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v18,v6,v4
 	{
@@ -18211,7 +18211,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v17,v7,v5
 	{
@@ -18220,7 +18220,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v16,v8,v10
 	{
@@ -18229,7 +18229,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v15,v9,v1
 	{
@@ -18238,7 +18238,7 @@ REX_HOOK_RAW(sub_82A92B48) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsraw128 v61,v19,v52
 	ctx.v61.s32[0] = ctx.v19.s32[0] >> (ctx.v52.u8[0] & 0x1F);
@@ -18853,7 +18853,7 @@ REX_HOOK_RAW(sub_82AC46D8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v31,v7,v11
 	temp.s64 = int64_t(ctx.v7.s32[0]) - int64_t(ctx.v11.s32[0]);
@@ -18874,7 +18874,7 @@ REX_HOOK_RAW(sub_82AC46D8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v29,v6,v9
 	{
@@ -18883,7 +18883,7 @@ REX_HOOK_RAW(sub_82AC46D8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v28,v8,v12
 	{
@@ -18892,7 +18892,7 @@ REX_HOOK_RAW(sub_82AC46D8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v27,v8,v12
 	temp.s64 = int64_t(ctx.v8.s32[0]) - int64_t(ctx.v12.s32[0]);
@@ -19404,7 +19404,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vmrghw128 v34,v37,v36
 	simde_mm_store_si128((simde__m128i*)ctx.v34.u32, simde_mm_unpackhi_epi32(simde_mm_load_si128((simde__m128i*)ctx.v36.u32), simde_mm_load_si128((simde__m128i*)ctx.v37.u32)));
@@ -19417,7 +19417,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v13,v10,v11
 	{
@@ -19426,7 +19426,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vspltisw128 v33,5
 	simde_mm_store_si128((simde__m128i*)ctx.v33.u32, simde_mm_set1_epi32(int(0x5)));
@@ -19482,7 +19482,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// rlwinm r7,r11,1,0,30
 	ctx.r7.u64 = __builtin_rotateleft64(ctx.r11.u32 | (ctx.r11.u64 << 32), 1) & 0xFFFFFFFE;
@@ -19493,7 +19493,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// rlwinm r5,r11,2,0,29
 	ctx.r5.u64 = __builtin_rotateleft64(ctx.r11.u32 | (ctx.r11.u64 << 32), 2) & 0xFFFFFFFC;
@@ -19543,7 +19543,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v27,v34,v60
 	{
@@ -19573,7 +19573,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v23,v6,v4
 	{
@@ -19582,7 +19582,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v21,v11,v60
 	{
@@ -19600,7 +19600,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v19,v29,v12
 	{
@@ -19609,7 +19609,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vor v11,v28,v28
 	simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_load_si128((simde__m128i*)ctx.v28.u8));
@@ -19620,7 +19620,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v12,v24,v25
 	{
@@ -19629,7 +19629,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v10,v26,v27
 	{
@@ -19638,7 +19638,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v10.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v10.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v17,v13,v13
 	{
@@ -19647,7 +19647,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v15,v8,v9
 	{
@@ -19656,7 +19656,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v14,v8,v52
 	{
@@ -19672,7 +19672,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v2,v6,v22
 	temp.s64 = int64_t(ctx.v6.s32[0]) - int64_t(ctx.v22.s32[0]);
@@ -19708,7 +19708,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v11,v12,v10
 	{
@@ -19717,7 +19717,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v7,v12,v10
 	temp.s64 = int64_t(ctx.v12.s32[0]) - int64_t(ctx.v10.s32[0]);
@@ -19744,7 +19744,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v26,v9,v60
 	{
@@ -19760,7 +19760,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v27,v6,v31
 	temp.s64 = int64_t(ctx.v6.s32[0]) - int64_t(ctx.v31.s32[0]);
@@ -19778,7 +19778,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v8,v12,v30
 	temp.s64 = int64_t(ctx.v12.s32[0]) - int64_t(ctx.v30.s32[0]);
@@ -19815,7 +19815,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v10,v6,v13
 	{
@@ -19824,7 +19824,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v10.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v10.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v9,v11,v8
 	{
@@ -19833,7 +19833,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v5,v29,v0
 	temp.s64 = int64_t(ctx.v29.s32[0]) - int64_t(ctx.v0.s32[0]);
@@ -19865,7 +19865,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v4,v5,v23
 	temp.s64 = int64_t(ctx.v5.s32[0]) - int64_t(ctx.v23.s32[0]);
@@ -19883,7 +19883,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v5,v5,v16
 	temp.s64 = int64_t(ctx.v5.s32[0]) - int64_t(ctx.v16.s32[0]);
@@ -19924,7 +19924,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vpkswss128 v63,v32,v32
 	simde_mm_store_si128((simde__m128i*)ctx.v63.s16, simde_mm_packs_epi32(simde_mm_load_si128((simde__m128i*)ctx.v32.s32), simde_mm_load_si128((simde__m128i*)ctx.v32.s32)));
@@ -19935,7 +19935,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v11,v4,v0
 	{
@@ -19944,7 +19944,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v8,v7,v12
 	temp.s64 = int64_t(ctx.v7.s32[0]) - int64_t(ctx.v12.s32[0]);
@@ -19962,7 +19962,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v0.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v12,v7,v12
 	{
@@ -19971,7 +19971,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v13,v3,v13
 	{
@@ -19980,7 +19980,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v21,v8,v11
 	{
@@ -19989,7 +19989,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// stvewx128 v63,r0,r10
 	ea = (ctx.r10.u32) & ~0x3;
@@ -20001,7 +20001,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsraw128 v62,v21,v53
 	ctx.v62.s32[0] = ctx.v21.s32[0] >> (ctx.v53.u8[0] & 0x1F);
@@ -20025,7 +20025,7 @@ REX_HOOK_RAW(sub_82AC4A60) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v18,v6,v13
 	temp.s64 = int64_t(ctx.v6.s32[0]) - int64_t(ctx.v13.s32[0]);
@@ -20315,7 +20315,7 @@ REX_HOOK_RAW(sub_82AC4DA8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v2,v13,v11
 	temp.s64 = int64_t(ctx.v13.s32[0]) - int64_t(ctx.v11.s32[0]);
@@ -20333,7 +20333,7 @@ REX_HOOK_RAW(sub_82AC4DA8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v31,v12,v10
 	temp.s64 = int64_t(ctx.v12.s32[0]) - int64_t(ctx.v10.s32[0]);
@@ -20450,7 +20450,7 @@ REX_HOOK_RAW(sub_82AC4DA8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v12.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vcfpsxws128 v13,v49,0
 	simde_mm_store_si128((simde__m128i*)ctx.v13.s32, rex::ppc::simde_mm_vctsxs(simde_mm_load_ps(ctx.v49.f32)));
@@ -20461,7 +20461,7 @@ REX_HOOK_RAW(sub_82AC4DA8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v11,v11,v25
 	{
@@ -20470,7 +20470,7 @@ REX_HOOK_RAW(sub_82AC4DA8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v23,v12,v0
 	temp.s64 = int64_t(ctx.v12.s32[0]) - int64_t(ctx.v0.s32[0]);
@@ -20493,7 +20493,7 @@ REX_HOOK_RAW(sub_82AC4DA8) {
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v21,v11,v13
 	temp.s64 = int64_t(ctx.v11.s32[0]) - int64_t(ctx.v13.s32[0]);
@@ -26261,7 +26261,7 @@ loc_82D37458:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v25,v31,v13
 	{
@@ -26270,7 +26270,7 @@ loc_82D37458:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v25.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v24,v30,v12
 	{
@@ -26279,7 +26279,7 @@ loc_82D37458:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v23,v27,v11
 	{
@@ -26288,7 +26288,7 @@ loc_82D37458:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v22,v26,v24
 	{
@@ -26297,7 +26297,7 @@ loc_82D37458:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v21,v25,v23
 	{
@@ -26306,7 +26306,7 @@ loc_82D37458:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v20,v22,v29
 	{
@@ -26315,7 +26315,7 @@ loc_82D37458:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v19,v21,v29
 	{
@@ -26324,7 +26324,7 @@ loc_82D37458:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsraw128 v38,v20,v59
 	ctx.v38.s32[0] = ctx.v20.s32[0] >> (ctx.v59.u8[0] & 0x1F);
@@ -26420,7 +26420,7 @@ loc_82D37514:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vupkhsb128 v10,v58,v96
 	simde_mm_store_si128((simde__m128i*)ctx.v10.s32, simde_mm_cvtepi16_epi32(simde_mm_unpackhi_epi64(simde_mm_load_si128((simde__m128i*)ctx.v58.s16), simde_mm_load_si128((simde__m128i*)ctx.v58.s16))));
@@ -26431,7 +26431,7 @@ loc_82D37514:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vupklsb128 v9,v58,v96
 	simde_mm_store_si128((simde__m128i*)ctx.v9.s32, simde_mm_cvtepi16_epi32(simde_mm_load_si128((simde__m128i*)ctx.v58.s16)));
@@ -26470,7 +26470,7 @@ loc_82D37514:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v27,v2,v13
 	temp.s64 = int64_t(ctx.v2.s32[0]) - int64_t(ctx.v13.s32[0]);
@@ -26488,7 +26488,7 @@ loc_82D37514:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v25,v31,v0
 	temp.s64 = int64_t(ctx.v31.s32[0]) - int64_t(ctx.v0.s32[0]);
@@ -26506,7 +26506,7 @@ loc_82D37514:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v24.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v22,v12,v12
 	{
@@ -26515,7 +26515,7 @@ loc_82D37514:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v23,v27,v30
 	temp.s64 = int64_t(ctx.v27.s32[0]) - int64_t(ctx.v30.s32[0]);
@@ -26542,7 +26542,7 @@ loc_82D37514:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v19,v9,v61
 	{
@@ -26558,7 +26558,7 @@ loc_82D37514:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v17,v23,v7
 	temp.s64 = int64_t(ctx.v23.s32[0]) - int64_t(ctx.v7.s32[0]);
@@ -26576,7 +26576,7 @@ loc_82D37514:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v15,v10,v61
 	{
@@ -26592,7 +26592,7 @@ loc_82D37514:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v0,v21,v6
 	temp.s64 = int64_t(ctx.v21.s32[0]) - int64_t(ctx.v6.s32[0]);
@@ -26610,7 +26610,7 @@ loc_82D37514:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v12,v17,v18
 	temp.s64 = int64_t(ctx.v17.s32[0]) - int64_t(ctx.v18.s32[0]);
@@ -26628,7 +26628,7 @@ loc_82D37514:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v10,v0,v14
 	temp.s64 = int64_t(ctx.v0.s32[0]) - int64_t(ctx.v14.s32[0]);
@@ -26646,7 +26646,7 @@ loc_82D37514:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v7,v10,v11
 	{
@@ -26655,7 +26655,7 @@ loc_82D37514:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v6,v9,v29
 	{
@@ -26664,7 +26664,7 @@ loc_82D37514:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v5,v7,v29
 	{
@@ -26673,7 +26673,7 @@ loc_82D37514:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsraw128 v56,v6,v59
 	ctx.v56.s32[0] = ctx.v6.s32[0] >> (ctx.v59.u8[0] & 0x1F);
@@ -26732,7 +26732,7 @@ loc_82D375F4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vupkhsb128 v0,v52,v96
 	simde_mm_store_si128((simde__m128i*)ctx.v0.s32, simde_mm_cvtepi16_epi32(simde_mm_unpackhi_epi64(simde_mm_load_si128((simde__m128i*)ctx.v52.s16), simde_mm_load_si128((simde__m128i*)ctx.v52.s16))));
@@ -26747,7 +26747,7 @@ loc_82D375F4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vupkhsb128 v48,v51,v96
 	simde_mm_store_si128((simde__m128i*)ctx.v48.s32, simde_mm_cvtepi16_epi32(simde_mm_unpackhi_epi64(simde_mm_load_si128((simde__m128i*)ctx.v51.s16), simde_mm_load_si128((simde__m128i*)ctx.v51.s16))));
@@ -26758,7 +26758,7 @@ loc_82D375F4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v5,v0,v0
 	{
@@ -26767,7 +26767,7 @@ loc_82D375F4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vupkhsb128 v10,v50,v96
 	simde_mm_store_si128((simde__m128i*)ctx.v10.s32, simde_mm_cvtepi16_epi32(simde_mm_unpackhi_epi64(simde_mm_load_si128((simde__m128i*)ctx.v50.s16), simde_mm_load_si128((simde__m128i*)ctx.v50.s16))));
@@ -26778,7 +26778,7 @@ loc_82D375F4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vupklsb128 v9,v50,v96
 	simde_mm_store_si128((simde__m128i*)ctx.v9.s32, simde_mm_cvtepi16_epi32(simde_mm_load_si128((simde__m128i*)ctx.v50.s16)));
@@ -26817,7 +26817,7 @@ loc_82D375F4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v27,v2,v13
 	temp.s64 = int64_t(ctx.v2.s32[0]) - int64_t(ctx.v13.s32[0]);
@@ -26835,7 +26835,7 @@ loc_82D375F4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v25,v31,v0
 	temp.s64 = int64_t(ctx.v31.s32[0]) - int64_t(ctx.v0.s32[0]);
@@ -26885,7 +26885,7 @@ loc_82D375F4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v20,v9,v9
 	{
@@ -26894,7 +26894,7 @@ loc_82D375F4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v19,v9,v61
 	{
@@ -26910,7 +26910,7 @@ loc_82D375F4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v15,v10,v61
 	{
@@ -26944,7 +26944,7 @@ loc_82D375F4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v13.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v11,v15,v16
 	{
@@ -26953,7 +26953,7 @@ loc_82D375F4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v11.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v12,v17,v18
 	temp.s64 = int64_t(ctx.v17.s32[0]) - int64_t(ctx.v18.s32[0]);
@@ -26980,7 +26980,7 @@ loc_82D375F4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v9.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v7,v10,v11
 	{
@@ -26989,7 +26989,7 @@ loc_82D375F4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v6,v9,v29
 	{
@@ -26998,7 +26998,7 @@ loc_82D375F4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v5,v7,v29
 	{
@@ -27007,7 +27007,7 @@ loc_82D375F4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsraw128 v47,v6,v59
 	ctx.v47.s32[0] = ctx.v6.s32[0] >> (ctx.v59.u8[0] & 0x1F);
@@ -45642,7 +45642,7 @@ loc_82D3D6E4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vupkhsb128 v0,v57,v96
 	simde_mm_store_si128((simde__m128i*)ctx.v0.s32, simde_mm_cvtepi16_epi32(simde_mm_unpackhi_epi64(simde_mm_load_si128((simde__m128i*)ctx.v57.s16), simde_mm_load_si128((simde__m128i*)ctx.v57.s16))));
@@ -45653,7 +45653,7 @@ loc_82D3D6E4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vupklsb128 v12,v57,v96
 	simde_mm_store_si128((simde__m128i*)ctx.v12.s32, simde_mm_cvtepi16_epi32(simde_mm_load_si128((simde__m128i*)ctx.v57.s16)));
@@ -45664,7 +45664,7 @@ loc_82D3D6E4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vupkhsb128 v11,v56,v96
 	simde_mm_store_si128((simde__m128i*)ctx.v11.s32, simde_mm_cvtepi16_epi32(simde_mm_unpackhi_epi64(simde_mm_load_si128((simde__m128i*)ctx.v56.s16), simde_mm_load_si128((simde__m128i*)ctx.v56.s16))));
@@ -45675,7 +45675,7 @@ loc_82D3D6E4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vupklsb128 v10,v56,v96
 	simde_mm_store_si128((simde__m128i*)ctx.v10.s32, simde_mm_cvtepi16_epi32(simde_mm_load_si128((simde__m128i*)ctx.v56.s16)));
@@ -45754,7 +45754,7 @@ loc_82D3D6E4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v5,v9,v12
 	{
@@ -45763,7 +45763,7 @@ loc_82D3D6E4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v4,v8,v11
 	{
@@ -45772,7 +45772,7 @@ loc_82D3D6E4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v3,v7,v10
 	{
@@ -45781,7 +45781,7 @@ loc_82D3D6E4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v2,v23,v21
 	{
@@ -45790,7 +45790,7 @@ loc_82D3D6E4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v1,v26,v22
 	{
@@ -45799,7 +45799,7 @@ loc_82D3D6E4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v31,v6,v4
 	{
@@ -45808,7 +45808,7 @@ loc_82D3D6E4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v30,v5,v3
 	{
@@ -45817,7 +45817,7 @@ loc_82D3D6E4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v29,v2,v25
 	{
@@ -45826,7 +45826,7 @@ loc_82D3D6E4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v28,v1,v25
 	{
@@ -45835,7 +45835,7 @@ loc_82D3D6E4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v27,v31,v25
 	{
@@ -45844,7 +45844,7 @@ loc_82D3D6E4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v26,v30,v25
 	{
@@ -45853,7 +45853,7 @@ loc_82D3D6E4:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsraw128 v54,v29,v59
 	ctx.v54.s32[0] = ctx.v29.s32[0] >> (ctx.v59.u8[0] & 0x1F);
@@ -45972,7 +45972,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vupkhsb128 v42,v49,v96
 	simde_mm_store_si128((simde__m128i*)ctx.v42.s32, simde_mm_cvtepi16_epi32(simde_mm_unpackhi_epi64(simde_mm_load_si128((simde__m128i*)ctx.v49.s16), simde_mm_load_si128((simde__m128i*)ctx.v49.s16))));
@@ -45983,7 +45983,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vupkhsb128 v9,v44,v96
 	simde_mm_store_si128((simde__m128i*)ctx.v9.s32, simde_mm_cvtepi16_epi32(simde_mm_unpackhi_epi64(simde_mm_load_si128((simde__m128i*)ctx.v44.s16), simde_mm_load_si128((simde__m128i*)ctx.v44.s16))));
@@ -46030,7 +46030,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vupkhsb128 v38,v50,v96
 	simde_mm_store_si128((simde__m128i*)ctx.v38.s32, simde_mm_cvtepi16_epi32(simde_mm_unpackhi_epi64(simde_mm_load_si128((simde__m128i*)ctx.v50.s16), simde_mm_load_si128((simde__m128i*)ctx.v50.s16))));
@@ -46052,7 +46052,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v27,v31,v0
 	temp.s64 = int64_t(ctx.v31.s32[0]) - int64_t(ctx.v0.s32[0]);
@@ -46072,7 +46072,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v22,v29,v30
 	temp.s64 = int64_t(ctx.v29.s32[0]) - int64_t(ctx.v30.s32[0]);
@@ -46090,7 +46090,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v20,v27,v28
 	temp.s64 = int64_t(ctx.v27.s32[0]) - int64_t(ctx.v28.s32[0]);
@@ -46115,7 +46115,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vupklsb128 v10,v40,v96
 	simde_mm_store_si128((simde__m128i*)ctx.v10.s32, simde_mm_cvtepi16_epi32(simde_mm_load_si128((simde__m128i*)ctx.v40.s16)));
@@ -46126,7 +46126,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v18,v8,v61
 	{
@@ -46144,7 +46144,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vupkhsb128 v11,v40,v96
 	simde_mm_store_si128((simde__m128i*)ctx.v11.s32, simde_mm_cvtepi16_epi32(simde_mm_unpackhi_epi64(simde_mm_load_si128((simde__m128i*)ctx.v40.s16), simde_mm_load_si128((simde__m128i*)ctx.v40.s16))));
@@ -46164,7 +46164,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v15,v9,v61
 	{
@@ -46191,7 +46191,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v1,v5,v14
 	temp.s64 = int64_t(ctx.v5.s32[0]) - int64_t(ctx.v14.s32[0]);
@@ -46209,7 +46209,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v2,v6,v17
 	temp.s64 = int64_t(ctx.v6.s32[0]) - int64_t(ctx.v17.s32[0]);
@@ -46227,7 +46227,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v31.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v30,v12,v62
 	{
@@ -46250,7 +46250,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v27,v1,v3
 	{
@@ -46259,7 +46259,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v27.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v26,v30,v31
 	{
@@ -46268,7 +46268,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v23,v29,v12
 	temp.s64 = int64_t(ctx.v29.s32[0]) - int64_t(ctx.v12.s32[0]);
@@ -46286,7 +46286,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v21,v27,v25
 	{
@@ -46295,7 +46295,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v20,v10,v10
 	{
@@ -46304,7 +46304,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v19,v23,v26
 	temp.s64 = int64_t(ctx.v23.s32[0]) - int64_t(ctx.v26.s32[0]);
@@ -46332,7 +46332,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v17,v8,v61
 	{
@@ -46348,7 +46348,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v16.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vpkswss128 v12,v36,v37
 	simde_mm_store_si128((simde__m128i*)ctx.v12.s16, simde_mm_packs_epi32(simde_mm_load_si128((simde__m128i*)ctx.v37.s32), simde_mm_load_si128((simde__m128i*)ctx.v36.s32)));
@@ -46368,7 +46368,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v10,v17,v18
 	{
@@ -46377,7 +46377,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v10.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v10.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vminsh v8,v12,v24
 	simde_mm_store_si128((simde__m128i*)ctx.v8.s16, simde_mm_min_epi16(simde_mm_load_si128((simde__m128i*)ctx.v12.s16), simde_mm_load_si128((simde__m128i*)ctx.v24.s16)));
@@ -46399,7 +46399,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// stvlx v6,r5,r11
 	ea = ctx.r5.u32 + ctx.r11.u32;
@@ -46412,7 +46412,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v3,v0,v62
 	{
@@ -46439,7 +46439,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v31,v38,v63
 	{
@@ -46455,7 +46455,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v29,v2,v0
 	temp.s64 = int64_t(ctx.v2.s32[0]) - int64_t(ctx.v0.s32[0]);
@@ -46473,7 +46473,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v27,v9,v61
 	{
@@ -46489,7 +46489,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v23,v29,v30
 	temp.s64 = int64_t(ctx.v29.s32[0]) - int64_t(ctx.v30.s32[0]);
@@ -46512,7 +46512,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v21,v23,v31
 	temp.s64 = int64_t(ctx.v23.s32[0]) - int64_t(ctx.v31.s32[0]);
@@ -46539,7 +46539,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v18,v19,v25
 	{
@@ -46548,7 +46548,7 @@ loc_82D3D830:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsraw128 v34,v18,v59
 	ctx.v34.s32[0] = ctx.v18.s32[0] >> (ctx.v59.u8[0] & 0x1F);
@@ -46607,7 +46607,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vupklsb128 v54,v56,v96
 	simde_mm_store_si128((simde__m128i*)ctx.v54.s32, simde_mm_cvtepi16_epi32(simde_mm_load_si128((simde__m128i*)ctx.v56.s16)));
@@ -46618,7 +46618,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v5,v0,v0
 	{
@@ -46627,7 +46627,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vupkhsb128 v53,v56,v96
 	simde_mm_store_si128((simde__m128i*)ctx.v53.s32, simde_mm_cvtepi16_epi32(simde_mm_unpackhi_epi64(simde_mm_load_si128((simde__m128i*)ctx.v56.s16), simde_mm_load_si128((simde__m128i*)ctx.v56.s16))));
@@ -46638,7 +46638,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v4.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsldoi128 v52,v33,v57,4
 	simde_mm_store_si128((simde__m128i*)ctx.v52.u8, simde_mm_alignr_epi8(simde_mm_load_si128((simde__m128i*)ctx.v33.u8), simde_mm_load_si128((simde__m128i*)ctx.v57.u8), 12));
@@ -46685,7 +46685,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v29,v2,v12
 	temp.s64 = int64_t(ctx.v2.s32[0]) - int64_t(ctx.v12.s32[0]);
@@ -46705,7 +46705,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vupklsb128 v49,v51,v96
 	simde_mm_store_si128((simde__m128i*)ctx.v49.s32, simde_mm_cvtepi16_epi32(simde_mm_load_si128((simde__m128i*)ctx.v51.s16)));
@@ -46761,7 +46761,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vupkhsb128 v11,v33,v96
 	simde_mm_store_si128((simde__m128i*)ctx.v11.s32, simde_mm_cvtepi16_epi32(simde_mm_unpackhi_epi64(simde_mm_load_si128((simde__m128i*)ctx.v33.s16), simde_mm_load_si128((simde__m128i*)ctx.v33.s16))));
@@ -46772,7 +46772,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v18.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vupklsb128 v10,v33,v96
 	simde_mm_store_si128((simde__m128i*)ctx.v10.s32, simde_mm_cvtepi16_epi32(simde_mm_load_si128((simde__m128i*)ctx.v33.s16)));
@@ -46783,7 +46783,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v19,v8,v61
 	{
@@ -46819,7 +46819,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v16,v9,v61
 	{
@@ -46837,7 +46837,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v4,v14,v18
 	temp.s64 = int64_t(ctx.v14.s32[0]) - int64_t(ctx.v18.s32[0]);
@@ -46864,7 +46864,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v5.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v2,v12,v12
 	{
@@ -46873,7 +46873,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v2.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v1,v12,v62
 	{
@@ -46896,7 +46896,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v29,v3,v5
 	{
@@ -46905,7 +46905,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v29.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v28,v1,v2
 	{
@@ -46914,7 +46914,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v27,v31,v12
 	temp.s64 = int64_t(ctx.v31.s32[0]) - int64_t(ctx.v12.s32[0]);
@@ -46932,7 +46932,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v23,v29,v25
 	{
@@ -46941,7 +46941,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v23.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v22,v10,v10
 	{
@@ -46950,7 +46950,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v22.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v21,v49,v63
 	{
@@ -46985,7 +46985,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v19.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v18,v8,v61
 	{
@@ -47003,7 +47003,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v17.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v16,v20,v21
 	temp.s64 = int64_t(ctx.v20.s32[0]) - int64_t(ctx.v21.s32[0]);
@@ -47021,7 +47021,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v15.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v14,v18,v19
 	{
@@ -47030,7 +47030,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v14.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vminsh v12,v12,v24
 	simde_mm_store_si128((simde__m128i*)ctx.v12.s16, simde_mm_min_epi16(simde_mm_load_si128((simde__m128i*)ctx.v12.s16), simde_mm_load_si128((simde__m128i*)ctx.v24.s16)));
@@ -47052,7 +47052,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v7.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// stvlx v8,r5,r11
 	ea = ctx.r5.u32 + ctx.r11.u32;
@@ -47065,7 +47065,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v6.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v5,v0,v62
 	{
@@ -47092,7 +47092,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v3.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v2,v48,v63
 	{
@@ -47108,7 +47108,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v1.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v31,v4,v0
 	temp.s64 = int64_t(ctx.v4.s32[0]) - int64_t(ctx.v0.s32[0]);
@@ -47126,7 +47126,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v30.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vslw128 v29,v9,v61
 	{
@@ -47142,7 +47142,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v28.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v27,v31,v1
 	temp.s64 = int64_t(ctx.v31.s32[0]) - int64_t(ctx.v1.s32[0]);
@@ -47165,7 +47165,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v26.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsubsws v23,v27,v2
 	temp.s64 = int64_t(ctx.v27.s32[0]) - int64_t(ctx.v2.s32[0]);
@@ -47192,7 +47192,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v21.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vaddsws v20,v21,v25
 	{
@@ -47201,7 +47201,7 @@ loc_82D3D9DC:
 		simde__m128i sum = simde_mm_add_epi32(a, b);
 		simde__m128i overflow = simde_mm_and_si128(simde_mm_xor_si128(a, sum), simde_mm_xor_si128(b, sum));
 		simde__m128i sat_val = simde_mm_xor_si128(simde_mm_srai_epi32(a, 31), simde_mm_set1_epi32(0x7FFFFFFF));
-		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_epi8(sum, sat_val, overflow));
+		simde_mm_store_si128((simde__m128i*)ctx.v20.u8, simde_mm_blendv_ps(sum, sat_val, overflow));
 	}
 	// vsraw128 v44,v20,v59
 	ctx.v44.s32[0] = ctx.v20.s32[0] >> (ctx.v59.u8[0] & 0x1F);

--- a/src/renut_engine/frameHooks.cpp
+++ b/src/renut_engine/frameHooks.cpp
@@ -1,4 +1,10 @@
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
 #include <windows.h>
+#else
+#include <time.h>
+#endif
 
 #include <rex/hook.h>
 #include "rex_macros.h"
@@ -72,8 +78,10 @@ void klungoDestruct_hook() // Called at 8246f62c (End of the function)
 // almost no load of its own. It is deliberately named separately from rexglue's
 // GPU `vsync` cvar and does not touch the SDK.
 // =============================================================================
+#ifdef _WIN32
 #ifndef CREATE_WAITABLE_TIMER_HIGH_RESOLUTION
 #define CREATE_WAITABLE_TIMER_HIGH_RESOLUTION 0x00000002
+#endif
 #endif
 
 REXCVAR_DEFINE_STRING(frame_cap, "Off", "Nuts&Bolts/Performance",
@@ -81,6 +89,7 @@ REXCVAR_DEFINE_STRING(frame_cap, "Off", "Nuts&Bolts/Performance",
 	"Off = uncapped, Display = match monitor refresh.")
 	.allowed({ "Off", "30", "60", "120", "144", "Display" });
 
+#ifdef _WIN32
 // One process-wide timer, created on first use. Falls back to a normal waitable
 // timer (and then to sleep_for) if the high-resolution flag isn't supported.
 static HANDLE renutFrameTimer()
@@ -93,6 +102,7 @@ static HANDLE renutFrameTimer()
 	}();
 	return timer;
 }
+#endif
 
 // Resolve the cvar to a target FPS: 0 = uncapped, "Display" = monitor refresh
 // (queried once), otherwise the literal number.
@@ -101,6 +111,7 @@ static int renutFrameCapFps()
 	const std::string& v = REXCVAR_GET(frame_cap);
 	if (v.empty() || v == "Off") return 0;
 	if (v == "Display") {
+#ifdef _WIN32
 		static int hz = []() -> int {
 			DEVMODEW dm{}; dm.dmSize = sizeof(dm);
 			if (EnumDisplaySettingsW(nullptr, ENUM_CURRENT_SETTINGS, &dm) &&
@@ -109,6 +120,11 @@ static int renutFrameCapFps()
 			return 60;
 		}();
 		return hz;
+#else
+		// No portable display-refresh query without pulling in a windowing
+		// dependency here; assume a common default.
+		return 60;
+#endif
 	}
 	return std::atoi(v.c_str());
 }
@@ -136,7 +152,9 @@ void renutFrameLimit()
 		return;
 	}
 
+#ifdef _WIN32
 	HANDLE timer = renutFrameTimer();
+#endif
 	constexpr auto kSpinTail = std::chrono::microseconds(400);
 	for (;;) {
 		now = clock::now();
@@ -144,6 +162,7 @@ void renutFrameLimit()
 		const auto remaining = next - now;
 		if (remaining > kSpinTail) {
 			const auto waitFor = remaining - kSpinTail;
+#ifdef _WIN32
 			if (timer) {
 				LARGE_INTEGER due;
 				due.QuadPart = -static_cast<LONGLONG>(
@@ -155,6 +174,16 @@ void renutFrameLimit()
 			} else {
 				std::this_thread::sleep_for(waitFor);
 			}
+#else
+			// clock_nanosleep with TIMER_ABSTIME avoids drift from repeatedly
+			// re-measuring "now" the way sleep_for's relative wait would.
+			const auto target = next - kSpinTail;
+			const auto targetNs = std::chrono::time_point_cast<std::chrono::nanoseconds>(target);
+			struct timespec ts;
+			ts.tv_sec = static_cast<time_t>(targetNs.time_since_epoch().count() / 1000000000LL);
+			ts.tv_nsec = static_cast<long>(targetNs.time_since_epoch().count() % 1000000000LL);
+			clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &ts, nullptr);
+#endif
 		} else {
 			std::this_thread::yield();  // brief sub-ms tail for pacing accuracy
 		}

--- a/src/renut_engine/game_activity_stats.cpp
+++ b/src/renut_engine/game_activity_stats.cpp
@@ -1,0 +1,141 @@
+#include "renut_engine/game_activity_stats.h"
+
+#include <atomic>
+#include <chrono>
+#include <mutex>
+
+namespace renut::game_activity_stats {
+
+namespace {
+
+struct Counters {
+    std::atomic_uint64_t frame = 0;
+    std::atomic_uint64_t session = 0;
+    std::atomic_uint64_t frame_ns = 0;
+};
+
+std::atomic_bool g_enabled = false;
+Counters g_animation_stream;
+Counters g_body_blend;
+Counters g_actor_script;
+Counters g_actor_generation;
+Snapshot g_snapshot;
+std::mutex g_snapshot_mutex;
+
+bool Record(Counters& counters) {
+    if (!g_enabled.load(std::memory_order_relaxed)) {
+        return false;
+    }
+    counters.frame.fetch_add(1, std::memory_order_relaxed);
+    counters.session.fetch_add(1, std::memory_order_relaxed);
+    return true;
+}
+
+void Finish(Counters& counters, uint64_t start) {
+    if (!start || !g_enabled.load(std::memory_order_relaxed)) {
+        return;
+    }
+    const uint64_t now = uint64_t(std::chrono::duration_cast<std::chrono::nanoseconds>(
+        std::chrono::steady_clock::now().time_since_epoch()).count());
+    counters.frame_ns.fetch_add(now - start, std::memory_order_relaxed);
+}
+
+uint64_t TakeFrame(Counters& counters) {
+    return counters.frame.exchange(0, std::memory_order_relaxed);
+}
+
+uint64_t Session(const Counters& counters) {
+    return counters.session.load(std::memory_order_relaxed);
+}
+
+uint64_t TakeFrameTime(Counters& counters) {
+    return counters.frame_ns.exchange(0, std::memory_order_relaxed);
+}
+
+thread_local uint64_t g_animation_stream_start = 0;
+thread_local uint64_t g_body_blend_start = 0;
+thread_local uint64_t g_actor_script_start = 0;
+thread_local uint64_t g_actor_generation_start = 0;
+
+uint64_t Now() {
+    return uint64_t(std::chrono::duration_cast<std::chrono::nanoseconds>(
+        std::chrono::steady_clock::now().time_since_epoch()).count());
+}
+
+}
+
+void SetEnabled(bool enabled) {
+    g_enabled.store(enabled, std::memory_order_relaxed);
+}
+
+void RecordAnimationStream() {
+    if (Record(g_animation_stream)) {
+        g_animation_stream_start = Now();
+    }
+}
+
+void FinishAnimationStream() {
+    Finish(g_animation_stream, g_animation_stream_start);
+    g_animation_stream_start = 0;
+}
+
+void RecordBodyBlend() {
+    if (Record(g_body_blend)) {
+        g_body_blend_start = Now();
+    }
+}
+
+void FinishBodyBlend() {
+    Finish(g_body_blend, g_body_blend_start);
+    g_body_blend_start = 0;
+}
+
+void RecordActorScript() {
+    if (Record(g_actor_script)) {
+        g_actor_script_start = Now();
+    }
+}
+
+void FinishActorScript() {
+    Finish(g_actor_script, g_actor_script_start);
+    g_actor_script_start = 0;
+}
+
+void RecordActorGeneration() {
+    if (Record(g_actor_generation)) {
+        g_actor_generation_start = Now();
+    }
+}
+
+void FinishActorGeneration() {
+    Finish(g_actor_generation, g_actor_generation_start);
+    g_actor_generation_start = 0;
+}
+
+void EndFrame() {
+    if (!g_enabled.load(std::memory_order_relaxed)) {
+        return;
+    }
+    Snapshot snapshot;
+    snapshot.animation_stream_frame = TakeFrame(g_animation_stream);
+    snapshot.animation_stream_session = Session(g_animation_stream);
+    snapshot.animation_stream_frame_ns = TakeFrameTime(g_animation_stream);
+    snapshot.body_blend_frame = TakeFrame(g_body_blend);
+    snapshot.body_blend_session = Session(g_body_blend);
+    snapshot.body_blend_frame_ns = TakeFrameTime(g_body_blend);
+    snapshot.actor_script_frame = TakeFrame(g_actor_script);
+    snapshot.actor_script_session = Session(g_actor_script);
+    snapshot.actor_script_frame_ns = TakeFrameTime(g_actor_script);
+    snapshot.actor_generation_frame = TakeFrame(g_actor_generation);
+    snapshot.actor_generation_session = Session(g_actor_generation);
+    snapshot.actor_generation_frame_ns = TakeFrameTime(g_actor_generation);
+    std::scoped_lock lock(g_snapshot_mutex);
+    g_snapshot = snapshot;
+}
+
+Snapshot GetSnapshot() {
+    std::scoped_lock lock(g_snapshot_mutex);
+    return g_snapshot;
+}
+
+}

--- a/src/renut_engine/game_activity_stats.h
+++ b/src/renut_engine/game_activity_stats.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <cstdint>
+
+namespace renut::game_activity_stats {
+
+struct Snapshot {
+    uint64_t animation_stream_frame = 0;
+    uint64_t animation_stream_session = 0;
+    uint64_t animation_stream_frame_ns = 0;
+    uint64_t body_blend_frame = 0;
+    uint64_t body_blend_session = 0;
+    uint64_t body_blend_frame_ns = 0;
+    uint64_t actor_script_frame = 0;
+    uint64_t actor_script_session = 0;
+    uint64_t actor_script_frame_ns = 0;
+    uint64_t actor_generation_frame = 0;
+    uint64_t actor_generation_session = 0;
+    uint64_t actor_generation_frame_ns = 0;
+};
+
+void SetEnabled(bool enabled);
+void RecordAnimationStream();
+void FinishAnimationStream();
+void RecordBodyBlend();
+void FinishBodyBlend();
+void RecordActorScript();
+void FinishActorScript();
+void RecordActorGeneration();
+void FinishActorGeneration();
+void EndFrame();
+Snapshot GetSnapshot();
+
+}

--- a/src/renut_engine/hooks.cpp
+++ b/src/renut_engine/hooks.cpp
@@ -56,6 +56,7 @@ REXCVAR_DEFINE_BOOL(disable_msaa, false, "Nuts&Bolts/Graphics", "Disables MSAA o
 REXCVAR_DEFINE_BOOL(disable_motion_blur, false, "Nuts&Bolts/Graphics", "Disables the full-screen speed/camera motion blur");
 // Name = "Max Acquired Parts Access"
 REXCVAR_DEFINE_BOOL(max_acquired_parts_access, false, "Nuts&Bolts/Cheats", "Allows max acquired vehicle parts");
+REXCVAR_DEFINE_BOOL(disable_tessellated_draw, true, "Nuts&Bolts/Graphics", "Skips hardware-tessellated draws (character-model smoothing) to avoid a GPU hang seen on Linux/RADV. Off = restore tessellation once the underlying SDK bug is fixed.");
 
 
 inline int bWidth = 640;
@@ -153,6 +154,10 @@ void disable_msaa_depth(PPCRegister& r6) {
 // motion-blur history. The surrounding Resolves/state restore still run.
 bool disable_motion_blur() {
     return REXCVAR_GET(disable_motion_blur);
+}
+
+bool disable_tessellated_draw() {
+    return REXCVAR_GET(disable_tessellated_draw);
 }
 
 // Fix the split-second black flash on heal/damage feedback.

--- a/src/renut_engine/linuxfixes/audio_backend.cpp
+++ b/src/renut_engine/linuxfixes/audio_backend.cpp
@@ -1,0 +1,33 @@
+// Forces SDL's PulseAudio backend on Linux.
+//
+// SDL picks an audio backend by probing its compiled-in drivers in priority
+// order, and on this desktop it settles on PipeWire. That path opens a device
+// and PipeWire even shows the "rexglue" stream as active and routed, but no
+// audio actually comes out. The PulseAudio backend (served by pipewire-pulse)
+// works, so pin SDL to it.
+//
+// SDL_HINT_AUDIO_DRIVER is literally "SDL_AUDIO_DRIVER" and SDL falls back to
+// the environment variable when the hint has not been set programmatically, so
+// exporting it is enough -- and it keeps reNut from having to link SDL3
+// directly, which it currently does not (SDL lives inside librexruntimerd.so).
+//
+// This has to happen before SDL_InitSubSystem(SDL_INIT_AUDIO), which the SDK
+// calls from SDLAudioDriver::Initialize() the first time the guest registers an
+// audio client. A static initializer runs before main(), so it is comfortably
+// early.
+//
+// overwrite=0: an SDL_AUDIO_DRIVER already present in the environment wins, so
+// you can still override this from the shell without rebuilding, e.g.
+//   SDL_AUDIO_DRIVER=pipewire ./renut
+
+#include <cstdlib>
+
+namespace {
+
+const bool g_audio_backend_pinned = [] {
+  // Does nothing if the variable is already set.
+  ::setenv("SDL_AUDIO_DRIVER", "pulseaudio", 0);
+  return true;
+}();
+
+}  // namespace

--- a/src/renut_engine/linuxfixes/audio_client_guard.cpp
+++ b/src/renut_engine/linuxfixes/audio_client_guard.cpp
@@ -1,0 +1,249 @@
+// Fixes a hard hang on Linux caused by an XAudio use-after-unregister race.
+//
+// Symptom
+// -------
+// A few seconds into the game every guest thread stops making progress while
+// the window keeps redrawing. One host thread ("Audio Worker") sits at 100% CPU.
+//
+// Cause
+// -----
+// rex::audio::AudioSystem::WorkerThreadMain() reads clients_[i].callback under
+// the global critical region, *releases the lock*, and only then runs the guest
+// audio callback:
+//
+//     auto global_lock = global_critical_region_.Acquire();
+//     uint32_t client_callback = clients_[index].callback;
+//     ...
+//     global_lock.unlock();
+//     if (client_callback) { function_dispatcher_->Execute(client_callback, ...); }
+//
+// If another guest thread calls XAudioUnregisterRenderDriverClient while that
+// callback is in flight, AudioSystem::UnregisterClient() destroys the driver and
+// resets the slot to {nullptr, 0, 0, 0, false}. The still-running callback then
+// calls XAudioSubmitRenderDriverFrame, and AudioSystem::SubmitFrame() does:
+//
+//     auto global_lock = global_critical_region_.Acquire();   // audio_system.cpp:261
+//     assert_true(clients_[index].driver != NULL);            // compiled out (NDEBUG)
+//     (clients_[index].driver)->SubmitFrame(samples_ptr);     // audio_system.cpp:264
+//
+// ...which dereferences a null AudioDriver* while holding the global lock.
+//
+// Why it hangs instead of crashing
+// --------------------------------
+// On Linux this never reaches a crash handler. ExceptionHandlerCallback() in
+// the SDK's exception_handler_posix.cpp walks its registered handlers and, when
+// none of them claims the fault, simply falls off the end of the function and
+// returns. Returning from a SIGSEGV handler without advancing RIP makes the
+// kernel restart the faulting instruction, which faults again -- forever.
+//
+// The audio worker therefore spins at 100% CPU and never runs the destructor
+// that would release the global critical region. Every thread that needs that
+// lock blocks permanently: GPU vblank interrupt dispatch, KeSetEvent, and every
+// guest thread parked in NtWaitForSingleObjectEx waiting on events that can no
+// longer be signalled. Only the host UI thread keeps running, which is why the
+// window stays alive while the game is frozen.
+//
+// Fix
+// ---
+// The SDK is upstream and cannot be patched, so the three XAudio driver-client
+// exports are interposed here. renut imports them as undefined symbols from
+// librexruntimerd.so, so defining them in the executable binds every call in
+// the recompiled game code to these wrappers at link time.
+//
+// We track which client indices are actually registered and drop any frame
+// submitted for a dead index instead of letting it reach the null driver. A
+// shared_mutex makes the check-and-submit atomic with respect to unregistration,
+// so the frame cannot be dropped in the gap between the two. Our lock is always
+// taken *before* the SDK's global critical region and never the other way round,
+// so it cannot introduce a lock-order inversion.
+//
+// Dropping is not enough on its own
+// ---------------------------------
+// Not crashing still leaves the *guest* half-torn. Comparing runs:
+//
+//     reg=2 unreg=1 drops=0  -> game re-registers, boots fine
+//     reg=1 unreg=1 drops=1  -> game never re-registers, hangs at appMainBoot
+//                               with every guest thread in NtWaitForSingleObjectEx
+//
+// That held for every run observed, so a dropped frame reliably wedges the
+// game's audio state machine even though the crash is gone. (The guest ignores
+// the return value of XAudioSubmitRenderDriverFrame entirely -- it calls it and
+// immediately returns -- so reporting an error instead would change nothing.)
+//
+// So rather than dropping the frame, we stop the race from happening: on
+// unregister we wait, *without* holding the lock, until frame submissions have
+// gone quiet, letting an in-flight callback deliver to a still-live driver
+// before the teardown runs. Bounded by kUnregisterMaxGrace so a game that
+// submits continuously cannot stall the unregistering thread indefinitely. The
+// observed gap between unregister and the orphaned submit was 37 ms.
+//
+// The drop path is kept as the backstop for anything that still slips through
+// (for example a submit arriving after the grace period expires); it is what
+// prevents the null-deref hang.
+//
+// A complete fix belongs in the SDK: AudioSystem::WorkerThreadMain() should hold
+// the global critical region across the guest callback dispatch instead of
+// releasing it first. That cannot be done from reNut, since the dispatch lives
+// inside librexruntimerd.so.
+//
+// Note: this covers the XAudioUnregisterRenderDriverClient path. AudioSystem::
+// Shutdown() also clears every client slot directly, but it terminates the audio
+// worker thread first, so there is no callback left in flight to race with.
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <shared_mutex>
+#include <thread>
+
+#include <rex/hook.h>
+#include <rex/system/xtypes.h>
+#include <rex/types.h>
+
+#include "../renut_logging.h"
+
+// The X_* status macros expand to a cast to X_RESULT, which lives in namespace rex.
+using rex::X_RESULT;
+
+// Provided by librexruntimerd.so (src/kernel/xboxkrnl/xboxkrnl_audio.cpp).
+// Not declared in any public SDK header, so they are declared here; the
+// signatures must match exactly for the mangled names to resolve.
+namespace rex::kernel::xboxkrnl {
+u32 XAudioRegisterRenderDriverClient_entry(mapped_u32 callback_ptr, mapped_u32 driver_ptr);
+u32 XAudioUnregisterRenderDriverClient_entry(mapped_void driver_ptr);
+u32 XAudioSubmitRenderDriverFrame_entry(mapped_void driver_ptr, mapped_void samples_ptr);
+}  // namespace rex::kernel::xboxkrnl
+
+namespace {
+
+// Handle layout produced by XAudioRegisterRenderDriverClient_entry:
+//   *driver_ptr = 0x41550000 | (index & 0xFFFF)
+constexpr uint32_t kDriverHandleTag = 0x41550000u;
+constexpr uint32_t kDriverHandleTagMask = 0xFFFF0000u;
+constexpr uint32_t kDriverIndexMask = 0x0000FFFFu;
+
+// Mirrors AudioSystem::kMaximumClientCount.
+constexpr uint32_t kMaximumClientCount = 8;
+
+// Bit i set => client index i is registered and has a live driver.
+uint32_t g_live_clients = 0;
+
+// Guards g_live_clients *and* the window in which a submitted frame is handed
+// to the SDK, so a concurrent unregister cannot destroy the driver in between.
+std::shared_mutex g_clients_mutex;
+
+// Rate-limit the "dropped frame" warning; the game submits ~one frame per few
+// milliseconds and would otherwise flood the log.
+std::atomic<uint32_t> g_dropped_frames{0};
+
+// Bumped for every frame that reaches the SDK. Unregister watches this to tell
+// whether a guest audio callback is still in flight.
+std::atomic<uint64_t> g_submitted_frames{0};
+
+// Unregister waits for submissions to stay quiet this long before tearing the
+// driver down (the orphaned submit was observed 37 ms after unregister)...
+constexpr auto kUnregisterQuietPeriod = std::chrono::milliseconds(30);
+// ...but never waits longer than this in total, so a game that submits
+// continuously cannot stall the unregistering guest thread. Unregister happens
+// about once per run, so this costs nothing in practice.
+constexpr auto kUnregisterMaxGrace = std::chrono::milliseconds(250);
+
+// Returns kMaximumClientCount if the handle is not a driver handle we know.
+uint32_t ClientIndexFromHandle(uint32_t handle) {
+  if ((handle & kDriverHandleTagMask) != kDriverHandleTag) {
+    return kMaximumClientCount;
+  }
+  const uint32_t index = handle & kDriverIndexMask;
+  return index < kMaximumClientCount ? index : kMaximumClientCount;
+}
+
+u32 RegisterRenderDriverClient(mapped_u32 callback_ptr, mapped_u32 driver_ptr) {
+  std::unique_lock lock(g_clients_mutex);
+
+  const rex::u32 result =
+      rex::kernel::xboxkrnl::XAudioRegisterRenderDriverClient_entry(callback_ptr, driver_ptr);
+  if (result != X_ERROR_SUCCESS || !driver_ptr) {
+    return result;
+  }
+
+  const uint32_t index = ClientIndexFromHandle(driver_ptr.value());
+  if (index >= kMaximumClientCount) {
+    RNUT_WARN("audio guard: register returned unrecognized driver handle {:08X}",
+              driver_ptr.value());
+    return result;
+  }
+
+  g_live_clients |= (1u << index);
+  RNUT_INFO("audio guard: client {} registered (handle {:08X})", index, driver_ptr.value());
+  return result;
+}
+
+u32 UnregisterRenderDriverClient(mapped_void driver_ptr) {
+  const uint32_t index = ClientIndexFromHandle(driver_ptr.guest_address());
+
+  // Let any in-flight guest audio callback land its frame on the still-live
+  // driver before we tear it down. Deliberately done *before* taking the lock,
+  // so submissions can still run while we wait -- holding it here would block
+  // the very callback we are waiting for.
+  if (index < kMaximumClientCount && (g_live_clients & (1u << index))) {
+    const auto start = std::chrono::steady_clock::now();
+    auto last_submit = start;
+    uint64_t seen = g_submitted_frames.load(std::memory_order_relaxed);
+    for (;;) {
+      const auto now = std::chrono::steady_clock::now();
+      const uint64_t current = g_submitted_frames.load(std::memory_order_relaxed);
+      if (current != seen) {
+        seen = current;
+        last_submit = now;
+      }
+      if (now - last_submit >= kUnregisterQuietPeriod || now - start >= kUnregisterMaxGrace) {
+        break;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+  }
+
+  std::unique_lock lock(g_clients_mutex);
+
+  // Clear the bit before tearing the driver down, so any submit that is waiting
+  // on the mutex right now sees a dead index rather than a freed driver.
+  if (index < kMaximumClientCount) {
+    g_live_clients &= ~(1u << index);
+    RNUT_INFO("audio guard: client {} unregistered (handle {:08X}, {} frames submitted)", index,
+              driver_ptr.guest_address(), g_submitted_frames.load(std::memory_order_relaxed));
+  }
+
+  return rex::kernel::xboxkrnl::XAudioUnregisterRenderDriverClient_entry(driver_ptr);
+}
+
+u32 SubmitRenderDriverFrame(mapped_void driver_ptr, mapped_void samples_ptr) {
+  // Shared: many submits may run concurrently, but none may overlap an
+  // unregister. Held across the call into the SDK, not just the check.
+  std::shared_lock lock(g_clients_mutex);
+
+  const uint32_t handle = driver_ptr.guest_address();
+  const uint32_t index = ClientIndexFromHandle(handle);
+  if (index >= kMaximumClientCount || !(g_live_clients & (1u << index))) {
+    // The driver behind this handle is gone. Passing it through would null-deref
+    // inside AudioSystem::SubmitFrame while it holds the global critical region
+    // and wedge the whole emulator. Drop the frame instead; the guest treats
+    // this as a successful submit and carries on.
+    const uint32_t dropped = g_dropped_frames.fetch_add(1, std::memory_order_relaxed) + 1;
+    if (dropped <= 5 || (dropped % 1000) == 0) {
+      RNUT_WARN("audio guard: dropped frame for stale driver handle {:08X} (drop #{})", handle,
+                dropped);
+    }
+    return X_ERROR_SUCCESS;
+  }
+
+  g_submitted_frames.fetch_add(1, std::memory_order_relaxed);
+  return rex::kernel::xboxkrnl::XAudioSubmitRenderDriverFrame_entry(driver_ptr, samples_ptr);
+}
+
+}  // namespace
+
+// These definitions preempt the identically named exports in librexruntimerd.so
+// for every call site inside renut.
+REX_HOOK(__imp__XAudioRegisterRenderDriverClient, RegisterRenderDriverClient)
+REX_HOOK(__imp__XAudioUnregisterRenderDriverClient, UnregisterRenderDriverClient)
+REX_HOOK(__imp__XAudioSubmitRenderDriverFrame, SubmitRenderDriverFrame)

--- a/src/renut_engine/linuxfixes/posix_file_access.cpp
+++ b/src/renut_engine/linuxfixes/posix_file_access.cpp
@@ -1,0 +1,150 @@
+// Fixes corrupted save data on Linux, caused by a broken POSIX open() mode.
+//
+// Symptom
+// -------
+// The game reports its save data as corrupted, repeatedly.
+//
+// Cause
+// -----
+// The SDK's POSIX backend (src/core/filesystem_posix.cpp,
+// FileHandle::OpenExisting) builds its open() flags like this:
+//
+//     int open_access = 0;
+//     if (desired_access & FileAccess::kGenericRead)  open_access |= O_RDONLY;
+//     if (desired_access & FileAccess::kGenericWrite) open_access |= O_WRONLY;
+//     if (desired_access & FileAccess::kGenericAll)   open_access |= O_RDWR;
+//     ...
+//     int handle = open(path.c_str(), open_access);
+//
+// O_RDONLY/O_WRONLY/O_RDWR are not bit flags. They are mutually exclusive
+// values occupying the low two bits (O_ACCMODE):
+//
+//     O_RDONLY = 0    O_WRONLY = 1    O_RDWR = 2    O_ACCMODE = 3
+//
+// So OR-ing them silently produces the wrong mode:
+//
+//     kGenericRead | kGenericWrite  ->  0 | 1  =  1  =  O_WRONLY   (read lost!)
+//     kGenericWrite | kGenericAll   ->  1 | 2  =  3  =  O_ACCMODE  (invalid)
+//
+// A save file is opened for read *and* write, which lands on the first case:
+// the descriptor comes back write-only. Every subsequent pread() then fails
+// with EBADF, HostPathFile::ReadSync turns that into X_STATUS_END_OF_FILE, and
+// the guest sees a zero-length / unreadable save -- i.e. "corrupted". The
+// second case is worse: open() rejects mode 3 with EINVAL, so the file cannot
+// be opened at all.
+//
+// This only affects Linux; the Win32 backend passes real GENERIC_* flags to
+// CreateFile, which do combine.
+//
+// Fix
+// ---
+// The SDK is upstream and cannot be patched, so this file provides its own
+// definition of FileHandle::OpenExisting that collapses the requested access
+// down to exactly one O_ACCMODE value before OR-ing in the modifier flags.
+//
+// Unlike the XAudio hooks, every caller of this function lives *inside*
+// librexruntimerd.so, so a plain link-time definition here would not be seen by
+// them. It works because the symbol is exported with default visibility and the
+// library is not linked -Bsymbolic, so its calls go through the PLT and resolve
+// against the global scope -- where the executable is searched first. reNut's
+// CMakeLists passes -Wl,--export-dynamic-symbol=<mangled name> to put this
+// definition into renut's dynamic symbol table so that lookup can find it.
+//
+// Also fixed here: on a failed read/write the SDK assigns the raw -1 from
+// pread/pwrite into *out_bytes_*, which underflows to SIZE_MAX for callers that
+// look at the count before the status. This version reports 0.
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+
+#include <rex/filesystem.h>
+
+namespace {
+
+class LinuxFileHandle final : public rex::filesystem::FileHandle {
+ public:
+  LinuxFileHandle(const std::filesystem::path& path, int handle)
+      : FileHandle(path), handle_(handle) {}
+
+  ~LinuxFileHandle() override {
+    if (handle_ != -1) {
+      close(handle_);
+      handle_ = -1;
+    }
+  }
+
+  bool Read(size_t file_offset, void* buffer, size_t buffer_length,
+            size_t* out_bytes_read) override {
+    ssize_t out = pread(handle_, buffer, buffer_length, static_cast<off_t>(file_offset));
+    if (out < 0) {
+      *out_bytes_read = 0;
+      return false;
+    }
+    *out_bytes_read = static_cast<size_t>(out);
+    return true;
+  }
+
+  bool Write(size_t file_offset, const void* buffer, size_t buffer_length,
+             size_t* out_bytes_written) override {
+    ssize_t out = pwrite(handle_, buffer, buffer_length, static_cast<off_t>(file_offset));
+    if (out < 0) {
+      *out_bytes_written = 0;
+      return false;
+    }
+    *out_bytes_written = static_cast<size_t>(out);
+    return true;
+  }
+
+  bool SetLength(size_t length) override {
+    return ftruncate(handle_, static_cast<off_t>(length)) >= 0;
+  }
+
+  void Flush() override { fsync(handle_); }
+
+ private:
+  int handle_ = -1;
+};
+
+}  // namespace
+
+namespace rex::filesystem {
+
+// Interposes the SDK's definition. Marked used so it survives even though
+// nothing inside renut calls it directly.
+__attribute__((used)) std::unique_ptr<FileHandle> FileHandle::OpenExisting(
+    const std::filesystem::path& path, uint32_t desired_access, bool /*allow_share_delete*/) {
+  // POSIX has no share-delete analog; unlinking an open file is always allowed.
+  const bool wants_read = (desired_access & (FileAccess::kGenericRead | FileAccess::kGenericExecute |
+                                             FileAccess::kGenericAll | FileAccess::kFileReadData)) != 0;
+  const bool wants_write =
+      (desired_access & (FileAccess::kGenericWrite | FileAccess::kGenericAll |
+                         FileAccess::kFileWriteData | FileAccess::kFileAppendData)) != 0;
+
+  // Exactly one access mode, never a bitwise mix.
+  int open_flags;
+  if (wants_read && wants_write) {
+    open_flags = O_RDWR;
+  } else if (wants_write) {
+    open_flags = O_WRONLY;
+  } else {
+    open_flags = O_RDONLY;
+  }
+
+  // Modifier flags are real bits and may be OR-ed in.
+  if (desired_access & FileAccess::kFileAppendData) {
+    open_flags |= O_APPEND;
+  }
+
+  int handle = open(path.c_str(), open_flags);
+  if (handle == -1) {
+    return nullptr;
+  }
+  return std::make_unique<LinuxFileHandle>(path, handle);
+}
+
+}  // namespace rex::filesystem

--- a/src/renut_engine/linuxfixes/xdg_paths.h
+++ b/src/renut_engine/linuxfixes/xdg_paths.h
@@ -1,0 +1,161 @@
+// XDG base-directory paths, so renut never writes next to its own executable.
+//
+// Why
+// ---
+// By default the SDK puts everything beside the binary:
+//
+//   rex_app.cpp:145   config_path = exe_dir / "<app>.toml"
+//   rex_app.cpp:170   log_dir     = exe_dir / "logs"
+//   path_config_store.h  <exe_dir>/<app>.cfg
+//
+// That is fine when running out of a build tree, but it breaks the moment renut
+// ships as anything users don't own the directory of -- an AppImage (read-only
+// squashfs mount), a Flatpak, or a system-wide install under /opt or /usr. The
+// app would fail to save its config and, worse, fail to open a log file just
+// when you most want one.
+//
+// This header resolves the three writable locations to the XDG base directory
+// spec instead:
+//
+//   config   $XDG_CONFIG_HOME/renut   (default ~/.config/renut)
+//   state    $XDG_STATE_HOME/renut    (default ~/.local/state/renut)
+//   logs     <state>/logs
+//
+// Game/user data already lands in ~/.local/share/renut via the path wizard, so
+// it needs no change here.
+//
+// Linux only, by design: on Windows the exe-relative layout is conventional and
+// writable, so that path is left exactly as it was. Every include of this header
+// is guarded by #ifndef _WIN32.
+//
+// Existing installs are migrated rather than abandoned: the first time a file is
+// wanted at its new location and is not there, an old copy sitting beside the
+// executable is copied across. That keeps a developer's working renut.cfg (with
+// their asset paths already filled in) after the switch.
+
+#pragma once
+
+#ifndef _WIN32
+
+#include <climits>
+#include <cstdlib>
+#include <filesystem>
+#include <string>
+#include <system_error>
+#include <unistd.h>
+
+namespace renut::linuxfixes {
+
+// Directory containing the running executable. Used only to find legacy files
+// to migrate, never as a write target.
+inline std::filesystem::path ExecutableDir() {
+  char buffer[PATH_MAX] = {};
+  const ssize_t len = ::readlink("/proc/self/exe", buffer, sizeof(buffer) - 1);
+  if (len > 0) {
+    return std::filesystem::path(std::string(buffer, static_cast<size_t>(len))).parent_path();
+  }
+  std::error_code ec;
+  auto cwd = std::filesystem::current_path(ec);
+  return ec ? std::filesystem::path(".") : cwd;
+}
+
+// Reads an XDG environment variable, ignoring the relative paths the spec says
+// to treat as unset. Falls back to $HOME/<fallback_suffix>.
+inline std::filesystem::path XdgDir(const char* env_name, const char* fallback_suffix) {
+  if (const char* value = std::getenv(env_name)) {
+    // The spec requires absolute paths; anything else must be ignored.
+    if (value[0] == '/') {
+      return std::filesystem::path(value);
+    }
+  }
+  const char* home = std::getenv("HOME");
+  if (!home || home[0] == '\0') {
+    // No HOME at all (unusual). Fall back to the CWD so we still land somewhere
+    // writable rather than trying to write into a read-only mount.
+    std::error_code ec;
+    auto cwd = std::filesystem::current_path(ec);
+    return (ec ? std::filesystem::path(".") : cwd) / ".renut";
+  }
+  return std::filesystem::path(home) / fallback_suffix;
+}
+
+inline std::filesystem::path ConfigDir() {
+  return XdgDir("XDG_CONFIG_HOME", ".config") / "renut";
+}
+
+inline std::filesystem::path StateDir() {
+  return XdgDir("XDG_STATE_HOME", ".local/state") / "renut";
+}
+
+inline std::filesystem::path LogDir() {
+  return StateDir() / "logs";
+}
+
+// Creates dir if needed. Returns false if it could not be created, letting
+// callers fall back rather than handing the SDK an unusable path.
+inline bool EnsureDir(const std::filesystem::path& dir) {
+  std::error_code ec;
+  std::filesystem::create_directories(dir, ec);
+  return !ec && std::filesystem::is_directory(dir, ec);
+}
+
+// Resolves a writable path for file_name inside dir, migrating a pre-existing
+// copy from beside the executable on first use.
+inline std::filesystem::path ResolveWithMigration(const std::filesystem::path& dir,
+                                                  const std::string& file_name) {
+  const auto target = dir / file_name;
+  std::error_code ec;
+
+  if (std::filesystem::exists(target, ec)) {
+    return target;
+  }
+  if (!EnsureDir(dir)) {
+    // Nowhere to put it; let the caller keep the old behaviour.
+    return ExecutableDir() / file_name;
+  }
+
+  const auto legacy = ExecutableDir() / file_name;
+  if (std::filesystem::exists(legacy, ec)) {
+    std::filesystem::copy_file(legacy, target, std::filesystem::copy_options::skip_existing, ec);
+    // If the copy failed the target simply will not exist yet, which is the same
+    // as a clean first run -- nothing is lost, so ec is deliberately ignored.
+  }
+  return target;
+}
+
+// Path for the next sequential log file, mirroring the SDK's NextSequentialLogPath
+// ("<app>_NNN.log"). Reimplemented here because setting the log_file cvar bypasses
+// the SDK's own sequencing, and losing per-run logs would be a regression.
+inline std::filesystem::path NextSequentialLog(const std::filesystem::path& dir,
+                                               const std::string& app_name) {
+  if (!EnsureDir(dir)) {
+    return {};
+  }
+
+  const std::string prefix = app_name + "_";
+  unsigned max_seq = 0;
+  std::error_code ec;
+  for (const auto& entry : std::filesystem::directory_iterator(dir, ec)) {
+    const std::string name = entry.path().filename().string();
+    if (name.size() < prefix.size() + 5 || name.compare(0, prefix.size(), prefix) != 0) {
+      continue;
+    }
+    if (entry.path().extension() != ".log") {
+      continue;
+    }
+    // Digits between the prefix and ".log"; skip rotated names like renut_001.1.log.
+    const std::string stem = entry.path().stem().string().substr(prefix.size());
+    if (stem.empty() || stem.find_first_not_of("0123456789") != std::string::npos) {
+      continue;
+    }
+    max_seq = std::max(max_seq, static_cast<unsigned>(std::strtoul(stem.c_str(), nullptr, 10)));
+  }
+
+  char name[64];
+  std::snprintf(name, sizeof(name), "%s_%03u.log", app_name.c_str(), max_seq + 1);
+  return dir / name;
+}
+
+}  // namespace renut::linuxfixes
+
+#endif  // !_WIN32

--- a/src/renut_engine/nativevk_phase0.cpp
+++ b/src/renut_engine/nativevk_phase0.cpp
@@ -13,6 +13,9 @@ namespace {
 
 std::atomic<uint64_t> g_frameDrawCount{0};
 std::atomic<uint64_t> g_lastFrameDrawCount{0};
+std::atomic<uint64_t> g_sessionFrameStarts{0};
+std::atomic<uint64_t> g_sessionFrameEnds{0};
+std::atomic<uint64_t> g_sessionTotalDraws{0};
 
 std::atomic<uint64_t> g_sessionSetVertexShaderCalls{0};
 std::atomic<uint64_t> g_sessionUnresolvedCalls{0};
@@ -28,6 +31,7 @@ std::unordered_set<uint32_t> g_handlesUnresolved;
 // those thunks can reach them.
 void CountDraw() {
     g_frameDrawCount.fetch_add(1, std::memory_order_relaxed);
+    g_sessionTotalDraws.fetch_add(1, std::memory_order_relaxed);
 }
 
 void RecordSetVertexShader(uint32_t handle) {
@@ -50,6 +54,9 @@ void RecordSetVertexShader(uint32_t handle) {
 Snapshot GetLatest() {
     Snapshot snapshot;
     snapshot.last_frame_draws = g_lastFrameDrawCount.load(std::memory_order_relaxed);
+    snapshot.session_frame_starts = g_sessionFrameStarts.load(std::memory_order_relaxed);
+    snapshot.session_frame_ends = g_sessionFrameEnds.load(std::memory_order_relaxed);
+    snapshot.session_total_draws = g_sessionTotalDraws.load(std::memory_order_relaxed);
     snapshot.session_set_vertex_shader_calls = g_sessionSetVertexShaderCalls.load(std::memory_order_relaxed);
     snapshot.session_unresolved_set_vertex_shader_calls = g_sessionUnresolvedCalls.load(std::memory_order_relaxed);
     std::lock_guard<std::mutex> lock(g_handleMutex);
@@ -59,17 +66,36 @@ Snapshot GetLatest() {
 }
 
 // Wired from FPS.cpp's appMainDrawStart/appMainDrawend (config/renut_hooks.toml,
-// address 0x82222250 -- already wraps the guest's ENTIRE per-frame draw
-// submission, see REX_HOOK_RAW(appMainDraw) in FPS.cpp). Using this existing
-// frame boundary rather than Present/Swap keeps Phase 0's draw count scoped
-// to exactly the same span the SDK's own real per-frame "draws" trace stat
-// (trace_stats.cpp) covers, so the two numbers are directly comparable.
+// address 0x82222250, appMainDraw's real entry point per config/renut_funcs.toml).
+//
+// Real, confirmed bug (2026-08-19, playtest diagnostics): appMainDrawStart
+// NEVER fires -- confirmed via `grep appMainDrawStart generated/*.cpp`
+// finding zero matches, only appMainDrawend. rexglue's codegen silently
+// drops one of two midasm_hook entries sharing the same address (same
+// pattern confirmed on the sibling appMainTickPreDrawStart/end pair -- only
+// "end" survives there too). So FrameStart() below is effectively dead code
+// today (kept in case a future codegen fix makes the pair work again, which
+// would just make these two calls redundant, not wrong). FrameEnd() alone
+// is made self-contained (atomic exchange, not separate load+store) so it
+// works correctly whether or not FrameStart ever actually runs alongside it.
+//
+// Second confirmed issue: even the one working hook only fired 8765 times
+// against the SDK's own 14218 real frames in the same session (~62%) -- this
+// address is NOT a reliable 1:1-with-real-frames marker (likely a guest
+// tick-rate/frame-pacing mismatch, not another codegen bug). That makes any
+// single "last frame" snapshot fundamentally unreliable here, not just
+// broken by the dead-hook bug above -- see Snapshot::last_frame_draws and
+// the diagnostics fields' own comments. GetLatest() callers should prefer
+// comparing session_total_draws against trace_stats' session_draws_total
+// (both cumulative, no frame-alignment assumption needed) over
+// last_frame_draws for the actual Phase 0 go/no-go call.
 void FrameStart() {
-    g_frameDrawCount.store(0, std::memory_order_relaxed);
+    g_sessionFrameStarts.fetch_add(1, std::memory_order_relaxed);
 }
 
 void FrameEnd() {
-    g_lastFrameDrawCount.store(g_frameDrawCount.load(std::memory_order_relaxed), std::memory_order_relaxed);
+    g_sessionFrameEnds.fetch_add(1, std::memory_order_relaxed);
+    g_lastFrameDrawCount.store(g_frameDrawCount.exchange(0, std::memory_order_relaxed), std::memory_order_relaxed);
 }
 
 }  // namespace renut::nativevk_phase0

--- a/src/renut_engine/nativevk_phase0.cpp
+++ b/src/renut_engine/nativevk_phase0.cpp
@@ -1,0 +1,102 @@
+#include "renut_engine/nativevk_phase0.h"
+#include "renut_engine/shader_dump.h"
+
+#include <atomic>
+#include <mutex>
+#include <unordered_set>
+
+#include <rex/ppc.h>
+
+namespace renut::nativevk_phase0 {
+
+namespace {
+
+std::atomic<uint64_t> g_frameDrawCount{0};
+std::atomic<uint64_t> g_lastFrameDrawCount{0};
+
+std::atomic<uint64_t> g_sessionSetVertexShaderCalls{0};
+std::atomic<uint64_t> g_sessionUnresolvedCalls{0};
+
+std::mutex g_handleMutex;
+std::unordered_set<uint32_t> g_handlesSeen;
+std::unordered_set<uint32_t> g_handlesUnresolved;
+
+}  // namespace
+
+// Called from the global-scope hook thunks at the bottom of this file --
+// kept internal-linkage-free (not in the anonymous namespace above) so
+// those thunks can reach them.
+void CountDraw() {
+    g_frameDrawCount.fetch_add(1, std::memory_order_relaxed);
+}
+
+void RecordSetVertexShader(uint32_t handle) {
+    g_sessionSetVertexShaderCalls.fetch_add(1, std::memory_order_relaxed);
+
+    uint64_t hash = 0;
+    const bool resolved = renut::shader_dump::TryResolveShaderUcodeHash(handle, hash);
+    if (!resolved) {
+        g_sessionUnresolvedCalls.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    std::lock_guard<std::mutex> lock(g_handleMutex);
+    if (g_handlesSeen.insert(handle).second) {
+        if (!resolved) g_handlesUnresolved.insert(handle);
+    } else if (resolved) {
+        g_handlesUnresolved.erase(handle);
+    }
+}
+
+Snapshot GetLatest() {
+    Snapshot snapshot;
+    snapshot.last_frame_draws = g_lastFrameDrawCount.load(std::memory_order_relaxed);
+    snapshot.session_set_vertex_shader_calls = g_sessionSetVertexShaderCalls.load(std::memory_order_relaxed);
+    snapshot.session_unresolved_set_vertex_shader_calls = g_sessionUnresolvedCalls.load(std::memory_order_relaxed);
+    std::lock_guard<std::mutex> lock(g_handleMutex);
+    snapshot.session_distinct_handles_seen = g_handlesSeen.size();
+    snapshot.session_distinct_handles_unresolved = g_handlesUnresolved.size();
+    return snapshot;
+}
+
+// Wired from FPS.cpp's appMainDrawStart/appMainDrawend (config/renut_hooks.toml,
+// address 0x82222250 -- already wraps the guest's ENTIRE per-frame draw
+// submission, see REX_HOOK_RAW(appMainDraw) in FPS.cpp). Using this existing
+// frame boundary rather than Present/Swap keeps Phase 0's draw count scoped
+// to exactly the same span the SDK's own real per-frame "draws" trace stat
+// (trace_stats.cpp) covers, so the two numbers are directly comparable.
+void FrameStart() {
+    g_frameDrawCount.store(0, std::memory_order_relaxed);
+}
+
+void FrameEnd() {
+    g_lastFrameDrawCount.store(g_frameDrawCount.load(std::memory_order_relaxed), std::memory_order_relaxed);
+}
+
+}  // namespace renut::nativevk_phase0
+
+// Hook thunks below are deliberately global-scope (not inside the namespace
+// above) -- every other midasm_hook target in this codebase (shader_dump.cpp,
+// FPS.cpp, hooks.cpp) is a plain global function, matched by name against
+// config/renut_hooks.toml's [[midasm_hook]] "name" field.
+
+// Read-only hooks on the four D3D9 draw entry points (config/renut_gpu_funcs.toml):
+// DrawVertices (0x8222C7A0), DrawIndexedVertices (0x826567C8), DrawVerticesUP
+// (0x8222E520), DrawIndexedVerticesUP (0x82656728). Just count -- no register
+// values needed, so registers = [] in config/renut_hooks.toml and these take
+// no PPCRegister arguments.
+void phase0DrawVertices_hook() { renut::nativevk_phase0::CountDraw(); }
+void phase0DrawIndexedVertices_hook() { renut::nativevk_phase0::CountDraw(); }
+void phase0DrawVerticesUP_hook() { renut::nativevk_phase0::CountDraw(); }
+void phase0DrawIndexedVerticesUP_hook() { renut::nativevk_phase0::CountDraw(); }
+
+// A second, independent midasm_hook at the SAME address as
+// dumpVertexShaderSet_hook (0x8222A0A8, shader_dump.cpp) -- confirmed
+// supported by rexglue's hook codegen (config/renut_hooks.toml already has
+// other duplicate-address pairs, e.g. 0x82222250's appMainDrawStart/end).
+// Deliberately NOT reusing dumpVertexShaderSet_hook itself: that function
+// (and everything it does -- dumpObjectHex, vertdecl-usage dumping) is
+// gated behind the unrelated renut_dump_vertex_decl cvar, so Phase 0
+// measurement must not depend on a user having that dump feature on.
+void phase0SetVertexShader_hook(PPCRegister&, PPCRegister& r4) {
+    renut::nativevk_phase0::RecordSetVertexShader(r4.u32);
+}

--- a/src/renut_engine/nativevk_phase0.h
+++ b/src/renut_engine/nativevk_phase0.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <cstdint>
+
+// Phase 0 of the SDK-independent native renderer rewrite (see
+// docs/ai/archive/native-renderer-rewrite-plan.md): validates, read-only,
+// whether hooking D3D9 draw/state calls directly at their guest addresses
+// (the new architecture's whole foundation) actually sees close to 100% of
+// real draws, and whether shader identity is resolvable for draws whose
+// vertex shader bypassed CreateVertexShader via IM_LOAD. Counts/logs only --
+// no rendering behavior changes.
+namespace renut::nativevk_phase0 {
+
+struct Snapshot {
+    // D3D9-hook draw count for the last fully-completed frame (sum of
+    // DrawVertices/DrawIndexedVertices/DrawVerticesUP/DrawIndexedVerticesUP
+    // hook hits between one appMainDrawStart and the next). Compare against
+    // trace_stats::GetLatest()'s "draws" value (the SDK's own real Vulkan
+    // draw-submission count) -- close agreement is Phase 0's coverage gate.
+    uint64_t last_frame_draws = 0;
+
+    // Session-lifetime SetVertexShader (0x8222A0A8) call count, and how many
+    // of those calls carried a handle TryResolveShaderUcodeHash could NOT
+    // resolve (i.e. the handle's shader never went through CreateVertexShader
+    // -- the known IM_LOAD-bypass risk this phase must measure, not assume).
+    uint64_t session_set_vertex_shader_calls = 0;
+    uint64_t session_unresolved_set_vertex_shader_calls = 0;
+
+    // Distinct (deduplicated) handle counts for the same measurement, since
+    // a single frequently-redrawn shader would otherwise dominate the raw
+    // call counts above and hide how many DISTINCT shaders are affected.
+    uint64_t session_distinct_handles_seen = 0;
+    uint64_t session_distinct_handles_unresolved = 0;
+};
+
+Snapshot GetLatest();
+
+// Called from FPS.cpp's appMainDrawStart/appMainDrawend (the guest's real
+// per-frame draw-submission boundary, config/renut_hooks.toml address
+// 0x82222250) to scope last_frame_draws to one frame.
+void FrameStart();
+void FrameEnd();
+
+// Called from this file's own global-scope hook thunks (nativevk_phase0.cpp)
+// -- declared here, not file-local, so their purpose is documented next to
+// the rest of this module's API.
+void CountDraw();
+void RecordSetVertexShader(uint32_t handle);
+
+}

--- a/src/renut_engine/nativevk_phase0.h
+++ b/src/renut_engine/nativevk_phase0.h
@@ -12,12 +12,28 @@
 namespace renut::nativevk_phase0 {
 
 struct Snapshot {
-    // D3D9-hook draw count for the last fully-completed frame (sum of
-    // DrawVertices/DrawIndexedVertices/DrawVerticesUP/DrawIndexedVerticesUP
-    // hook hits between one appMainDrawStart and the next). Compare against
-    // trace_stats::GetLatest()'s "draws" value (the SDK's own real Vulkan
-    // draw-submission count) -- close agreement is Phase 0's coverage gate.
+    // D3D9-hook draw count between the two most recent appMainDrawend hook
+    // fires (see FrameEnd()'s own comment for real, confirmed problems with
+    // treating this as "one real frame" -- appMainDrawStart never fires at
+    // all, and even the one working hook only covers ~62% of the SDK's own
+    // real frame count in testing). Kept as a rough diagnostic only --
+    // PREFER session_total_draws vs trace_stats::GetLatest()'s
+    // "session_draws_total" (both session-cumulative) for the actual Phase 0
+    // coverage gate, since that comparison needs no frame-alignment
+    // assumption at all.
     uint64_t last_frame_draws = 0;
+
+    // Raw diagnostic counters (2026-08-19): confirmed via
+    // `grep appMainDrawStart generated/*.cpp` (zero matches) that rexglue's
+    // codegen silently drops one of two midasm_hook entries sharing an
+    // address -- appMainDrawStart never fires, only appMainDrawend does, and
+    // even that one only fired 8765 times against the SDK's own 14218 real
+    // frames in one session (~62%). session_total_draws is the reliable
+    // session-cumulative D3D9-hook draw count -- compare it against
+    // trace_stats' own session-cumulative "session_draws_total".
+    uint64_t session_frame_starts = 0;
+    uint64_t session_frame_ends = 0;
+    uint64_t session_total_draws = 0;
 
     // Session-lifetime SetVertexShader (0x8222A0A8) call count, and how many
     // of those calls carried a handle TryResolveShaderUcodeHash could NOT

--- a/src/renut_engine/overlays/ab_benchmark_overlay.h
+++ b/src/renut_engine/overlays/ab_benchmark_overlay.h
@@ -1,8 +1,7 @@
 #pragma once
 
 #include "imgui.h"
-
-#include <dlfcn.h>
+#include "renut_engine/overlays/dl_compat.h"
 
 // Content-only: no window/Begin/End, no hotkey. Hosted as a tab inside
 // DebugHubOverlayDialog (see debug_hub_overlay.h), which owns the single F5
@@ -29,21 +28,29 @@ inline const Api& Get() {
     static const Api api = [] {
         Api result;
         // The plugin is already resident (the graphics system came from it), so
-        // RTLD_NOLOAD just takes a handle to it rather than loading a second copy.
-        void* self = dlopen("librexgpu-nativevkrd.so", RTLD_LAZY | RTLD_NOLOAD);
+        // this only ever takes a handle to an already-loaded module, never a
+        // real load -- see dl_compat.h's own comment for why that matters.
+#ifdef _WIN32
+        void* self = RenutDlOpenNoLoad("rexgpu-nativevkrd.dll");
         if (!self) {
-            self = dlopen("librexgpu-nativevk.so", RTLD_LAZY | RTLD_NOLOAD);
+            self = RenutDlOpenNoLoad("rexgpu-nativevk.dll");
         }
+#else
+        void* self = RenutDlOpenNoLoad("librexgpu-nativevkrd.so");
+        if (!self) {
+            self = RenutDlOpenNoLoad("librexgpu-nativevk.so");
+        }
+#endif
         if (!self) {
             // Fall back to a global lookup for builds that link it directly.
-            self = dlopen(nullptr, RTLD_LAZY);
+            self = RenutDlOpenSelf();
         }
         if (self) {
-            result.start = reinterpret_cast<void (*)()>(dlsym(self, "renut_ab_start"));
-            result.stop = reinterpret_cast<void (*)()>(dlsym(self, "renut_ab_stop"));
-            result.is_active = reinterpret_cast<int (*)()>(dlsym(self, "renut_ab_is_active"));
-            result.status = reinterpret_cast<const char* (*)()>(dlsym(self, "renut_ab_status"));
-            dlclose(self);
+            result.start = reinterpret_cast<void (*)()>(RenutDlSym(self, "renut_ab_start"));
+            result.stop = reinterpret_cast<void (*)()>(RenutDlSym(self, "renut_ab_stop"));
+            result.is_active = reinterpret_cast<int (*)()>(RenutDlSym(self, "renut_ab_is_active"));
+            result.status = reinterpret_cast<const char* (*)()>(RenutDlSym(self, "renut_ab_status"));
+            RenutDlClose(self);
         }
         return result;
     }();

--- a/src/renut_engine/overlays/ab_benchmark_overlay.h
+++ b/src/renut_engine/overlays/ab_benchmark_overlay.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include "imgui.h"
+
+#include <dlfcn.h>
+
+// Content-only: no window/Begin/End, no hotkey. Hosted as a tab inside
+// DebugHubOverlayDialog (see debug_hub_overlay.h), which owns the single F5
+// toggle shared by all the renderer debug panels.
+//
+// Drives the GPU plugin's alternating A/B benchmark and shows its progress.
+// The plugin is loaded with dlopen, so its symbols are resolved at runtime
+// rather than linked. When they are missing - a stock xenos build, or a
+// plugin without the benchmark - this reports that instead of failing.
+namespace renut::overlays::ab_benchmark {
+
+namespace detail {
+
+struct Api {
+    void (*start)() = nullptr;
+    void (*stop)() = nullptr;
+    int (*is_active)() = nullptr;
+    const char* (*status)() = nullptr;
+
+    bool Available() const { return start && stop && is_active && status; }
+};
+
+inline const Api& Get() {
+    static const Api api = [] {
+        Api result;
+        // The plugin is already resident (the graphics system came from it), so
+        // RTLD_NOLOAD just takes a handle to it rather than loading a second copy.
+        void* self = dlopen("librexgpu-nativevkrd.so", RTLD_LAZY | RTLD_NOLOAD);
+        if (!self) {
+            self = dlopen("librexgpu-nativevk.so", RTLD_LAZY | RTLD_NOLOAD);
+        }
+        if (!self) {
+            // Fall back to a global lookup for builds that link it directly.
+            self = dlopen(nullptr, RTLD_LAZY);
+        }
+        if (self) {
+            result.start = reinterpret_cast<void (*)()>(dlsym(self, "renut_ab_start"));
+            result.stop = reinterpret_cast<void (*)()>(dlsym(self, "renut_ab_stop"));
+            result.is_active = reinterpret_cast<int (*)()>(dlsym(self, "renut_ab_is_active"));
+            result.status = reinterpret_cast<const char* (*)()>(dlsym(self, "renut_ab_status"));
+            dlclose(self);
+        }
+        return result;
+    }();
+    return api;
+}
+
+inline void Toggle(const Api& api) {
+    if (!api.Available()) {
+        return;
+    }
+    if (api.is_active() != 0) {
+        api.stop();
+    } else {
+        api.start();
+    }
+}
+
+}  // namespace detail
+
+inline void DrawContent() {
+    const detail::Api& api = detail::Get();
+    if (!api.Available()) {
+        ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.4f, 1.0f),
+                           "Benchmark not available in this GPU plugin.");
+        ImGui::TextWrapped(
+            "This benchmark harness was part of the old renut plugin's diagnostic "
+            "instrumentation, removed while shrinking the rexglue-sdk patch to a "
+            "minimal, principled diff (see docs/ai/history.md). Not currently wired "
+            "up in rexgpu-nativevk.");
+        return;
+    }
+
+    const bool running = api.is_active() != 0;
+    if (ImGui::Button(running ? "Stop" : "Start", ImVec2(120.0f, 0.0f))) {
+        detail::Toggle(api);
+    }
+    ImGui::SameLine();
+    if (running) {
+        ImGui::TextColored(ImVec4(1.0f, 0.85f, 0.3f, 1.0f), "running");
+    } else {
+        ImGui::TextDisabled("idle");
+    }
+
+    ImGui::Separator();
+    ImGui::TextUnformatted(api.status());
+    ImGui::Separator();
+    ImGui::TextDisabled("A = stock path, B = optimisation under test.");
+    ImGui::TextDisabled("Stand somewhere busy and keep the camera still.");
+}
+
+}  // namespace renut::overlays::ab_benchmark

--- a/src/renut_engine/overlays/debug_hub_overlay.h
+++ b/src/renut_engine/overlays/debug_hub_overlay.h
@@ -6,16 +6,19 @@
 #include "imgui.h"
 #include "renut_engine/game_activity_stats.h"
 #include "renut_engine/overlays/ab_benchmark_overlay.h"
+#include "renut_engine/overlays/dl_compat.h"
 #include "renut_engine/overlays/render_stats_overlay.h"
-
-#include <dlfcn.h>
 
 // One F5 window hosting the three renderer debug panels (Renderer
 // performance, A/B benchmark, Native shader debug) as tabs, instead of three
 // separately-toggled/always-on windows scattered around the screen. The
 // native-shader tab's content lives in the GPU plugin (only rexgpu-nativevk
-// has one) and is pulled in with dlsym, the same cross-module pattern
-// ab_benchmark_overlay.h already used for renut_ab_*.
+// has one) and is pulled in with dl_compat.h's dlsym-equivalent, the same
+// cross-module pattern ab_benchmark_overlay.h already used for renut_ab_*.
+// Available on Windows too (see dl_compat.h) as of 2026-08-19 -- previously
+// this whole dialog, including the Performance tab (which needs no plugin
+// symbol lookup at all), was compiled out of Windows builds entirely because
+// only the Native Shaders/A-B Benchmark tabs actually needed dlopen/dlsym.
 class DebugHubOverlayDialog : public rex::ui::ImGuiDialog {
 public:
     explicit DebugHubOverlayDialog(rex::ui::ImGuiDrawer* drawer) : rex::ui::ImGuiDialog(drawer) {
@@ -69,20 +72,27 @@ private:
         if (!native_shader_resolved_) {
             native_shader_resolved_ = true;
             // The plugin is already resident (the graphics system came from
-            // it), so RTLD_NOLOAD just takes a handle to it rather than
-            // loading a second copy.
-            void* self = dlopen("librexgpu-nativevkrd.so", RTLD_LAZY | RTLD_NOLOAD);
+            // it), so this only ever takes a handle to an already-loaded
+            // module, never a real load -- see dl_compat.h's own comment.
+#ifdef _WIN32
+            void* self = RenutDlOpenNoLoad("rexgpu-nativevkrd.dll");
             if (!self) {
-                self = dlopen("librexgpu-nativevk.so", RTLD_LAZY | RTLD_NOLOAD);
+                self = RenutDlOpenNoLoad("rexgpu-nativevk.dll");
             }
+#else
+            void* self = RenutDlOpenNoLoad("librexgpu-nativevkrd.so");
+            if (!self) {
+                self = RenutDlOpenNoLoad("librexgpu-nativevk.so");
+            }
+#endif
             if (!self) {
                 // Fall back to a global lookup for builds that link it directly.
-                self = dlopen(nullptr, RTLD_LAZY);
+                self = RenutDlOpenSelf();
             }
             if (self) {
                 native_shader_draw_ = reinterpret_cast<void (*)()>(
-                    dlsym(self, "RenutNativeShaderDebugPanelDrawContent"));
-                dlclose(self);
+                    RenutDlSym(self, "RenutNativeShaderDebugPanelDrawContent"));
+                RenutDlClose(self);
             }
         }
         if (!native_shader_draw_) {

--- a/src/renut_engine/overlays/debug_hub_overlay.h
+++ b/src/renut_engine/overlays/debug_hub_overlay.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#include <rex/ui/imgui_dialog.h>
+#include <rex/ui/keybinds.h>
+
+#include "imgui.h"
+#include "renut_engine/game_activity_stats.h"
+#include "renut_engine/overlays/ab_benchmark_overlay.h"
+#include "renut_engine/overlays/render_stats_overlay.h"
+
+#include <dlfcn.h>
+
+// One F5 window hosting the three renderer debug panels (Renderer
+// performance, A/B benchmark, Native shader debug) as tabs, instead of three
+// separately-toggled/always-on windows scattered around the screen. The
+// native-shader tab's content lives in the GPU plugin (only rexgpu-nativevk
+// has one) and is pulled in with dlsym, the same cross-module pattern
+// ab_benchmark_overlay.h already used for renut_ab_*.
+class DebugHubOverlayDialog : public rex::ui::ImGuiDialog {
+public:
+    explicit DebugHubOverlayDialog(rex::ui::ImGuiDrawer* drawer) : rex::ui::ImGuiDialog(drawer) {
+        rex::ui::RegisterBind("bind_renut_debug_hub", "F5",
+            "Toggle renderer debug panels (performance / A-B benchmark / native shaders)", [this] {
+                visible_ = !visible_;
+                renut::game_activity_stats::SetEnabled(visible_);
+            });
+    }
+
+    ~DebugHubOverlayDialog() {
+        rex::ui::UnregisterBind("bind_renut_debug_hub");
+    }
+
+    void OnDraw(ImGuiIO&) override {
+        if (!visible_) {
+            return;
+        }
+        ImGui::SetNextWindowPos(ImVec2(10.0f, 130.0f), ImGuiCond_FirstUseEver);
+        ImGui::SetNextWindowBgAlpha(0.72f);
+        ImGui::SetNextWindowSize(ImVec2(560.0f, 680.0f), ImGuiCond_FirstUseEver);
+        const ImGuiWindowFlags flags = ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoNav;
+        if (!ImGui::Begin("Renderer debug##RenutDebugHub", &visible_, flags)) {
+            ImGui::End();
+            return;
+        }
+        if (ImGui::BeginTabBar("RenutDebugHubTabs")) {
+            if (ImGui::BeginTabItem("Performance")) {
+                renut::overlays::render_stats::DrawContent();
+                ImGui::EndTabItem();
+            }
+            if (ImGui::BeginTabItem("A/B Benchmark")) {
+                renut::overlays::ab_benchmark::DrawContent();
+                ImGui::EndTabItem();
+            }
+            if (ImGui::BeginTabItem("Native Shaders")) {
+                DrawNativeShaderTab();
+                ImGui::EndTabItem();
+            }
+            ImGui::EndTabBar();
+        }
+        ImGui::End();
+    }
+
+private:
+    bool visible_ = false;
+    void (*native_shader_draw_)() = nullptr;
+    bool native_shader_resolved_ = false;
+
+    void DrawNativeShaderTab() {
+        if (!native_shader_resolved_) {
+            native_shader_resolved_ = true;
+            // The plugin is already resident (the graphics system came from
+            // it), so RTLD_NOLOAD just takes a handle to it rather than
+            // loading a second copy.
+            void* self = dlopen("librexgpu-nativevkrd.so", RTLD_LAZY | RTLD_NOLOAD);
+            if (!self) {
+                self = dlopen("librexgpu-nativevk.so", RTLD_LAZY | RTLD_NOLOAD);
+            }
+            if (!self) {
+                // Fall back to a global lookup for builds that link it directly.
+                self = dlopen(nullptr, RTLD_LAZY);
+            }
+            if (self) {
+                native_shader_draw_ = reinterpret_cast<void (*)()>(
+                    dlsym(self, "RenutNativeShaderDebugPanelDrawContent"));
+                dlclose(self);
+            }
+        }
+        if (!native_shader_draw_) {
+            ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.4f, 1.0f),
+                               "Native shader debug panel not available in this GPU plugin.");
+            ImGui::TextWrapped("Run with gpu_plugin = \"nativevk\" in renut.toml.");
+            return;
+        }
+        native_shader_draw_();
+    }
+};

--- a/src/renut_engine/overlays/dl_compat.h
+++ b/src/renut_engine/overlays/dl_compat.h
@@ -1,0 +1,60 @@
+#pragma once
+
+// Minimal dlopen/dlsym/dlclose shim so the F5 debug hub's cross-plugin
+// symbol lookups (native-shader tab, A/B benchmark tab -- see
+// debug_hub_overlay.h and ab_benchmark_overlay.h) work on Windows too,
+// instead of compiling the whole debug hub out of Windows builds entirely
+// (previously done in renut_app.h; see that file's git history).
+//
+// Both call sites only ever want a handle to an ALREADY-loaded module (the
+// GPU plugin is resident because the graphics system came from it) -- never
+// a real load. On POSIX that's RTLD_NOLOAD; on Windows the equivalent is
+// GetModuleHandle, which (unlike LoadLibrary) does NOT increment the
+// module's reference count. That asymmetry is why RenutDlClose() is a no-op
+// on Windows: calling FreeLibrary on a GetModuleHandle-obtained handle would
+// wrongly decrement a refcount this code never incremented, risking
+// unloading a plugin still in use elsewhere. POSIX dlclose() after a
+// successful RTLD_NOLOAD dlopen is safe and balanced (every successful
+// dlopen call, NOLOAD included, increments the refcount once), so that side
+// keeps calling the real dlclose().
+
+#ifdef _WIN32
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+inline void* RenutDlOpenNoLoad(const char* name) {
+    return reinterpret_cast<void*>(GetModuleHandleA(name));
+}
+
+inline void* RenutDlOpenSelf() {
+    return reinterpret_cast<void*>(GetModuleHandleA(nullptr));
+}
+
+inline void* RenutDlSym(void* handle, const char* name) {
+    return handle ? reinterpret_cast<void*>(GetProcAddress(reinterpret_cast<HMODULE>(handle), name)) : nullptr;
+}
+
+inline void RenutDlClose(void*) {}
+
+#else
+
+#include <dlfcn.h>
+
+inline void* RenutDlOpenNoLoad(const char* name) {
+    return dlopen(name, RTLD_LAZY | RTLD_NOLOAD);
+}
+
+inline void* RenutDlOpenSelf() {
+    return dlopen(nullptr, RTLD_LAZY);
+}
+
+inline void* RenutDlSym(void* handle, const char* name) {
+    return handle ? dlsym(handle, name) : nullptr;
+}
+
+inline void RenutDlClose(void* handle) {
+    if (handle) dlclose(handle);
+}
+
+#endif

--- a/src/renut_engine/overlays/path_setup_wizard.h
+++ b/src/renut_engine/overlays/path_setup_wizard.h
@@ -6,8 +6,15 @@
 #include <filesystem>
 #include <functional>
 #include <string>
+
+#ifdef _WIN32
 #include <shobjidl.h>
 #include <windows.h>
+#else
+#include <array>
+#include <cstdio>
+#include <sys/wait.h>
+#endif
 
 class PathSetupWizard : public rex::ui::ImGuiDialog {
 public:
@@ -27,7 +34,7 @@ public:
 
         // First-run check — if a valid saved config exists, skip the wizard entirely
         if (auto saved = PathConfigStore::TryLoad(app_name)) {
-            rex::PathConfig cfg;
+            rex::PathConfig cfg = defaults;
             cfg.game_data_root = saved->game_data_root;
             cfg.user_data_root = saved->user_data_root;
             cfg.update_data_root = saved->update_data_root;
@@ -36,6 +43,7 @@ public:
         }
 
         // No saved config — show the wizard
+        defaults_ = defaults;
         game_data_buf_ = defaults.game_data_root.string();
         user_data_buf_ = defaults.user_data_root.string();
         update_data_buf_ = defaults.update_data_root.string();
@@ -108,6 +116,7 @@ private:
         }
     }
 
+#ifdef _WIN32
     static std::string BrowseForFolder(const char* default_path) {
         std::string result;
         IFileDialog* dlg = nullptr;
@@ -152,6 +161,58 @@ private:
         dlg->Release();
         return result;
     }
+#else
+    static std::string ShellQuote(const std::string& s) {
+        std::string out = "'";
+        for (char c : s) {
+            if (c == '\'') out += "'\\''";
+            else out += c;
+        }
+        out += "'";
+        return out;
+    }
+
+    // Runs a picker command and returns its trimmed stdout, or (found=false) if
+    // the command itself couldn't be run (e.g. the binary isn't installed).
+    static std::string RunPicker(const std::string& cmd, bool& found) {
+        found = true;
+        FILE* pipe = popen(cmd.c_str(), "r");
+        if (!pipe) { found = false; return std::string(); }
+
+        std::string result;
+        std::array<char, 512> buf;
+        size_t n;
+        while ((n = fread(buf.data(), 1, buf.size(), pipe)) > 0)
+            result.append(buf.data(), n);
+
+        int status = pclose(pipe);
+        if (WIFEXITED(status) && WEXITSTATUS(status) == 127)
+            found = false;  // shell couldn't find the binary
+
+        while (!result.empty() && (result.back() == '\n' || result.back() == '\r'))
+            result.pop_back();
+        return result;
+    }
+
+    // No SDL/portal dialog integration here (would need to pump the event loop
+    // while blocked); shell out to whichever native picker is installed instead.
+    static std::string BrowseForFolder(const char* default_path) {
+        bool found = false;
+        std::string cmd = "zenity --file-selection --directory --title=\"Select Folder\"";
+        if (default_path && default_path[0])
+            cmd += " --filename=" + ShellQuote(std::string(default_path) + "/");
+        cmd += " 2>/dev/null";
+
+        std::string result = RunPicker(cmd, found);
+        if (found) return result;
+
+        cmd = "kdialog --getexistingdirectory " +
+            ShellQuote((default_path && default_path[0]) ? default_path : ".") +
+            " 2>/dev/null";
+        result = RunPicker(cmd, found);
+        return result;
+    }
+#endif
 
     void TryCommit() {
         std::filesystem::path game = game_data_buf_.c_str();
@@ -174,7 +235,7 @@ private:
         visible_ = false;
         error_.clear();
 
-        rex::PathConfig cfg;
+        rex::PathConfig cfg = defaults_;
         cfg.game_data_root = std::move(game);
         cfg.user_data_root = std::move(user);
         cfg.update_data_root = std::move(update);
@@ -188,11 +249,12 @@ private:
         on_complete_(std::move(cfg));
     }
 
-    std::string  app_name_;
-    bool         visible_ = false;
-    std::string  game_data_buf_;
-    std::string  user_data_buf_;
-    std::string  update_data_buf_;
-    std::string  error_;
-    CompletionFn on_complete_;
+    std::string     app_name_;
+    rex::PathConfig defaults_;
+    bool            visible_ = false;
+    std::string     game_data_buf_;
+    std::string     user_data_buf_;
+    std::string     update_data_buf_;
+    std::string     error_;
+    CompletionFn    on_complete_;
 };

--- a/src/renut_engine/overlays/render_stats_overlay.h
+++ b/src/renut_engine/overlays/render_stats_overlay.h
@@ -1,0 +1,206 @@
+#pragma once
+
+#include "imgui.h"
+#include "renut_engine/Fps.h"
+#include "renut_engine/game_activity_stats.h"
+#include "renut_engine/trace_stats.h"
+
+// Content-only: no window/Begin/End, no hotkey. Hosted as a tab inside
+// DebugHubOverlayDialog (see debug_hub_overlay.h), which owns the single F5
+// toggle shared by all the renderer debug panels.
+namespace renut::overlays::render_stats {
+
+namespace detail {
+
+inline bool Has(const renut::trace_stats::Snapshot& trace, const char* name) {
+    return trace.values.find(name) != trace.values.end();
+}
+
+inline double Value(const renut::trace_stats::Snapshot& trace, const char* name) {
+    const auto found = trace.values.find(name);
+    return found == trace.values.end() ? 0.0 : found->second;
+}
+
+// Every field below is only present in trace.values if this build's
+// command_processor.cpp instrumentation actually measures it (see
+// RenutEmitTraceRow in trace_stats.cpp) -- an absent key means "not
+// wired up", not "measured as zero". Show that distinctly instead of a
+// misleading 0.00, so a genuinely idle stat and an unimplemented one
+// don't look identical.
+inline void Unmeasured(const char* label) {
+    ImGui::TextDisabled("%-28s     n/a  (not measured)", label);
+}
+
+inline void Time(const renut::trace_stats::Snapshot& trace, const char* label, const char* value) {
+    if (!Has(trace, value)) {
+        Unmeasured(label);
+        return;
+    }
+    ImGui::Text("%-28s %7.2f ms", label, Value(trace, value));
+}
+
+inline void Count(const renut::trace_stats::Snapshot& trace, const char* label, const char* value) {
+    if (!Has(trace, value)) {
+        Unmeasured(label);
+        return;
+    }
+    ImGui::Text("%-28s %7.0f", label, Value(trace, value));
+}
+
+inline void Rate(const renut::trace_stats::Snapshot& trace, const char* label, const char* value) {
+    if (!Has(trace, value)) {
+        Unmeasured(label);
+        return;
+    }
+    ImGui::Text("%-28s %7.1f ns", label, Value(trace, value));
+}
+
+inline void DrawTrace(const renut::trace_stats::Snapshot& trace) {
+    ImGui::Separator();
+    ImGui::TextUnformatted("GPU trace: latest frame");
+    ImGui::TextDisabled("%s", trace.path.c_str());
+    Time(trace, "Frame", "frame_ms");
+    Rate(trace, "Draw submission per draw", "ns_per_draw");
+    ImGui::TextDisabled("Normalised cost: compare this, not raw ms, across runs (draw count varies a lot).");
+    Time(trace, "CPU blocked on GPU", "gpuwait_ms");
+    Time(trace, "Draw submission", "issuedraw_ms");
+    Time(trace, "Texture requests", "tex_ms");
+    Time(trace, "Descriptor bindings", "bind_ms");
+    Time(trace, "Vertex residency", "vfetch_ms");
+    Time(trace, "Samplers", "samp_ms");
+    Time(trace, "Render targets", "rt_ms");
+    Time(trace, "Pipeline setup", "pipe_ms");
+    Time(trace, "Present", "swap_ms");
+    Time(trace, "EDRAM resolve", "issuecopy_ms");
+    ImGui::Separator();
+    ImGui::TextUnformatted("GPU submission visibility");
+    Count(trace, "Draws submitted", "draws");
+    Count(trace, "Depth-only submissions", "depthonly");
+    Count(trace, "No-pixel-shader submissions", "nopixelshader");
+    Count(trace, "Empty-scissor submissions", "scissor_empty");
+    Count(trace, "Tiny-viewport submissions", "viewport_tiny");
+    Count(trace, "Off-target submissions", "offscreen");
+    Count(trace, "Small-target submissions", "smallrt");
+    ImGui::TextDisabled("The last five categories can overlap; they are not summed.");
+    ImGui::TextDisabled("Objects culled before draw submission need a game visibility-manager hook.");
+    if (ImGui::CollapsingHeader("All trace timings")) {
+        Time(trace, "Primary buffer execution", "execprimary_ms");
+        Time(trace, "GPU thread idle", "stall_ms");
+        Time(trace, "Cross-thread callbacks", "pendingfns_ms");
+        Time(trace, "Primitive processing", "prim_ms");
+        Time(trace, "Shader translation", "shadertrans_ms");
+        Time(trace, "Pipeline/layout bind bookkeeping", "post_ms");
+        Time(trace, "Memexport range sync", "memexport_ms");
+        Time(trace, "Render pass enter/barriers", "renderpass_enter_ms");
+        Time(trace, "Draw command submission", "drawcmd_ms");
+        Time(trace, "System constants", "sysconst_ms");
+        Time(trace, "Dynamic state", "dyn_ms");
+        Time(trace, "Descriptor writes", "texwrite_ms");
+        Time(trace, "vkUpdateDescriptorSets", "updsets_ms");
+        Count(trace, "Frame-in-flight waits", "fencewait_n");
+        Time(trace, "GPU frame-in-flight wait", "fencewait_ms");
+    }
+    if (ImGui::CollapsingHeader("Trace counts")) {
+        Count(trace, "Draws", "draws");
+        Count(trace, "Render passes", "rp_n");
+        Count(trace, "...small (transfer-only)", "rp_transfer");
+        Count(trace, "...small (other)", "rp_small");
+        Count(trace, "Render target switches", "rt_switch");
+        Count(trace, "Barrier submits", "barrier_submits");
+        Count(trace, "Buffer barriers", "barrier_buf");
+        Count(trace, "Image barriers", "barrier_img");
+        Count(trace, "Texture cache calls", "texcalls");
+        Count(trace, "No-transition textures", "tex_notrans");
+        Count(trace, "GPU fence waits", "gpuwait_n");
+        Count(trace, "EDRAM resolves", "issuecopy_n");
+        Count(trace, "Primary buffers", "execprimary_n");
+        Count(trace, "GPU thread stalls", "stall_n");
+        Count(trace, "Shared read/write", "use_rw");
+        Count(trace, "Shared conservative rw", "use_rw_cons");
+        Count(trace, "Shared read-only", "use_read");
+        Count(trace, "Shared memory upload calls", "upload_calls");
+        Count(trace, "...upload ranges", "upload_ranges");
+        Count(trace, "...upload pages", "upload_pages");
+        ImGui::TextDisabled("Each upload call transitions shared memory to transfer-dest,");
+        ImGui::TextDisabled("then back to read on the next draw: a likely barrier source.");
+        if (Has(trace, "rp_mpixels")) {
+            ImGui::Text("%-28s %7.1f Mpx", "Pass attachment pixels", Value(trace, "rp_mpixels"));
+        } else {
+            Unmeasured("Pass attachment pixels");
+        }
+        Count(trace, "Color draws (has pixel shader)", "color_draws");
+        Count(trace, "...distinct (vs, ps) pairs", "color_draw_identities");
+        if (Has(trace, "color_draws") && Has(trace, "color_draw_identities")) {
+            const double color_draws = Value(trace, "color_draws");
+            const double identities = Value(trace, "color_draw_identities");
+            const double per_identity = identities > 0.0 ? color_draws / identities : 0.0;
+            ImGui::Text("%-28s %7.1f", "...draws per distinct pair", per_identity);
+        } else {
+            Unmeasured("...draws per distinct pair");
+        }
+        ImGui::TextDisabled("Distinct pairs is a proxy object/material count; low pair count");
+        ImGui::TextDisabled("with high draws per pair means few objects drawn many times each");
+        ImGui::TextDisabled("(normal multi-pass materials). High pair count while little is");
+        ImGui::TextDisabled("visible would suggest an off-screen culling gap.");
+        Count(trace, "...pairs drawn <=2x (suspicious)", "identities_low_use");
+        Count(trace, "...pairs drawn >=6x (normal)", "identities_high_use");
+        ImGui::TextDisabled("A large low-use count is a long tail of single-use shader pairs -");
+        ImGui::TextDisabled("consistent with many off-screen objects each contributing a draw.");
+        ImGui::Separator();
+        Count(trace, "Phase 1 native draws (see docs/ai/research.md)", "phase1_draws");
+        Time(trace, "Phase 1 native draw cost (CPU wall time)", "phase1_ms");
+        ImGui::TextDisabled("Substitutes one specific vertex shader's draws with a hand-built");
+        ImGui::TextDisabled("native Vulkan pipeline. CPU wall time, not isolated GPU time -");
+        ImGui::TextDisabled("compare against the Xenos-translated path's ns_per_draw above.");
+        Count(trace, "Generalized native draws (batch shader cache)", "xenos_draws");
+        Time(trace, "Generalized native draw cost (CPU wall time)", "xenos_ms");
+        ImGui::TextDisabled("Any (vertex,pixel) shader pair that successfully batch-converted");
+        ImGui::TextDisabled("via XenosRecomp (tools/xenos_batch_convert.py) gets a real native");
+        ImGui::TextDisabled("pipeline here -- constant buffers are not yet wired (push constants");
+        ImGui::TextDisabled("are zeroed), so shaders that read constants will render with wrong");
+        ImGui::TextDisabled("uniform data even though the draw mechanism itself is real.");
+    }
+    if (ImGui::CollapsingHeader("Draw-state counts")) {
+        Count(trace, "Descriptor-set updates", "updsets_calls");
+        Count(trace, "Constant writes", "consts_writes");
+        Count(trace, "Vertex texture writes", "texvert_writes");
+        Count(trace, "Pixel texture writes", "texpix_writes");
+        Count(trace, "Same pipeline", "pipe_same");
+        Count(trace, "Same vertex layout", "layout_same");
+        Count(trace, "Same texture mask", "texmask_same");
+        Count(trace, "Valid descriptor sets", "sets_valid");
+        Count(trace, "Mergeable draws", "mergeable");
+        Count(trace, "Empty scissors", "scissor_empty");
+        Count(trace, "Tiny viewports", "viewport_tiny");
+        Count(trace, "Offscreen draws", "offscreen");
+        Count(trace, "Depth-only draws", "depthonly");
+        Count(trace, "No-pixel-shader draws", "nopixelshader");
+        Count(trace, "Small render targets", "smallrt");
+        ImGui::TextDisabled("Offscreen/empty means submitted but cannot affect its target.");
+        ImGui::TextDisabled("Game frustum-culled objects never reach this GPU trace.");
+    }
+}
+
+}  // namespace detail
+
+inline void DrawContent() {
+    const auto trace = renut::trace_stats::GetLatest();
+    const auto activity = renut::game_activity_stats::GetSnapshot();
+    ImGui::Text("Guest tick (game logic)      %6.2f ms", cpuMS);
+    ImGui::Text("Guest draw submission (appMainDraw) %6.2f ms", gpuMS);
+    ImGui::TextDisabled("Whole-frame guest CPU thread time; not GPU work despite the name.");
+    ImGui::Separator();
+    ImGui::TextUnformatted("Game activity: frame / session");
+    ImGui::Text("Animation streams    %5llu / %-8llu %6.3f ms", static_cast<unsigned long long>(activity.animation_stream_frame), static_cast<unsigned long long>(activity.animation_stream_session), activity.animation_stream_frame_ns / 1000000.0);
+    ImGui::Text("Body blends          %5llu / %-8llu %6.3f ms", static_cast<unsigned long long>(activity.body_blend_frame), static_cast<unsigned long long>(activity.body_blend_session), activity.body_blend_frame_ns / 1000000.0);
+    ImGui::Text("Actor scripts        %5llu / %-8llu %6.3f ms", static_cast<unsigned long long>(activity.actor_script_frame), static_cast<unsigned long long>(activity.actor_script_session), activity.actor_script_frame_ns / 1000000.0);
+    ImGui::Text("Actor generation     %5llu / %-8llu %6.3f ms", static_cast<unsigned long long>(activity.actor_generation_frame), static_cast<unsigned long long>(activity.actor_generation_session), activity.actor_generation_frame_ns / 1000000.0);
+    ImGui::TextDisabled("frame / session / measured guest CPU time");
+    if (trace.available) {
+        detail::DrawTrace(trace);
+    } else {
+        ImGui::TextDisabled("GPU trace unavailable: waiting for the first frame from the GPU plugin.");
+    }
+}
+
+}  // namespace renut::overlays::render_stats

--- a/src/renut_engine/overlays/render_stats_overlay.h
+++ b/src/renut_engine/overlays/render_stats_overlay.h
@@ -3,6 +3,7 @@
 #include "imgui.h"
 #include "renut_engine/Fps.h"
 #include "renut_engine/game_activity_stats.h"
+#include "renut_engine/nativevk_phase0.h"
 #include "renut_engine/trace_stats.h"
 
 // Content-only: no window/Begin/End, no hotkey. Hosted as a tab inside
@@ -83,6 +84,36 @@ inline void DrawTrace(const renut::trace_stats::Snapshot& trace) {
     Count(trace, "Small-target submissions", "smallrt");
     ImGui::TextDisabled("The last five categories can overlap; they are not summed.");
     ImGui::TextDisabled("Objects culled before draw submission need a game visibility-manager hook.");
+    ImGui::Separator();
+    ImGui::TextUnformatted("Phase 0: D3D9-hook rewrite validation");
+    ImGui::TextDisabled("docs/ai/archive/native-renderer-rewrite-plan.md -- is D3D9-hook coverage");
+    ImGui::TextDisabled("close to the real draw count, and are shader handles resolvable?");
+    {
+        const auto phase0 = renut::nativevk_phase0::GetLatest();
+        ImGui::Text("%-28s %7llu", "D3D9-hook draws (last frame)",
+            static_cast<unsigned long long>(phase0.last_frame_draws));
+        if (Has(trace, "draws")) {
+            const double sdkDraws = Value(trace, "draws");
+            const double ratio = sdkDraws > 0.0 ? double(phase0.last_frame_draws) / sdkDraws * 100.0 : 0.0;
+            ImGui::Text("%-28s %6.1f %%  (%.0f real)", "...as %% of SDK draws", ratio, sdkDraws);
+        } else {
+            Unmeasured("...as % of SDK draws");
+        }
+        ImGui::Text("%-28s %7llu", "SetVertexShader calls (session)",
+            static_cast<unsigned long long>(phase0.session_set_vertex_shader_calls));
+        const double unresolvedPct = phase0.session_set_vertex_shader_calls > 0
+            ? double(phase0.session_unresolved_set_vertex_shader_calls) / double(phase0.session_set_vertex_shader_calls) * 100.0
+            : 0.0;
+        ImGui::Text("%-28s %7llu  (%.1f %%)", "...unresolved calls",
+            static_cast<unsigned long long>(phase0.session_unresolved_set_vertex_shader_calls), unresolvedPct);
+        ImGui::Text("%-28s %7llu", "Distinct handles (session)",
+            static_cast<unsigned long long>(phase0.session_distinct_handles_seen));
+        ImGui::Text("%-28s %7llu", "...distinct unresolved",
+            static_cast<unsigned long long>(phase0.session_distinct_handles_unresolved));
+        ImGui::TextDisabled("Unresolved = SetVertexShader handle never seen at CreateVertexShader");
+        ImGui::TextDisabled("(the known IM_LOAD-bypass risk) -- resolvable via ucode-hash correlation");
+        ImGui::TextDisabled("only if the shader DID go through CreateVertexShader at some point.");
+    }
     if (ImGui::CollapsingHeader("All trace timings")) {
         Time(trace, "Primary buffer execution", "execprimary_ms");
         Time(trace, "GPU thread idle", "stall_ms");

--- a/src/renut_engine/overlays/render_stats_overlay.h
+++ b/src/renut_engine/overlays/render_stats_overlay.h
@@ -90,11 +90,16 @@ inline void DrawTrace(const renut::trace_stats::Snapshot& trace) {
     ImGui::TextDisabled("close to the real draw count, and are shader handles resolvable?");
     {
         const auto phase0 = renut::nativevk_phase0::GetLatest();
-        ImGui::Text("%-28s %7llu", "D3D9-hook draws (last frame)",
-            static_cast<unsigned long long>(phase0.last_frame_draws));
-        if (Has(trace, "draws")) {
-            const double sdkDraws = Value(trace, "draws");
-            const double ratio = sdkDraws > 0.0 ? double(phase0.last_frame_draws) / sdkDraws * 100.0 : 0.0;
+        // Session-cumulative comparison, not a single-frame snapshot -- see
+        // nativevk_phase0.h's own comment for why last_frame_draws isn't
+        // trustworthy (appMainDrawStart never fires; even the one working
+        // hook only covers ~62% of real frames). This needs no assumption
+        // that the two measurement paths share a frame boundary at all.
+        ImGui::Text("%-28s %7llu", "D3D9-hook draws (session)",
+            static_cast<unsigned long long>(phase0.session_total_draws));
+        if (Has(trace, "session_draws_total")) {
+            const double sdkDraws = Value(trace, "session_draws_total");
+            const double ratio = sdkDraws > 0.0 ? double(phase0.session_total_draws) / sdkDraws * 100.0 : 0.0;
             ImGui::Text("%-28s %6.1f %%  (%.0f real)", "...as %% of SDK draws", ratio, sdkDraws);
         } else {
             Unmeasured("...as % of SDK draws");
@@ -112,6 +117,24 @@ inline void DrawTrace(const renut::trace_stats::Snapshot& trace) {
             static_cast<unsigned long long>(phase0.session_distinct_handles_unresolved));
         ImGui::TextDisabled("Unresolved = SetVertexShader handle never seen at CreateVertexShader");
         ImGui::TextDisabled("(the known IM_LOAD-bypass risk) -- resolvable via ucode-hash correlation");
+        if (ImGui::CollapsingHeader("Phase 0 raw diagnostics (frame-boundary sanity check)")) {
+            ImGui::TextDisabled("Confirmed 2026-08-19: appMainDrawStart never fires (codegen drops one");
+            ImGui::TextDisabled("of two hooks sharing an address), and even appMainDrawend only covers");
+            ImGui::TextDisabled("~62%% of real frames -- this is why the coverage %% above uses session-");
+            ImGui::TextDisabled("cumulative totals, not a last-frame snapshot. Kept for reference.");
+            ImGui::Text("%-28s %7llu", "Frame-start hook fires", static_cast<unsigned long long>(phase0.session_frame_starts));
+            ImGui::Text("%-28s %7llu", "Frame-end hook fires", static_cast<unsigned long long>(phase0.session_frame_ends));
+            ImGui::Text("%-28s %7llu", "Total draws (session)", static_cast<unsigned long long>(phase0.session_total_draws));
+            if (Has(trace, "frame")) {
+                ImGui::Text("%-28s %7.0f", "SDK real frame count", Value(trace, "frame"));
+            } else {
+                Unmeasured("SDK real frame count");
+            }
+            ImGui::TextDisabled("If frame-start/end fires are far below SDK real frame count, the");
+            ImGui::TextDisabled("appMainDrawStart/end hook (0x82222250) is NOT firing once per real");
+            ImGui::TextDisabled("frame despite being appMainDraw's real entry -- last_frame_draws above");
+            ImGui::TextDisabled("would then span many real frames, not one, and isn't trustworthy yet.");
+        }
         ImGui::TextDisabled("only if the shader DID go through CreateVertexShader at some point.");
     }
     if (ImGui::CollapsingHeader("All trace timings")) {

--- a/src/renut_engine/path_config_store.h
+++ b/src/renut_engine/path_config_store.h
@@ -3,7 +3,16 @@
 #include <fstream>
 #include <optional>
 #include <string>
+
+#ifdef _WIN32
 #include <windows.h>
+#else
+#include <climits>
+#include <unistd.h>
+// Keeps the .cfg out of the executable's directory so renut still works when
+// installed read-only (AppImage/Flatpak/system install). See that header.
+#include "linuxfixes/xdg_paths.h"
+#endif
 
 namespace PathConfigStore {
 
@@ -31,10 +40,19 @@ namespace PathConfigStore {
     }
 
     inline std::filesystem::path GetStorePath(const std::string& app_name) {
+#ifdef _WIN32
         wchar_t exe_path[MAX_PATH] = {};
         GetModuleFileNameW(nullptr, exe_path, MAX_PATH);
         std::filesystem::path dir = std::filesystem::path(exe_path).parent_path();
+#else
+        // ~/.config/renut/<app>.cfg, migrating an existing file from beside the
+        // executable on first use so current setups keep their asset paths.
+        return renut::linuxfixes::ResolveWithMigration(renut::linuxfixes::ConfigDir(),
+                                                       app_name + ".cfg");
+#endif
+#ifdef _WIN32
         return dir / (app_name + ".cfg");
+#endif
     }
 
     inline std::optional<SavedPaths> TryLoad(const std::string& app_name) {

--- a/src/renut_engine/render_hooks_stub.cpp
+++ b/src/renut_engine/render_hooks_stub.cpp
@@ -1,0 +1,107 @@
+#include "renut_engine/game_activity_stats.h"
+
+#include "rex_macros.h"
+#include "globals.h"
+
+void gameActivityAnimationStream(PPCRegister&, PPCRegister&, PPCRegister&) {
+    renut::game_activity_stats::RecordAnimationStream();
+}
+
+void gameActivityAnimationStreamEnd(PPCRegister&, PPCRegister&, PPCRegister&) {
+    renut::game_activity_stats::FinishAnimationStream();
+}
+
+void gameActivityBodyBlend(PPCRegister&, PPCRegister&, PPCRegister&) {
+    renut::game_activity_stats::RecordBodyBlend();
+}
+
+void gameActivityBodyBlendEnd(PPCRegister&, PPCRegister&, PPCRegister&) {
+    renut::game_activity_stats::FinishBodyBlend();
+}
+
+void gameActivityActorScript(PPCRegister&, PPCRegister&, PPCRegister&) {
+    renut::game_activity_stats::RecordActorScript();
+}
+
+void gameActivityActorScriptEnd(PPCRegister&, PPCRegister&, PPCRegister&) {
+    renut::game_activity_stats::FinishActorScript();
+}
+
+void gameActivityActorGeneration(PPCRegister&, PPCRegister&, PPCRegister&) {
+    renut::game_activity_stats::RecordActorGeneration();
+}
+
+void gameActivityActorGenerationEnd(PPCRegister&, PPCRegister&, PPCRegister&) {
+    renut::game_activity_stats::FinishActorGeneration();
+}
+
+void PresentNativeFrame() {}
+
+void nativeSetVertexShader(PPCRegister&, PPCRegister&) {}
+void nativeSetPixelShader(PPCRegister&, PPCRegister&) {}
+void nativeSetVertexDeclaration(PPCRegister&, PPCRegister&) {}
+void nativeCreateVertexDeclarationBegin(PPCRegister&) {}
+void nativeCreateVertexDeclarationEnd(PPCRegister&) {}
+void nativeSetStreamSource(PPCRegister&, PPCRegister&, PPCRegister&, PPCRegister&, PPCRegister&, PPCRegister&) {}
+void nativeSetIndices(PPCRegister&, PPCRegister&) {}
+void nativeSetTexture(PPCRegister&, PPCRegister&, PPCRegister&) {}
+void nativeSetVertexConstants(PPCRegister&, PPCRegister&, PPCRegister&, PPCRegister&) {}
+void nativeSetPixelConstants(PPCRegister&, PPCRegister&, PPCRegister&, PPCRegister&) {}
+void nativeSetRenderTarget(PPCRegister&, PPCRegister&, PPCRegister&) {}
+void nativeSetDepthStencil(PPCRegister&, PPCRegister&) {}
+void nativeSetViewport(PPCRegister&, PPCRegister&) {}
+void nativeSetScissor(PPCRegister&, PPCRegister&) {}
+void nativeDrawIndexed(PPCRegister&, PPCRegister&, PPCRegister&, PPCRegister&, PPCRegister&) {}
+void nativeDraw(PPCRegister&, PPCRegister&, PPCRegister&, PPCRegister&) {}
+void nativeClear(PPCRegister&, PPCRegister&, PPCRegister&, PPCRegister&, PPCRegister&, PPCRegister&, PPCRegister&) {}
+void nativeResolve(PPCRegister&, PPCRegister&, PPCRegister&, PPCRegister&, PPCRegister&, PPCRegister&, PPCRegister&, PPCRegister&) {}
+void nativeSwap(PPCRegister&, PPCRegister&, PPCRegister&) {
+    renut::game_activity_stats::EndFrame();
+}
+
+void nativeSetAlphaBlendEnable(PPCRegister&, PPCRegister&) {}
+void nativeSetSrcBlend(PPCRegister&, PPCRegister&) {}
+void nativeSetDestBlend(PPCRegister&, PPCRegister&) {}
+void nativeSetBlendOp(PPCRegister&, PPCRegister&) {}
+void nativeSetSeparateAlphaBlendEnable(PPCRegister&, PPCRegister&) {}
+void nativeSetSrcBlendAlpha(PPCRegister&, PPCRegister&) {}
+void nativeSetDestBlendAlpha(PPCRegister&, PPCRegister&) {}
+void nativeSetBlendOpAlpha(PPCRegister&, PPCRegister&) {}
+void nativeSetBlendFactor(PPCRegister&, PPCRegister&) {}
+void nativeSetAlphaTestEnable(PPCRegister&, PPCRegister&) {}
+void nativeSetAlphaRef(PPCRegister&, PPCRegister&) {}
+void nativeSetAlphaFunc(PPCRegister&, PPCRegister&) {}
+void nativeSetZEnable(PPCRegister&, PPCRegister&) {}
+void nativeSetZWriteEnable(PPCRegister&, PPCRegister&) {}
+void nativeSetZFunc(PPCRegister&, PPCRegister&) {}
+void nativeSetCullMode(PPCRegister&, PPCRegister&) {}
+void nativeSetFillMode(PPCRegister&, PPCRegister&) {}
+void nativeSetColorWriteEnable(PPCRegister&, PPCRegister&) {}
+void nativeSetScissorEnable(PPCRegister&, PPCRegister&) {}
+void nativeSetDepthBias(PPCRegister&, PPCRegister&) {}
+void nativeSetSlopeScaleDepthBias(PPCRegister&, PPCRegister&) {}
+void nativeSetStencilEnable(PPCRegister&, PPCRegister&) {}
+void nativeSetTwoSidedStencilMode(PPCRegister&, PPCRegister&) {}
+void nativeSetStencilFunc(PPCRegister&, PPCRegister&) {}
+void nativeSetStencilFail(PPCRegister&, PPCRegister&) {}
+void nativeSetStencilZFail(PPCRegister&, PPCRegister&) {}
+void nativeSetStencilPass(PPCRegister&, PPCRegister&) {}
+void nativeSetStencilRef(PPCRegister&, PPCRegister&) {}
+void nativeSetStencilMask(PPCRegister&, PPCRegister&) {}
+void nativeSetStencilWriteMask(PPCRegister&, PPCRegister&) {}
+void nativeSetCCWStencilFunc(PPCRegister&, PPCRegister&) {}
+void nativeSetCCWStencilFail(PPCRegister&, PPCRegister&) {}
+void nativeSetCCWStencilZFail(PPCRegister&, PPCRegister&) {}
+void nativeSetCCWStencilPass(PPCRegister&, PPCRegister&) {}
+
+void nativeSetSamplerMinFilter(PPCRegister&, PPCRegister&, PPCRegister&) {}
+void nativeSetSamplerMagFilter(PPCRegister&, PPCRegister&, PPCRegister&) {}
+void nativeSetSamplerMipFilter(PPCRegister&, PPCRegister&, PPCRegister&) {}
+void nativeSetSamplerAddressU(PPCRegister&, PPCRegister&, PPCRegister&) {}
+void nativeSetSamplerAddressV(PPCRegister&, PPCRegister&, PPCRegister&) {}
+void nativeSetSamplerAddressW(PPCRegister&, PPCRegister&, PPCRegister&) {}
+void nativeSetSamplerMaxAnisotropy(PPCRegister&, PPCRegister&, PPCRegister&) {}
+void nativeSetSamplerMipMapLodBias(PPCRegister&, PPCRegister&, PPCRegister&) {}
+void nativeSetSamplerMaxMipLevel(PPCRegister&, PPCRegister&, PPCRegister&) {}
+void nativeSetSamplerMinMipLevel(PPCRegister&, PPCRegister&, PPCRegister&) {}
+void nativeSetSamplerBorderColor(PPCRegister&, PPCRegister&, PPCRegister&) {}

--- a/src/renut_engine/renut_trace_hook.h
+++ b/src/renut_engine/renut_trace_hook.h
@@ -1,0 +1,66 @@
+#pragma once
+
+// Minimal, additive extension point: VulkanCommandProcessor times a handful
+// of its own existing phases (already-real call sites -- primitive
+// processing, texture/sampler/render-target/pipeline setup, draw submission,
+// GPU fence waits) and hands the numbers off once per frame via this single
+// weak hook. All aggregation, storage, and display (the reNut "Renderer
+// performance" overlay) lives in reNut's own code, which defines the strong
+// symbol and exports it to the plugin -- same pattern as
+// src/renut_engine/linuxfixes/*.cpp's REX_HOOK overrides, just in the other
+// direction (SDK calling out to the host exe instead of the host exe
+// overriding an SDK symbol). rexgpu-xenos links and runs identically whether
+// or not a host defines this symbol -- the call site checks it is non-null
+// first.
+//
+// Lives in reNut's own tree (not rex/graphics/vulkan/renut_trace_hook.h
+// inside the SDK checkout) so trace_stats.cpp compiles regardless of SDK
+// patch state -- the identically-named SDK-side header (added by
+// cmake/patches/rexglue_sdk_native_renderer.patch, only present when the SDK
+// is built via the REXSDK_DIR/from-source flow in docs/ai/nativevk.md, NOT
+// the default find_package(rexglue) prebuilt path) previously made this a
+// hard compile failure for anyone on a plain SDK. This copy MUST stay
+// byte-identical (struct layout, call signature) to the SDK-side one -- it's
+// a real ABI boundary crossed at runtime via a weak dynamic symbol, not just
+// a compile-time convenience. If either side changes, update both.
+
+#include <cstdint>
+
+extern "C" {
+
+struct RenutTraceRow {
+  uint64_t frame;
+  uint64_t draws;
+  double frame_ms;
+  double issuedraw_ms;
+  double ns_per_draw;
+  double prim_ms;
+  double samp_ms;
+  double tex_ms;
+  double rt_ms;
+  double pipe_ms;
+  double shadertrans_ms;
+  double sysconst_ms;
+  double vfetch_ms;
+  double dyn_ms;
+  double bind_ms;
+  double memexport_ms;
+  double renderpass_enter_ms;
+  double drawcmd_ms;
+  double gpuwait_ms;
+  uint64_t gpuwait_n;
+  double swap_ms;
+  double issuecopy_ms;
+  uint64_t issuecopy_n;
+  uint64_t depthonly;
+  uint64_t nopixelshader;
+};
+
+// Defined by reNut's own code (src/renut_engine/trace_stats.cpp), exported
+// from the renut executable's dynamic symbol table so the plugin's PLT entry
+// resolves to it. Declared weak so rexgpu-xenos and any standalone build of
+// rexgpu-nativevk (without a host defining it) still link and run -- the call
+// site always null-checks before calling.
+void RenutEmitTraceRow(const RenutTraceRow* row) __attribute__((weak));
+
+}

--- a/src/renut_engine/renut_xenos_shader_cache.h
+++ b/src/renut_engine/renut_xenos_shader_cache.h
@@ -12,7 +12,7 @@
 #include <cstddef>
 #include <cstdint>
 
-// Real fix (2026-08-16): the compiled SPIR-V's vertex shader stage declares
+// the compiled SPIR-V's vertex shader stage declares
 // FIXED Vulkan input locations per D3D9 usage/usageIndex (XenosRecomp's own
 // shader_recompiler.cpp: USAGE_LOCATIONS table, e.g. Position=0, Normal=1,
 // Tangent=2, Binormal=3, TexCoord0=4, ...) -- NOT sequential 0,1,2,... in
@@ -36,7 +36,7 @@
 // kVertexLocationUnset marks unused slots. Pixel shaders (which have no
 // vertex input stage) leave this fully unset.
 //
-// Real fix (2026-08-17): raised 16 -> 32, and the assignment rule changed
+// raised 16 -> 32, and the assignment rule changed
 // from "look the usage up in XenosRecomp's USAGE_LOCATIONS table" to "the
 // i-th vertex element gets location i". The old comment's claim that no
 // captured shader had more than ~9 attributes was measured on too small a
@@ -55,7 +55,7 @@
 inline constexpr uint32_t kRenutMaxVertexLocations = 32;
 inline constexpr uint8_t kRenutVertexLocationUnset = 0xFF;
 
-// Real fix (2026-08-17): vertexLocations[] is now purely positional (see its
+// vertexLocations[] is now purely positional (see its
 // own header comment above), so it can no longer double as "this attribute's
 // D3D9 TexCoord usage index" the way the old usage-based location scheme
 // let the runtime infer for free. XenosRecomp's own compiled HLSL still

--- a/src/renut_engine/renut_xenos_shader_cache.h
+++ b/src/renut_engine/renut_xenos_shader_cache.h
@@ -1,0 +1,87 @@
+#pragma once
+// Real-data shape for the batch-converted native-renderer shader cache (see
+// docs/ai/research.md "convert the important/common shaders"). Populated
+// by generated/renut_xenos_shader_cache.cpp, produced at build time by
+// tools/xenos_batch_convert.py + tools/xenos_cache_unpack.cpp from the
+// user's real captured guest shader dump.
+//
+// spirvOffset/spirvSize index into g_renutXenosSpirvWords (uint32_t words,
+// i.e. already real SPIR-V ready for vkCreateShaderModule -- ZSTD/smol-v
+// decoding already happened at build time, not here).
+
+#include <cstddef>
+#include <cstdint>
+
+// Real fix (2026-08-16): the compiled SPIR-V's vertex shader stage declares
+// FIXED Vulkan input locations per D3D9 usage/usageIndex (XenosRecomp's own
+// shader_recompiler.cpp: USAGE_LOCATIONS table, e.g. Position=0, Normal=1,
+// Tangent=2, Binormal=3, TexCoord0=4, ...) -- NOT sequential 0,1,2,... in
+// vfetch-instruction order. The runtime pipeline cache previously assigned
+// locations purely sequentially (renut_xenos_pipeline_cache.cpp's
+// next_location++), which happened to work only for the first, simplest
+// proven shader (whose 2 attributes' real locations were coincidentally
+// sequential) -- for real shaders with a location gap (e.g. Normal=1 then
+// TexCoord0=4), this produced a real Vulkan validation error
+// ("pVertexAttributeDescriptions does not have a Location 4, but
+// [VK_SHADER_STAGE_VERTEX_BIT] has [Input variable, Location 4] at that
+// Location") and, even when it didn't hard-fail, silently bound the wrong
+// data to the wrong shader input (confirmed real cause of visible
+// stretched-texture/wrong-lighting corruption). vertexLocations[i] is the
+// REAL Vulkan location for the i-th attribute in vertex_bindings() iteration
+// order (same order tools/ucode_analyze.cpp's JSON output uses, since both
+// walk the same real Shader::AnalyzeUcode()/vertex_bindings() data) --
+// computed at build time (tools/xenos_cache_unpack.cpp's
+// ExtractVertexLocations) using the SAME assignment rule XenosRecomp itself
+// used to compile the shader, not re-derived or guessed at runtime.
+// kVertexLocationUnset marks unused slots. Pixel shaders (which have no
+// vertex input stage) leave this fully unset.
+//
+// Real fix (2026-08-17): raised 16 -> 32, and the assignment rule changed
+// from "look the usage up in XenosRecomp's USAGE_LOCATIONS table" to "the
+// i-th vertex element gets location i". The old comment's claim that no
+// captured shader had more than ~9 attributes was measured on too small a
+// sample: re-checked across every captured shader, the real maximum is 28
+// (one binding with 12 attributes plus another with 7 is typical for the
+// skinned/instanced geometry here), and 198 shaders were being rejected
+// outright partly because of the 16 ceiling. 32 matches both the
+// maxVertexInputAttributes this GPU reports and XenosRecomp's own
+// maxVertexInputAttributes cap, so the two sides cannot disagree.
+//
+// NOTE: 32 exceeds Vulkan's GUARANTEED minimum of 16 for
+// maxVertexInputAttributes. That is deliberate and safe here because the
+// runtime rejects any shader whose attribute count exceeds the device's real
+// reported limit before creating a pipeline, falling back to the stock
+// renderer rather than failing pipeline creation.
+inline constexpr uint32_t kRenutMaxVertexLocations = 32;
+inline constexpr uint8_t kRenutVertexLocationUnset = 0xFF;
+
+// Real fix (2026-08-17): vertexLocations[] is now purely positional (see its
+// own header comment above), so it can no longer double as "this attribute's
+// D3D9 TexCoord usage index" the way the old usage-based location scheme
+// let the runtime infer for free. XenosRecomp's own compiled HLSL still
+// bakes the real usageIndex as a literal into tfetchTexcoord()'s call site
+// at compile time (shader_recompiler.cpp's `recompile(VertexFetchInstruction)`),
+// so THAT part needs no fix -- but renut_xenos_pipeline_cache.cpp separately
+// needs the real usageIndex at pipeline-build time too, to compute
+// swapped_texcoords_mask (which real TexCoord semantic bit to set based on
+// the ACTUAL bound vertex format being 16-bit-per-channel). That data has
+// no other source at runtime (ParsedVertexFetchInstruction carries no D3D9
+// usage info at all -- see shader.h's VertexBinding::Attribute), so it's
+// captured here at build time the same way vertexLocations[] is.
+// kRenutTexCoordSemanticUnset marks a raw attribute that either isn't a
+// TexCoord usage at all, or whose data is unavailable (pixel shaders, or a
+// shader with no remap match).
+inline constexpr uint8_t kRenutTexCoordSemanticUnset = 0xFF;
+
+struct RenutXenosShaderCacheEntry {
+	uint64_t hash;
+	size_t spirvOffset;
+	size_t spirvSize;
+	uint32_t specConstantsMask;
+	uint8_t vertexLocations[kRenutMaxVertexLocations];
+	uint8_t vertexTexCoordSemanticIndex[kRenutMaxVertexLocations];
+};
+
+extern const uint32_t g_renutXenosSpirvWords[];
+extern const RenutXenosShaderCacheEntry g_renutXenosShaderCacheEntries[];
+extern const size_t g_renutXenosShaderCacheEntryCount;

--- a/src/renut_engine/shader_dump.cpp
+++ b/src/renut_engine/shader_dump.cpp
@@ -4,6 +4,7 @@
 #include <rex/hash.h>
 #include <rex/runtime.h>
 #include "renut_logging.h"
+#include "renut_engine/shader_dump.h"
 
 #include <algorithm>
 #include <array>
@@ -464,10 +465,16 @@ void dumpVertexDeclarationCreated_hook(PPCRegister& r3)
 // is about to allocate and return. Independent of dumpVertexShader_hook's
 // own dump_guest_shaders gate: this needs to run whenever
 // renut_dump_vertex_decl is on, even if dump_guest_shaders is off.
+// Real, deliberate change (see docs/ai/archive/native-renderer-rewrite-plan.md
+// Phase 0): this used to early-return unless renut_dump_vertex_decl was
+// enabled, same as the rest of this file's dump-to-disk paths. But this
+// function (and dumpVertexShaderCreated_hook below) only computes a hash and
+// inserts into a map -- no I/O -- and renut::shader_dump::TryResolveShaderUcodeHash
+// (used by nativevk_phase0.cpp to measure real IM_LOAD-bypass rate) needs
+// g_shaderHandleToUcodeHash populated unconditionally, not only when a user
+// happens to have the unrelated vertex-decl-dump feature enabled.
 void dumpVertexShaderCreate_hook(PPCRegister& r3)
 {
-	if (!REXCVAR_GET(renut_dump_vertex_decl)) return;
-
 	uint64_t ucodeHash = 0;
 	if (!computeShaderUcodeHash(r3.u32, ucodeHash)) return;
 
@@ -482,8 +489,6 @@ void dumpVertexShaderCreate_hook(PPCRegister& r3)
 // with the ucode hash computed at entry above.
 void dumpVertexShaderCreated_hook(PPCRegister& r3)
 {
-	if (!REXCVAR_GET(renut_dump_vertex_decl)) return;
-
 	const uint32_t handle = r3.u32;
 	if (handle < 0x10000000u || handle >= 0x90000000u) return;
 
@@ -628,6 +633,18 @@ uint64_t resolveShaderUcodeHash(uint32_t handle)
 }
 
 }  // namespace
+
+namespace renut::shader_dump {
+
+bool TryResolveShaderUcodeHash(uint32_t handle, uint64_t& outHash)
+{
+	const uint64_t hash = resolveShaderUcodeHash(handle);
+	if (hash == 0) return false;
+	outHash = hash;
+	return true;
+}
+
+}  // namespace renut::shader_dump
 
 void dumpVertexShaderSet_hook(PPCRegister& r3, PPCRegister& r4)
 {

--- a/src/renut_engine/shader_dump.cpp
+++ b/src/renut_engine/shader_dump.cpp
@@ -1,35 +1,3 @@
-// =============================================================================
-// Guest shader dumping.
-//
-// Captures the D3D9 shader blobs the XEX hands to D3DDevice_CreateVertexShader
-// (0x8264E8B0) and D3DDevice_CreatePixelShader (0x8264E6A8). D3D9 is statically
-// linked into the XEX, so despite the rex_ names in renut_gpu_funcs.toml these
-// are ordinary recompiled guest functions and a midasm hook fires normally.
-// Both hooks sit on the function's first instruction (`mflr r12`), so r3 still
-// holds the incoming pFunction argument.
-//
-// Creation is the cheap chokepoint: it runs once per shader at load, unlike the
-// Set*Shader path which runs per draw.
-//
-// pFunction is self-describing. Confirmed against both decompiled creators --
-// each reads the same three leading words and copies exactly two ranges out of
-// them (XMemCpy of pFunction[1] bytes from pFunction, then memcpy of
-// pFunction[2] bytes from pFunction + pFunction[1]):
-//
-//   [0] flags -- bit 0 selects the extended (872-byte) shader object over 40
-//   [1] header size in bytes; the microcode begins at pFunction + [1]
-//   [2] microcode size in bytes
-//
-// So header + microcode is the entire blob, and one register is enough to dump
-// it. All three words are big-endian; the dumped bytes are written exactly as
-// the guest holds them, which is the byte order Xenos ucode tooling expects.
-//
-// This is distinct from the SDK's `dump_shaders` cvar, which dumps translated
-// host shaders down in the GPU backend. This dumps the original guest blob.
-//
-// Purely observational: neither hook returns or redirects.
-// =============================================================================
-
 #include <rex/ppc.h>
 #include <rex/cvar.h>
 #include <rex/filesystem.h>
@@ -37,6 +5,9 @@
 #include <rex/runtime.h>
 #include "renut_logging.h"
 
+#include <algorithm>
+#include <array>
+#include <atomic>
 #include <cstdint>
 #include <cstdio>
 #include <filesystem>
@@ -44,7 +15,9 @@
 #include <mutex>
 #include <string>
 #include <system_error>
+#include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
 #if defined(_MSC_VER)
 #include <stdlib.h>
@@ -60,16 +33,158 @@ REXCVAR_DEFINE_BOOL(dump_guest_shaders, false, "Nuts&Bolts/Graphics",
 
 namespace {
 
-// Both sizes are bounded by what the guest is willing to allocate and copy; a
-// real shader is a few KiB at most. Anything past this is not a shader blob.
 constexpr uint32_t kMaxBlobBytes = 1u << 20;
-
-// The three leading words are read unconditionally, so the header can never be
-// smaller than they are.
 constexpr uint32_t kMinHeaderBytes = 12;
 
 std::mutex g_dumpMutex;
 std::unordered_set<uint64_t> g_dumped;
+
+// Real ShaderContainer layout (see XenosRecomp/XenosRecomp/shader.h's
+// ShaderContainer/Shader structs, confirmed via direct source read):
+//   +0x00 flags, +0x04 virtualSize, +0x08 physicalSize, +0x0C fieldC,
+//   +0x10 constantTableOffset, +0x14 definitionTableOffset,
+//   +0x18 shaderOffset, +0x1C field1C, +0x20 field20  (36 bytes)
+// then, at container+shaderOffset, a Shader struct:
+//   +0x00 physicalOffset, +0x04 size, +0x08 field8, +0x0C fieldC,
+//   +0x10 field10, +0x14 interpolatorInfo  (24 bytes)
+//
+// Real bug fixed here (2026-08-16): words[1] ("headerSize") is actually
+// ShaderContainer::virtualSize, NOT a microcode start offset -- confirmed
+// via direct hex inspection of captured containers plus XenosRecomp's own
+// shader_recompiler.cpp:1559 (`shaderData + shaderContainer->virtualSize +
+// shader->physicalOffset`). Xenos microcode instructions actually start
+// virtualSize + shader->physicalOffset bytes into the container (past the
+// embedded constant table's literal float/bool/loop constant blocks, which
+// physicalOffset skips over -- confirmed real, non-zero physicalOffset
+// values of 48/64 bytes on real captured shaders, exactly matching a
+// stray leading block of float-looking bytes this project's own ucode_analyze
+// tool was silently misparsing as garbage instructions). words[2]
+// ("ucodeSize") is ShaderContainer::physicalSize, which similarly
+// overcounts by physicalOffset bytes -- the real microcode length is
+// Shader::size, read from the Shader struct itself, not physicalSize.
+constexpr uint32_t kShaderStructOffsetPhysicalOffset = 0;
+constexpr uint32_t kShaderStructOffsetSize = 4;
+constexpr uint32_t kShaderStructBytes = 24;
+
+// Resolves the real microcode (ucode) byte range within a captured
+// ShaderContainer blob. Returns false if the container's shaderOffset (or
+// anything it points at) doesn't fit within the blob's own reported size,
+// in which case the caller should treat the blob as unparseable (matches
+// this file's existing "implausible blob" skip behavior).
+bool ResolveRealUcodeRange(const uint8_t* blob, uint32_t virtualSize, uint32_t physicalSize,
+                           const uint8_t*& ucodeOut, uint32_t& ucodeSizeOut)
+{
+	const uint32_t* words = reinterpret_cast<const uint32_t*>(blob);
+	const uint32_t shaderOffset = RENUT_BSWAP32(words[6]);  // ShaderContainer::shaderOffset, +0x18
+	if (shaderOffset < 36 || uint64_t(shaderOffset) + kShaderStructBytes > uint64_t(virtualSize)) {
+		return false;
+	}
+	const uint8_t* shaderStruct = blob + shaderOffset;
+	const uint32_t physicalOffset =
+		RENUT_BSWAP32(*reinterpret_cast<const uint32_t*>(shaderStruct + kShaderStructOffsetPhysicalOffset));
+	const uint32_t size =
+		RENUT_BSWAP32(*reinterpret_cast<const uint32_t*>(shaderStruct + kShaderStructOffsetSize));
+	if (size == 0 || uint64_t(physicalOffset) + size > uint64_t(physicalSize)) {
+		return false;
+	}
+	ucodeOut = blob + virtualSize + physicalOffset;
+	ucodeSizeOut = size;
+	return true;
+}
+
+// Real fix (2026-08-17): factored out of dumpVertexDeclUsage so it can be
+// called from dumpVertexShaderCreate_hook -- see g_shaderHandleToUcodeHash's
+// own comment for why. Computes the SAME ucode-only hash
+// (post-ResolveRealUcodeRange) that must match the real Vulkan pipeline's
+// ucode_data_hash(), from a raw pFunction pointer. Returns false if the
+// blob doesn't parse as plausible.
+bool computeShaderUcodeHash(uint32_t pFunction, uint64_t& outHash)
+{
+	if (!pFunction) return false;
+
+	const uint8_t* base = rex::Runtime::instance()->virtual_membase();
+	const uint8_t* blob = base + pFunction;
+	const uint32_t* words = reinterpret_cast<const uint32_t*>(blob);
+	const uint32_t headerSize = RENUT_BSWAP32(words[1]);
+	const uint32_t ucodeSize = RENUT_BSWAP32(words[2]);
+	if (headerSize < kMinHeaderBytes || headerSize > kMaxBlobBytes ||
+		ucodeSize == 0 || ucodeSize > kMaxBlobBytes) {
+		return false;
+	}
+
+	const uint8_t* ucode = blob + headerSize;
+	uint32_t realUcodeSize = ucodeSize;
+	if (const uint8_t* realUcode; ResolveRealUcodeRange(blob, headerSize, ucodeSize, realUcode, realUcodeSize)) {
+		ucode = realUcode;
+	} else {
+		realUcodeSize = ucodeSize;
+	}
+	outHash = XXH3_64bits(ucode, realUcodeSize);
+	return true;
+}
+
+// A real, parsed Xbox 360 D3DVERTEXELEMENT9-equivalent entry (12 bytes on
+// this platform, not PC D3D9's 8 -- see VertexDeclElement's own comment at
+// its parse site for the real struct layout, confirmed via UnleashedRecomp's
+// GuestVertexElement).
+struct VertexDeclElement { uint16_t offset; uint32_t type; uint8_t usage; uint8_t usageIndex; };
+
+constexpr uint32_t kVertexDeclElementStride = 12;
+constexpr uint32_t kMaxVertexDeclElements = 32;  // scan cap, real decls are far smaller
+constexpr uint32_t kMaxPlausibleVertexDeclElements = 16;
+constexpr uint8_t kMaxPlausibleVertexDeclUsage = 13;  // D3DDECLUSAGE_SAMPLE, the highest real value
+
+// Real fix (2026-08-17): MUST be called immediately when pElements is known
+// fresh (at CreateVertexDeclaration time) -- see g_pendingDeclElements's own
+// comment for why deferring this read to SetVertexDeclaration time was
+// fatally broken (the array is frequently caller-stack-allocated and long
+// overwritten by the time SetVertexDeclaration fires, sometimes seconds/many
+// calls later). Returns an empty vector if the array doesn't parse as
+// plausible (either structurally -- no terminator found within the scan cap
+// -- or semantically -- an out-of-range usage byte, a strong signal we're
+// reading unrelated memory rather than a real declaration).
+std::vector<VertexDeclElement> parsePlausibleVertexDecl(uint32_t pElements)
+{
+	if (pElements < 0x10000000u || pElements >= 0x90000000u) return {};
+
+	const uint8_t* base = rex::Runtime::instance()->virtual_membase();
+	std::vector<VertexDeclElement> elements;
+	bool foundTerminator = false;
+	for (uint32_t count = 0; count < kMaxVertexDeclElements; ++count) {
+		const uint8_t* e = base + pElements + count * kVertexDeclElementStride;
+		const uint16_t streamField = (uint16_t(e[0]) << 8) | e[1];
+		if (streamField == 0x00FFu || (streamField & 0xFF) == 0xFFu) {
+			foundTerminator = true;
+			break;
+		}
+		elements.push_back({
+			uint16_t((uint16_t(e[2]) << 8) | e[3]),
+			// Real struct layout (confirmed via UnleashedRecomp's
+			// GuestVertexElement, same XDK): stream:u16@0, offset:u16@2,
+			// type:u32@4 (a packed Xenos hardware fetch-format code, e.g.
+			// FLOAT3 = 0x2A23B9 -- NOT a small enum), method:u8@8,
+			// usage:u8@9, usageIndex:u8@10, pad:u8@11.
+			(uint32_t(e[4]) << 24) | (uint32_t(e[5]) << 16) | (uint32_t(e[6]) << 8) | e[7],
+			e[9],
+			e[10],
+		});
+	}
+
+	// Real safety fix (2026-08-17): the consumer (build_synthetic_container.py)
+	// treats any captured file as ground truth, overriding its own heuristic
+	// fallback -- writing a garbage capture is WORSE than writing nothing,
+	// it would poison a shader the heuristic might have gotten right. Reject
+	// anything that doesn't look like a real declaration rather than trust
+	// it blindly: no terminator found within the scan cap, too many
+	// elements, or any out-of-range usage byte (valid D3DDECLUSAGE is 0-13).
+	if (!foundTerminator || elements.empty() || elements.size() > kMaxPlausibleVertexDeclElements) {
+		return {};
+	}
+	for (const VertexDeclElement& e : elements) {
+		if (e.usage > kMaxPlausibleVertexDeclUsage) return {};
+	}
+	return elements;
+}
 
 bool writeFile(const std::filesystem::path& path, const uint8_t* data, size_t size)
 {
@@ -88,7 +203,6 @@ bool writeFile(const std::filesystem::path& path, const uint8_t* data, size_t si
 
 void dumpShaderBlob(PPCRegister& r3, const char* tag)
 {
-	// Disabled by default: one bool check per shader creation.
 	if (!REXCVAR_GET(dump_guest_shaders)) return;
 
 	const uint32_t pFunction = r3.u32;
@@ -109,19 +223,43 @@ void dumpShaderBlob(PPCRegister& r3, const char* tag)
 		return;
 	}
 
-	const uint8_t* ucode = blob + headerSize;
 	const size_t total = static_cast<size_t>(headerSize) + ucodeSize;
 
-	// The game recreates the same shaders across loads; hash the blob so each
-	// distinct one is written once per launch.
-	const uint64_t hash = XXH3_64bits(blob, total);
+	// Real microcode range (2026-08-16 fix, see ResolveRealUcodeRange's
+	// header comment): headerSize/ucodeSize (virtualSize/physicalSize) mark
+	// the whole container's virtual+physical regions, not where real Xenos
+	// instructions start/how long they run -- that needs shaderOffset ->
+	// Shader::physicalOffset/size. Falls back to the (known-wrong, but
+	// previously the only available) virtualSize-relative slice if the
+	// container doesn't parse as expected, so a genuinely malformed/unusual
+	// blob still produces SOME .ucode file rather than none.
+	const uint8_t* ucode = blob + headerSize;
+	uint32_t realUcodeSize = ucodeSize;
+	if (const uint8_t* realUcode; ResolveRealUcodeRange(blob, headerSize, ucodeSize, realUcode, realUcodeSize)) {
+		ucode = realUcode;
+	} else {
+		realUcodeSize = ucodeSize;
+	}
+
+	// Real bug found+fixed (2026-08-18): this used to hash the whole blob
+	// (header+ucode, XXH3_64bits(blob, total)), NOT the same value as
+	// computeShaderUcodeHash() above or the real runtime
+	// Shader::ucode_data_hash() (pipeline_cache.cpp:
+	// XXH3_64bits(host_address, dword_count*4), ucode-only). Confirmed via
+	// direct measurement: with the old formula, 0/163 distinct vertex
+	// shaders drawn in an extended real play session ever matched anything
+	// in the native shader cache (pixel shaders, unaffected by this specific
+	// bug, matched ~96%) -- every file this function ever wrote under
+	// shaders/vs_*.bin was named/keyed by a hash nothing downstream (the
+	// native pipeline cache's runtime lookup) could ever produce again.
+	// Existing captures in shaders/ from before this fix are permanently
+	// mis-hashed and need a fresh capture session to benefit.
+	const uint64_t hash = XXH3_64bits(ucode, realUcodeSize);
 	{
 		std::lock_guard<std::mutex> lock(g_dumpMutex);
 		if (!g_dumped.insert(hash).second) return;
 	}
 
-	// Always "shaders" alongside the exe, so dumps land next to the build being
-	// run rather than wherever the working directory happens to point.
 	const std::filesystem::path outDir =
 		rex::filesystem::GetExecutableFolder() / "shaders";
 
@@ -136,10 +274,8 @@ void dumpShaderBlob(PPCRegister& r3, const char* tag)
 	std::snprintf(stem, sizeof(stem), "%s_%016llx", tag,
 		static_cast<unsigned long long>(hash));
 
-	// .bin is the complete pFunction the game passed; .ucode is just the Xenos
-	// microcode, which is what a shader disassembler wants.
 	if (!writeFile(outDir / (std::string(stem) + ".bin"), blob, total)) return;
-	if (!writeFile(outDir / (std::string(stem) + ".ucode"), ucode, ucodeSize)) return;
+	if (!writeFile(outDir / (std::string(stem) + ".ucode"), ucode, realUcodeSize)) return;
 
 	RNUT_INFO("shader dump: {} (flags {:#x}, header {} B, ucode {} B) from {:#x}",
 		stem, flags, headerSize, ucodeSize, pFunction);
@@ -147,14 +283,440 @@ void dumpShaderBlob(PPCRegister& r3, const char* tag)
 
 }  // namespace
 
-// D3DDevice_CreateVertexShader @ 0x8264E8B0 -- r3 = pFunction at entry.
+void dumpCodeBytesOnce();
+
 void dumpVertexShader_hook(PPCRegister& r3)
 {
 	dumpShaderBlob(r3, "vs");
+	dumpCodeBytesOnce();
 }
 
-// D3DDevice_CreatePixelShader @ 0x8264E6A8 -- r3 = pFunction at entry.
 void dumpPixelShader_hook(PPCRegister& r3)
 {
 	dumpShaderBlob(r3, "ps");
+}
+
+void dumpVertexShaderSet_hook(PPCRegister& r3, PPCRegister& r4);
+void dumpVertexDeclarationSet_hook(PPCRegister& r3, PPCRegister& r4);
+void dumpVertexDeclarationCreated_hook(PPCRegister& r3);
+void dumpVertexShaderCreate_hook(PPCRegister& r3);
+void dumpVertexShaderCreated_hook(PPCRegister& r3);
+
+namespace {
+
+REXCVAR_DEFINE_BOOL(renut_dump_vertex_decl, false, "Nuts&Bolts/Graphics",
+	"Dump real D3DVERTEXELEMENT9 arrays passed to CreateVertexDeclaration, for "
+	"native-renderer Phase 1 shader-container reconstruction.");
+
+std::mutex g_declMutex;
+std::unordered_set<uint32_t> g_declLogged;
+
+// Real fix (2026-08-17): sub_8264EA90 (the guest function this project's
+// "CreateVertexDeclaration" hook sits at the true entry of, confirmed via
+// direct recompiled-PPC-code inspection) allocates a NEW handle object and
+// returns it in r3 -- SetVertexDeclaration (0x82205700) later receives that
+// returned HANDLE, not the original D3DVERTEXELEMENT9[] array pointer this
+// hook captures. Treating the handle as if it WERE the elements pointer
+// (the previous behavior) meant SetVertexDeclaration's dump path walked
+// garbage/handle-object memory as if it were a raw element array -- the
+// real cause of "vertdecl DIAG: bail pElements range" firing on effectively
+// every call. Fix: capture the true elements pointer here, capture the
+// returned handle at the function's real return point (0x8264EAFC, a
+// second, separate hook -- see dumpVertexDeclarationCreated_hook), and
+// build a handle -> elements-pointer map so SetVertexDeclaration can look
+// up the real array by the handle it actually receives.
+//
+// Real bug found+fixed 2026-08-17 (second pass, after first real captures
+// came back corrupted): this game creates vertex declarations from MULTIPLE
+// THREADS concurrently (confirmed real -- captured log shows CreateVertexDeclaration
+// hooks firing from several distinct thread IDs). A single shared
+// g_pendingDeclElements meant thread A's entry-hook value could be
+// overwritten by thread B's own Create call before thread A's OWN exit hook
+// read it back, silently pairing thread A's handle with thread B's elements
+// pointer -- exactly matching what the real captured data showed: most
+// captures had wildly implausible offsets/types (reading whatever unrelated
+// array thread B had created), while occasional ones came out clean.
+// thread_local makes each thread's entry->exit pairing immune to any other
+// thread's concurrent Create calls (safe because a single thread cannot
+// reenter CreateVertexDeclaration on itself before its own call returns).
+//
+// Real fix (2026-08-17, THIRD pass): even with thread_local, real captures
+// STILL came back corrupted -- proof: the exact same decl address
+// (0x7018ef00) parsed to a DIFFERENT element count at different points in
+// the same session, which is impossible for real static data. Root cause:
+// pElements is very often a CALLER-STACK-ALLOCATED array (a local variable
+// in whatever guest function builds the declaration), valid only for the
+// duration of the CreateVertexDeclaration call itself -- by the time
+// SetVertexDeclaration fires (which can be far later), that stack memory
+// has been overwritten by unrelated calls. Storing just the raw pointer and
+// re-reading it later was fundamentally broken for stack-sourced arrays;
+// only the ONE declaration living in the game's static data segment
+// (0x82xxxxxx) ever came back clean. Fix: parse the array's CONTENT
+// immediately here, while guaranteed fresh, and store the parsed data
+// itself (not a pointer to re-read later).
+thread_local std::vector<VertexDeclElement> g_pendingDeclElements;
+std::unordered_map<uint32_t, std::vector<VertexDeclElement>> g_declHandleToElements;
+
+std::mutex g_vsMutex;
+uint64_t g_lastBoundVertexShaderUcodeHash = 0;
+// Real fix (2026-08-16): SetVertexDeclaration and SetVertexShader do NOT
+// have a fixed call order -- confirmed via real captured log, this game
+// calls SetVertexDeclaration BEFORE SetVertexShader, so tracking only "the
+// last bound vertex shader" and dumping from the declaration hook alone
+// meant dumpVertexDeclUsageForBoundShader() always ran with no shader
+// bound yet, silently hitting its early-return every single time (the
+// real cause of shaders_vertdecl/ being completely empty, independent of
+// the separate ucode-offset bug fixed elsewhere in this file). Track the
+// last bound declaration too, and dump from BOTH hooks -- whichever one
+// fires second for a given pair has both pieces of state available.
+std::vector<VertexDeclElement> g_lastBoundVertexDeclElements;
+std::unordered_set<uint64_t> g_vertDeclDumped;
+
+// Real fix (2026-08-17): the SAME handle-vs-real-pointer confusion as
+// g_declHandleToElements above, but for vertex shaders. sub_8264E8B0 (the
+// guest function dumpVertexShader_hook already sits at the true entry of,
+// used by the separately-gated dump_guest_shaders feature) ALSO allocates a
+// new handle object and returns it in r3 -- confirmed via the same
+// recompiled-code inspection technique, its two return paths (success at
+// loc_8264E96C, failure at loc_8264E8E4) converge at loc_8264E998 with r3
+// already holding the final handle (or 0). SetVertexShader (0x8222A0A8)
+// receives that handle in r4, not the raw shader-blob pointer this hook's
+// own entry capture sees -- so dumpVertexDeclUsage's pFunction argument was
+// always the handle, explaining the "implausible blob" bails once pElements
+// started resolving correctly.
+//
+// thread_local for the same real, confirmed reason as g_pendingDeclElements
+// above (multi-threaded CreateVertexShader calls cross-contaminating a
+// shared pending value).
+//
+// Real fix (2026-08-17, THIRD pass): same stack-staleness problem as
+// g_pendingDeclElements -- storing the raw pFunction pointer for later
+// re-reading was unsafe if it's ever stack-sourced. Store the already-
+// computed ucode hash instead (0 = invalid/not yet known), computed
+// immediately at CreateVertexShader time via computeShaderUcodeHash().
+thread_local uint64_t g_pendingShaderUcodeHash = 0;
+std::unordered_map<uint32_t, uint64_t> g_shaderHandleToUcodeHash;
+
+}  // namespace
+
+void dumpVertexDeclaration_hook(PPCRegister& r3, PPCRegister& r4, PPCRegister& r5,
+	PPCRegister& r6, PPCRegister& r7, PPCRegister& r8, PPCRegister& r9, PPCRegister& r10)
+{
+	(void)r4; (void)r5; (void)r6; (void)r7; (void)r8; (void)r9; (void)r10;
+	if (!REXCVAR_GET(renut_dump_vertex_decl)) return;
+	dumpCodeBytesOnce();
+
+	const uint32_t pElements = r3.u32;
+	if (pElements < 0x10000000u || pElements >= 0x90000000u) {
+		return;
+	}
+
+	// Real fix (2026-08-17, THIRD pass): parse immediately -- see
+	// g_pendingDeclElements's own comment for why deferring this read is
+	// fatally broken for (very common) stack-sourced element arrays.
+	std::vector<VertexDeclElement> elements = parsePlausibleVertexDecl(pElements);
+
+	bool alreadyLogged;
+	{
+		std::lock_guard<std::mutex> lock(g_declMutex);
+		g_pendingDeclElements = elements;
+		alreadyLogged = !g_declLogged.insert(pElements).second;
+	}
+	if (alreadyLogged || elements.empty()) return;
+
+	std::string line = "renut vertex decl:";
+	for (const VertexDeclElement& e : elements) {
+		char entry[64];
+		std::snprintf(entry, sizeof(entry), " off=%u type=%06x usage=%u usageIdx=%u",
+			e.offset, e.type, e.usage, e.usageIndex);
+		line += entry;
+	}
+
+	RNUT_INFO("{} (from {:#x}, {} elements)", line, pElements, elements.size());
+}
+
+// Fires at guest address 0x8264EAFC, sub_8264EA90's real return point
+// (confirmed via recompiled-code inspection: r3 there already holds either
+// the freshly-allocated handle or 0 on allocation failure -- both paths
+// converge on this label before the epilogue runs). Pairs the elements
+// pointer captured at function entry (dumpVertexDeclaration_hook, above)
+// with the handle this function is about to return, so
+// dumpVertexDeclarationSet_hook can later resolve the real elements array
+// from the handle SetVertexDeclaration actually receives.
+void dumpVertexDeclarationCreated_hook(PPCRegister& r3)
+{
+	if (!REXCVAR_GET(renut_dump_vertex_decl)) return;
+
+	const uint32_t handle = r3.u32;
+	if (handle < 0x10000000u || handle >= 0x90000000u) return;
+
+	std::lock_guard<std::mutex> lock(g_declMutex);
+	if (!g_pendingDeclElements.empty()) {
+		g_declHandleToElements[handle] = std::move(g_pendingDeclElements);
+		g_pendingDeclElements.clear();
+	}
+}
+
+// Fires at sub_8264E8B0's true entry (0x8264E8B0, same address
+// dumpVertexShader_hook already sits at for the separately-gated
+// dump_guest_shaders feature) -- captures the shader's ucode hash
+// IMMEDIATELY (see g_pendingShaderUcodeHash's own comment for why deferring
+// this to later is unsafe) for later pairing with the handle this function
+// is about to allocate and return. Independent of dumpVertexShader_hook's
+// own dump_guest_shaders gate: this needs to run whenever
+// renut_dump_vertex_decl is on, even if dump_guest_shaders is off.
+void dumpVertexShaderCreate_hook(PPCRegister& r3)
+{
+	if (!REXCVAR_GET(renut_dump_vertex_decl)) return;
+
+	uint64_t ucodeHash = 0;
+	if (!computeShaderUcodeHash(r3.u32, ucodeHash)) return;
+
+	std::lock_guard<std::mutex> lock(g_vsMutex);
+	g_pendingShaderUcodeHash = ucodeHash;
+}
+
+// Fires at sub_8264E8B0's real return point (0x8264E998, confirmed via
+// recompiled-code inspection the same way as dumpVertexDeclarationCreated_hook
+// -- both the success path (loc_8264E96C) and failure path (loc_8264E8E4)
+// converge here with r3 already holding the final handle, or 0). Pairs it
+// with the ucode hash computed at entry above.
+void dumpVertexShaderCreated_hook(PPCRegister& r3)
+{
+	if (!REXCVAR_GET(renut_dump_vertex_decl)) return;
+
+	const uint32_t handle = r3.u32;
+	if (handle < 0x10000000u || handle >= 0x90000000u) return;
+
+	std::lock_guard<std::mutex> lock(g_vsMutex);
+	if (g_pendingShaderUcodeHash != 0) {
+		g_shaderHandleToUcodeHash[handle] = g_pendingShaderUcodeHash;
+		g_pendingShaderUcodeHash = 0;
+	}
+}
+
+// Real bug found+fixed 2026-08-17: this is called from SetVertexShader AND
+// SetVertexDeclaration, both genuinely hot per-draw paths -- unconditionally
+// logging every bail meant ~70,000 lines/second in real play, which filled
+// and rotated past the log's whole retention window (21 files x 5MB) in
+// under 15 SECONDS. That silently destroyed the one-time startup-phase
+// evidence (real CreateVertexDeclaration captures) this capture pipeline
+// most needs to debug, and produced logs too foot-gunned to read. Each bail
+// reason is now logged only the first kMaxBailLogs times (still enough to
+// confirm the pattern) rather than forever.
+namespace {
+constexpr uint32_t kMaxBailLogs = 20;
+std::atomic<uint32_t> g_bailNoElementsLogged{0};
+std::atomic<uint32_t> g_bailNoHashLogged{0};
+}  // namespace
+
+// Real fix (2026-08-17, THIRD pass): takes ALREADY-PARSED, already-validated
+// data -- no more re-reading pElements/pFunction memory here, since both are
+// frequently stack-sourced and long stale by the time this runs (see
+// g_pendingDeclElements's and g_pendingShaderUcodeHash's own comments).
+void dumpVertexDeclUsage(const std::vector<VertexDeclElement>& elements, uint64_t ucodeHash)
+{
+	if (elements.empty()) {
+		if (g_bailNoElementsLogged.fetch_add(1, std::memory_order_relaxed) < kMaxBailLogs) {
+			RNUT_INFO("renut vertdecl DIAG: bail no elements resolved");
+		}
+		return;
+	}
+	if (ucodeHash == 0) {
+		if (g_bailNoHashLogged.fetch_add(1, std::memory_order_relaxed) < kMaxBailLogs) {
+			RNUT_INFO("renut vertdecl DIAG: bail no ucode hash resolved");
+		}
+		return;
+	}
+
+	{
+		std::lock_guard<std::mutex> lock(g_declMutex);
+		if (!g_vertDeclDumped.insert(ucodeHash).second) {
+			return;
+		}
+	}
+
+	const std::filesystem::path outDir =
+		rex::filesystem::GetExecutableFolder() / "shaders_vertdecl";
+	std::error_code ec;
+	std::filesystem::create_directories(outDir, ec);
+	if (ec) {
+		RNUT_INFO("renut vertdecl DIAG: bail create_directories failed ({})", ec.message());
+		return;
+	}
+
+	char stem[48];
+	std::snprintf(stem, sizeof(stem), "vs_%016llx", static_cast<unsigned long long>(ucodeHash));
+	std::ofstream file(outDir / (std::string(stem) + ".vertdecl.txt"), std::ios::trunc);
+	if (!file) {
+		RNUT_INFO("renut vertdecl DIAG: bail ofstream failed for vs_{:016x}", ucodeHash);
+		return;
+	}
+
+	for (const VertexDeclElement& e : elements) {
+		file << "offset=" << e.offset << " type=" << std::hex << e.type << std::dec
+			<< " usage=" << int(e.usage) << " usageIndex=" << int(e.usageIndex) << "\n";
+	}
+
+	RNUT_INFO("vertex decl usage: vs_{:016x} ({} elements)", ucodeHash, elements.size());
+}
+
+// TEMP DIAGNOSTIC (2026-08-16): writes a real hex-dump of a D3D9 object's
+// first 64 bytes straight to a file (immune to the log's 5MB rotation,
+// which was confirmed real -- the once-per-process log line this used to
+// be next to never survived to be read back, rotated out before the
+// session ended even though the hook body itself demonstrably ran, per
+// the "vertdecl DIAG: bail pElements range 0x0" lines proving
+// dumpVertexShaderSet_hook executes every call). One file per (tag,
+// object address) so repeated binds of the same object don't spam.
+void dumpObjectHex(const char* tag, uint32_t pObject)
+{
+	if (pObject < 0x10000000u || pObject >= 0x90000000u) return;
+	const std::filesystem::path outDir = rex::filesystem::GetExecutableFolder() / "shaders_objdump";
+	std::error_code ec;
+	std::filesystem::create_directories(outDir, ec);
+	if (ec) return;
+	char stem[64];
+	std::snprintf(stem, sizeof(stem), "%s_%08x.txt", tag, pObject);
+	const std::filesystem::path path = outDir / stem;
+	if (std::filesystem::exists(path)) return;
+
+	const uint8_t* base = rex::Runtime::instance()->virtual_membase();
+	const uint32_t* obj = reinterpret_cast<const uint32_t*>(base + pObject);
+	std::ofstream file(path, std::ios::trunc);
+	if (!file) return;
+	// Real captured blob pointers (shader dump: vs_... "from 0x43785820"
+	// style log lines) all land in 0x43000000-0x44ffffff with a real
+	// ShaderContainer flags dword (0x102a11xx) at their own +0 -- widened
+	// to 128 bytes and each field that looks like a plausible pointer gets
+	// ONE extra dereference tried and reported too, in case the real blob
+	// pointer needs indirection through this object rather than being a
+	// direct field.
+	for (int i = 0; i < 32; ++i) {
+		uint32_t value = RENUT_BSWAP32(obj[i]);
+		file << "[+" << std::hex << (i * 4) << "]=" << value;
+		if (value >= 0x40000000u && value < 0x50000000u) {
+			uint32_t deref = RENUT_BSWAP32(*reinterpret_cast<const uint32_t*>(base + value));
+			file << " -> [0]=" << deref;
+		}
+		file << std::dec << "\n";
+	}
+}
+
+namespace {
+
+// Resolve a SetVertexDeclaration handle (r4 at 0x82205700) back to the
+// already-parsed elements captured at CreateVertexDeclaration time (see
+// g_declHandleToElements's own comment). Returns an empty vector if the
+// handle was never seen created (e.g. renut_dump_vertex_decl was enabled
+// only after this declaration was already created) or its capture didn't
+// pass plausibility validation.
+std::vector<VertexDeclElement> resolveDeclElements(uint32_t handle)
+{
+	std::lock_guard<std::mutex> lock(g_declMutex);
+	auto it = g_declHandleToElements.find(handle);
+	return it != g_declHandleToElements.end() ? it->second : std::vector<VertexDeclElement>{};
+}
+
+// r4 at SetVertexShader (0x8222A0A8) is the HANDLE sub_8264E8B0 returned,
+// not the real shader-blob pointer -- see g_shaderHandleToUcodeHash's own
+// comment.
+uint64_t resolveShaderUcodeHash(uint32_t handle)
+{
+	std::lock_guard<std::mutex> lock(g_vsMutex);
+	auto it = g_shaderHandleToUcodeHash.find(handle);
+	return it != g_shaderHandleToUcodeHash.end() ? it->second : 0;
+}
+
+}  // namespace
+
+void dumpVertexShaderSet_hook(PPCRegister& r3, PPCRegister& r4)
+{
+	if (!REXCVAR_GET(renut_dump_vertex_decl)) return;
+	static std::once_flag entered;
+	std::call_once(entered, [&] {
+		RNUT_INFO("renut SetVertexShader hook ENTERED: r3={:#x} r4={:#x}", r3.u32, r4.u32);
+	});
+	dumpObjectHex("vs_obj", r4.u32);
+	dumpCodeBytesOnce();
+	const uint64_t ucodeHash = resolveShaderUcodeHash(r4.u32);
+	std::vector<VertexDeclElement> lastDecl;
+	{
+		std::lock_guard<std::mutex> lock(g_vsMutex);
+		g_lastBoundVertexShaderUcodeHash = ucodeHash;
+		lastDecl = g_lastBoundVertexDeclElements;
+	}
+	// Real fix (2026-08-16, see g_lastBoundVertexDeclElements's own comment):
+	// no fixed call order between this hook and SetVertexDeclaration, so
+	// also try the dump here using whatever declaration was bound most
+	// recently -- covers the (confirmed real) case where the declaration
+	// is set first.
+	dumpVertexDeclUsage(lastDecl, ucodeHash);
+}
+
+void dumpVertexDeclarationSet_hook(PPCRegister& r3, PPCRegister& r4)
+{
+	if (!REXCVAR_GET(renut_dump_vertex_decl)) return;
+	static std::once_flag entered;
+	std::call_once(entered, [&] {
+		RNUT_INFO("renut SetVertexDeclaration hook ENTERED: r3={:#x} r4={:#x}", r3.u32, r4.u32);
+	});
+	dumpObjectHex("decl_obj", r4.u32);
+	dumpCodeBytesOnce();
+	// r4 is the HANDLE sub_8264EA90 returned, not the real elements array
+	// pointer (see g_declHandleToElements's own comment) -- resolve it.
+	std::vector<VertexDeclElement> realElements = resolveDeclElements(r4.u32);
+	uint64_t lastShaderHash;
+	{
+		std::lock_guard<std::mutex> lock(g_vsMutex);
+		g_lastBoundVertexDeclElements = realElements;
+		lastShaderHash = g_lastBoundVertexShaderUcodeHash;
+	}
+	dumpVertexDeclUsage(realElements, lastShaderHash);
+}
+
+REXCVAR_DEFINE_BOOL(renut_dump_code, false, "Nuts&Bolts/Graphics",
+	"One-shot dump of raw guest code bytes at known D3D9 function addresses, "
+	"for offline PPC disassembly (native-renderer vertex-declaration work).");
+
+void dumpCodeBytesOnce()
+{
+	static std::once_flag dumped;
+	if (!REXCVAR_GET(renut_dump_code)) return;
+
+	std::call_once(dumped, [] {
+		const uint8_t* base = rex::Runtime::instance()->virtual_membase();
+		const std::filesystem::path outDir = rex::filesystem::GetExecutableFolder() / "code_dump";
+		std::error_code ec;
+		std::filesystem::create_directories(outDir, ec);
+		if (ec) {
+			RNUT_ERROR("code dump: cannot create {} ({})", outDir.string(), ec.message());
+			return;
+		}
+
+		struct Target {
+			uint32_t address;
+			const char* name;
+		};
+		static constexpr Target kTargets[] = {
+			{0x8264EA90u, "CreateVertexDeclaration"},
+			{0x8264E8B0u, "CreateVertexShader"},
+			{0x8264E6A8u, "CreatePixelShader"},
+			{0x8222A0A8u, "SetVertexShader"},
+			{0x82205700u, "SetVertexDeclaration"},
+		};
+		constexpr size_t kDumpBytes = 512;
+
+		for (const Target& t : kTargets) {
+			std::ofstream file(outDir / (std::string(t.name) + ".bin"), std::ios::binary | std::ios::trunc);
+			if (!file) {
+				RNUT_ERROR("code dump: could not open output for {}", t.name);
+				continue;
+			}
+			file.write(reinterpret_cast<const char*>(base + t.address),
+				static_cast<std::streamsize>(kDumpBytes));
+			RNUT_INFO("code dump: wrote {} bytes for {} @ {:#x} -> code_dump/{}.bin",
+				kDumpBytes, t.name, t.address, t.name);
+		}
+	});
 }

--- a/src/renut_engine/shader_dump.cpp
+++ b/src/renut_engine/shader_dump.cpp
@@ -48,7 +48,7 @@ std::unordered_set<uint64_t> g_dumped;
 //   +0x00 physicalOffset, +0x04 size, +0x08 field8, +0x0C fieldC,
 //   +0x10 field10, +0x14 interpolatorInfo  (24 bytes)
 //
-// Real bug fixed here (2026-08-16): words[1] ("headerSize") is actually
+// Real bug fixed here: words[1] ("headerSize") is actually
 // ShaderContainer::virtualSize, NOT a microcode start offset -- confirmed
 // via direct hex inspection of captured containers plus XenosRecomp's own
 // shader_recompiler.cpp:1559 (`shaderData + shaderContainer->virtualSize +
@@ -92,7 +92,7 @@ bool ResolveRealUcodeRange(const uint8_t* blob, uint32_t virtualSize, uint32_t p
 	return true;
 }
 
-// Real fix (2026-08-17): factored out of dumpVertexDeclUsage so it can be
+// factored out of dumpVertexDeclUsage so it can be
 // called from dumpVertexShaderCreate_hook -- see g_shaderHandleToUcodeHash's
 // own comment for why. Computes the SAME ucode-only hash
 // (post-ResolveRealUcodeRange) that must match the real Vulkan pipeline's
@@ -134,7 +134,7 @@ constexpr uint32_t kMaxVertexDeclElements = 32;  // scan cap, real decls are far
 constexpr uint32_t kMaxPlausibleVertexDeclElements = 16;
 constexpr uint8_t kMaxPlausibleVertexDeclUsage = 13;  // D3DDECLUSAGE_SAMPLE, the highest real value
 
-// Real fix (2026-08-17): MUST be called immediately when pElements is known
+// MUST be called immediately when pElements is known
 // fresh (at CreateVertexDeclaration time) -- see g_pendingDeclElements's own
 // comment for why deferring this read to SetVertexDeclaration time was
 // fatally broken (the array is frequently caller-stack-allocated and long
@@ -170,7 +170,7 @@ std::vector<VertexDeclElement> parsePlausibleVertexDecl(uint32_t pElements)
 		});
 	}
 
-	// Real safety fix (2026-08-17): the consumer (build_synthetic_container.py)
+	// Real safety fix: the consumer (build_synthetic_container.py)
 	// treats any captured file as ground truth, overriding its own heuristic
 	// fallback -- writing a garbage capture is WORSE than writing nothing,
 	// it would poison a shader the heuristic might have gotten right. Reject
@@ -225,8 +225,8 @@ void dumpShaderBlob(PPCRegister& r3, const char* tag)
 
 	const size_t total = static_cast<size_t>(headerSize) + ucodeSize;
 
-	// Real microcode range (2026-08-16 fix, see ResolveRealUcodeRange's
-	// header comment): headerSize/ucodeSize (virtualSize/physicalSize) mark
+	// Real microcode range (see ResolveRealUcodeRange's header comment):
+	// headerSize/ucodeSize (virtualSize/physicalSize) mark
 	// the whole container's virtual+physical regions, not where real Xenos
 	// instructions start/how long they run -- that needs shaderOffset ->
 	// Shader::physicalOffset/size. Falls back to the (known-wrong, but
@@ -241,7 +241,7 @@ void dumpShaderBlob(PPCRegister& r3, const char* tag)
 		realUcodeSize = ucodeSize;
 	}
 
-	// Real bug found+fixed (2026-08-18): this used to hash the whole blob
+	// Real bug found+fixed: this used to hash the whole blob
 	// (header+ucode, XXH3_64bits(blob, total)), NOT the same value as
 	// computeShaderUcodeHash() above or the real runtime
 	// Shader::ucode_data_hash() (pipeline_cache.cpp:
@@ -311,7 +311,7 @@ REXCVAR_DEFINE_BOOL(renut_dump_vertex_decl, false, "Nuts&Bolts/Graphics",
 std::mutex g_declMutex;
 std::unordered_set<uint32_t> g_declLogged;
 
-// Real fix (2026-08-17): sub_8264EA90 (the guest function this project's
+// sub_8264EA90 (the guest function this project's
 // "CreateVertexDeclaration" hook sits at the true entry of, confirmed via
 // direct recompiled-PPC-code inspection) allocates a NEW handle object and
 // returns it in r3 -- SetVertexDeclaration (0x82205700) later receives that
@@ -326,10 +326,9 @@ std::unordered_set<uint32_t> g_declLogged;
 // build a handle -> elements-pointer map so SetVertexDeclaration can look
 // up the real array by the handle it actually receives.
 //
-// Real bug found+fixed 2026-08-17 (second pass, after first real captures
-// came back corrupted): this game creates vertex declarations from MULTIPLE
-// THREADS concurrently (confirmed real -- captured log shows CreateVertexDeclaration
-// hooks firing from several distinct thread IDs). A single shared
+// This game creates vertex declarations from MULTIPLE THREADS concurrently
+// (confirmed -- captured log shows CreateVertexDeclaration hooks firing
+// from several distinct thread IDs). A single shared
 // g_pendingDeclElements meant thread A's entry-hook value could be
 // overwritten by thread B's own Create call before thread A's OWN exit hook
 // read it back, silently pairing thread A's handle with thread B's elements
@@ -340,8 +339,8 @@ std::unordered_set<uint32_t> g_declLogged;
 // thread's concurrent Create calls (safe because a single thread cannot
 // reenter CreateVertexDeclaration on itself before its own call returns).
 //
-// Real fix (2026-08-17, THIRD pass): even with thread_local, real captures
-// STILL came back corrupted -- proof: the exact same decl address
+// Even with thread_local, captures STILL came back corrupted -- proof:
+// the exact same decl address
 // (0x7018ef00) parsed to a DIFFERENT element count at different points in
 // the same session, which is impossible for real static data. Root cause:
 // pElements is very often a CALLER-STACK-ALLOCATED array (a local variable
@@ -359,7 +358,7 @@ std::unordered_map<uint32_t, std::vector<VertexDeclElement>> g_declHandleToEleme
 
 std::mutex g_vsMutex;
 uint64_t g_lastBoundVertexShaderUcodeHash = 0;
-// Real fix (2026-08-16): SetVertexDeclaration and SetVertexShader do NOT
+// SetVertexDeclaration and SetVertexShader do NOT
 // have a fixed call order -- confirmed via real captured log, this game
 // calls SetVertexDeclaration BEFORE SetVertexShader, so tracking only "the
 // last bound vertex shader" and dumping from the declaration hook alone
@@ -372,7 +371,7 @@ uint64_t g_lastBoundVertexShaderUcodeHash = 0;
 std::vector<VertexDeclElement> g_lastBoundVertexDeclElements;
 std::unordered_set<uint64_t> g_vertDeclDumped;
 
-// Real fix (2026-08-17): the SAME handle-vs-real-pointer confusion as
+// the SAME handle-vs-real-pointer confusion as
 // g_declHandleToElements above, but for vertex shaders. sub_8264E8B0 (the
 // guest function dumpVertexShader_hook already sits at the true entry of,
 // used by the separately-gated dump_guest_shaders feature) ALSO allocates a
@@ -389,8 +388,8 @@ std::unordered_set<uint64_t> g_vertDeclDumped;
 // above (multi-threaded CreateVertexShader calls cross-contaminating a
 // shared pending value).
 //
-// Real fix (2026-08-17, THIRD pass): same stack-staleness problem as
-// g_pendingDeclElements -- storing the raw pFunction pointer for later
+// Same stack-staleness problem as g_pendingDeclElements -- storing the
+// raw pFunction pointer for later
 // re-reading was unsafe if it's ever stack-sourced. Store the already-
 // computed ucode hash instead (0 = invalid/not yet known), computed
 // immediately at CreateVertexShader time via computeShaderUcodeHash().
@@ -411,8 +410,8 @@ void dumpVertexDeclaration_hook(PPCRegister& r3, PPCRegister& r4, PPCRegister& r
 		return;
 	}
 
-	// Real fix (2026-08-17, THIRD pass): parse immediately -- see
-	// g_pendingDeclElements's own comment for why deferring this read is
+	// Parse immediately -- see g_pendingDeclElements's own comment for
+	// why deferring this read is
 	// fatally broken for (very common) stack-sourced element arrays.
 	std::vector<VertexDeclElement> elements = parsePlausibleVertexDecl(pElements);
 
@@ -495,7 +494,7 @@ void dumpVertexShaderCreated_hook(PPCRegister& r3)
 	}
 }
 
-// Real bug found+fixed 2026-08-17: this is called from SetVertexShader AND
+// this is called from SetVertexShader AND
 // SetVertexDeclaration, both genuinely hot per-draw paths -- unconditionally
 // logging every bail meant ~70,000 lines/second in real play, which filled
 // and rotated past the log's whole retention window (21 files x 5MB) in
@@ -510,8 +509,8 @@ std::atomic<uint32_t> g_bailNoElementsLogged{0};
 std::atomic<uint32_t> g_bailNoHashLogged{0};
 }  // namespace
 
-// Real fix (2026-08-17, THIRD pass): takes ALREADY-PARSED, already-validated
-// data -- no more re-reading pElements/pFunction memory here, since both are
+// Takes ALREADY-PARSED, already-validated data -- no more re-reading
+// pElements/pFunction memory here, since both are
 // frequently stack-sourced and long stale by the time this runs (see
 // g_pendingDeclElements's and g_pendingShaderUcodeHash's own comments).
 void dumpVertexDeclUsage(const std::vector<VertexDeclElement>& elements, uint64_t ucodeHash)
@@ -561,7 +560,7 @@ void dumpVertexDeclUsage(const std::vector<VertexDeclElement>& elements, uint64_
 	RNUT_INFO("vertex decl usage: vs_{:016x} ({} elements)", ucodeHash, elements.size());
 }
 
-// TEMP DIAGNOSTIC (2026-08-16): writes a real hex-dump of a D3D9 object's
+// TEMP DIAGNOSTIC: writes a real hex-dump of a D3D9 object's
 // first 64 bytes straight to a file (immune to the log's 5MB rotation,
 // which was confirmed real -- the once-per-process log line this used to
 // be next to never survived to be read back, rotated out before the
@@ -646,8 +645,8 @@ void dumpVertexShaderSet_hook(PPCRegister& r3, PPCRegister& r4)
 		g_lastBoundVertexShaderUcodeHash = ucodeHash;
 		lastDecl = g_lastBoundVertexDeclElements;
 	}
-	// Real fix (2026-08-16, see g_lastBoundVertexDeclElements's own comment):
-	// no fixed call order between this hook and SetVertexDeclaration, so
+	// See g_lastBoundVertexDeclElements's own comment: no fixed call order
+	// between this hook and SetVertexDeclaration, so
 	// also try the dump here using whatever declaration was bound most
 	// recently -- covers the (confirmed real) case where the declaration
 	// is set first.

--- a/src/renut_engine/shader_dump.h
+++ b/src/renut_engine/shader_dump.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <cstdint>
+
+namespace renut::shader_dump {
+
+// Resolves a SetVertexShader (0x8222A0A8) handle argument back to the ucode
+// hash captured when that handle was created (CreateVertexShader,
+// 0x8264E8B0/0x8264E998) -- see shader_dump.cpp's g_shaderHandleToUcodeHash
+// for the full story. Returns false if the handle was never seen created
+// (e.g. it bypassed CreateVertexShader entirely via IM_LOAD -- this is
+// exactly the signal docs/ai/archive/native-renderer-rewrite-plan.md's
+// Phase 0 needs to measure). Always available regardless of the
+// renut_dump_vertex_decl cvar: the underlying capture is unconditional
+// (cheap hash+map-insert, no I/O), only file dumping is cvar-gated.
+bool TryResolveShaderUcodeHash(uint32_t handle, uint64_t& outHash);
+
+}

--- a/src/renut_engine/sleep.h
+++ b/src/renut_engine/sleep.h
@@ -43,4 +43,4 @@ ppc_u32_result_t Sleep_hook(ppc_u32_t ms) {
 
     return 0;
 }
-PPC_HOOK(sub_82715B60, Sleep_hook);
+REX_HOOK(sub_82715B60, Sleep_hook);

--- a/src/renut_engine/trace_stats.cpp
+++ b/src/renut_engine/trace_stats.cpp
@@ -1,0 +1,64 @@
+#include "renut_engine/trace_stats.h"
+
+#include <mutex>
+
+#include <rex/graphics/vulkan/renut_trace_hook.h>
+
+namespace renut::trace_stats {
+
+namespace {
+std::mutex g_mutex;
+Snapshot g_latest;
+}
+
+Snapshot GetLatest() {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    return g_latest;
+}
+
+// Strong definition of the weak hook declared in renut_trace_hook.h: the
+// nativevk/xenos plugin (loaded into this same process) calls this once per
+// frame with everything it measured. Must be exported to the plugin's
+// dynamic symbol table (see CMakeLists.txt's --export-dynamic-symbol) so its
+// PLT entry resolves here instead of staying null. extern "C" keeps the name
+// unmangled to match renut_trace_hook.h's declaration exactly.
+extern "C" void RenutEmitTraceRow(const RenutTraceRow* row) {
+    if (!row) {
+        return;
+    }
+    Snapshot snapshot;
+    snapshot.available = true;
+    snapshot.path = "(live)";
+    auto& values = snapshot.values;
+    values.reserve(32);
+    values["frame"] = double(row->frame);
+    values["draws"] = double(row->draws);
+    values["frame_ms"] = row->frame_ms;
+    values["issuedraw_ms"] = row->issuedraw_ms;
+    values["ns_per_draw"] = row->ns_per_draw;
+    values["prim_ms"] = row->prim_ms;
+    values["samp_ms"] = row->samp_ms;
+    values["tex_ms"] = row->tex_ms;
+    values["rt_ms"] = row->rt_ms;
+    values["pipe_ms"] = row->pipe_ms;
+    values["shadertrans_ms"] = row->shadertrans_ms;
+    values["sysconst_ms"] = row->sysconst_ms;
+    values["vfetch_ms"] = row->vfetch_ms;
+    values["dyn_ms"] = row->dyn_ms;
+    values["bind_ms"] = row->bind_ms;
+    values["memexport_ms"] = row->memexport_ms;
+    values["renderpass_enter_ms"] = row->renderpass_enter_ms;
+    values["drawcmd_ms"] = row->drawcmd_ms;
+    values["gpuwait_ms"] = row->gpuwait_ms;
+    values["gpuwait_n"] = double(row->gpuwait_n);
+    values["swap_ms"] = row->swap_ms;
+    values["issuecopy_ms"] = row->issuecopy_ms;
+    values["issuecopy_n"] = double(row->issuecopy_n);
+    values["depthonly"] = double(row->depthonly);
+    values["nopixelshader"] = double(row->nopixelshader);
+
+    std::lock_guard<std::mutex> lock(g_mutex);
+    g_latest = std::move(snapshot);
+}
+
+}

--- a/src/renut_engine/trace_stats.cpp
+++ b/src/renut_engine/trace_stats.cpp
@@ -2,7 +2,7 @@
 
 #include <mutex>
 
-#include <rex/graphics/vulkan/renut_trace_hook.h>
+#include "renut_engine/renut_trace_hook.h"
 
 namespace renut::trace_stats {
 

--- a/src/renut_engine/trace_stats.cpp
+++ b/src/renut_engine/trace_stats.cpp
@@ -9,6 +9,16 @@ namespace renut::trace_stats {
 namespace {
 std::mutex g_mutex;
 Snapshot g_latest;
+// Session-cumulative sum of row->draws across every RenutEmitTraceRow call
+// (2026-08-19, see docs/ai/archive/native-renderer-rewrite-plan.md Phase 0):
+// a single frame's "draws" value isn't safely comparable against
+// nativevk_phase0's session-cumulative D3D9-hook draw count -- the two hook
+// mechanisms don't share a common, reliably-firing per-frame boundary (the
+// appMainDrawStart/appMainDrawend pair Phase 0 originally used to scope a
+// "last frame" snapshot turned out not to fire once per real frame; see that
+// file's own comment). Comparing session totals sidesteps needing any frame
+// alignment between the two measurement paths at all.
+uint64_t g_sessionDrawsTotal = 0;
 }
 
 Snapshot GetLatest() {
@@ -58,6 +68,8 @@ extern "C" void RenutEmitTraceRow(const RenutTraceRow* row) {
     values["nopixelshader"] = double(row->nopixelshader);
 
     std::lock_guard<std::mutex> lock(g_mutex);
+    g_sessionDrawsTotal += row->draws;
+    values["session_draws_total"] = double(g_sessionDrawsTotal);
     g_latest = std::move(snapshot);
 }
 

--- a/src/renut_engine/trace_stats.h
+++ b/src/renut_engine/trace_stats.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+namespace renut::trace_stats {
+
+struct Snapshot {
+    bool available = false;
+    std::string path;
+    std::unordered_map<std::string, double> values;
+};
+
+// Latest per-frame GPU trace row, updated live from the render thread via
+// RenutEmitTraceRow (see rex/graphics/vulkan/renut_trace_hook.h and this
+// file's .cpp) -- no file on disk, no polling.
+Snapshot GetLatest();
+
+}

--- a/tools/batch_build_synthetic_containers.py
+++ b/tools/batch_build_synthetic_containers.py
@@ -3,11 +3,10 @@
 capture in shaders_ucode_hash/ (produced by the renut_dump_ucode_hash cvar,
 keyed by the real runtime ucode_data_hash() -- NOT shader_dump.cpp's D3D9-
 hook-based captures, which structurally miss most of this game's actual
-draw-time shaders; see PLAN_native_renderer.md and this session's own
-investigation: 0% overlap between shader_dump.cpp's captures and real
-`renut color draw pair` draw identities, root-caused to IM_LOAD/
+draw-time shaders (confirmed 0% overlap between shader_dump.cpp's captures
+and real `renut color draw pair` draw identities, root-caused to IM_LOAD/
 IM_LOAD_IMMEDIATE GPU command-stream shader loads that never call D3D9's
-CreateVertexShader/CreatePixelShader at all).
+CreateVertexShader/CreatePixelShader at all -- see docs/ai/research.md).
 
 Builds one synthetic ShaderContainer .bin per real .ucode file into
 OUTPUT_DIR, using the same real vertex-fetch/texture-fetch analysis
@@ -23,7 +22,7 @@ Usage:
 --reject-heuristic: skip (don't emit a container for) any vertex shader
     whose semantics needed the fallback POSITION-first/TEXCOORD-follows
     heuristic (no real captured D3D9 vertex declaration available) --
-    real fix for a real, confirmed 2026-08-16 finding: applying that
+    fix for a confirmed finding: applying that
     heuristic broadly (not just to the one shader it was originally
     verified against) produces genuinely wrong vertex data for shaders
     with different real layouts (normals, colors, multiple UV sets in a
@@ -31,7 +30,7 @@ Usage:
     ~150 heuristic-based shaders went live simultaneously. Real vertex-
     declaration capture is structurally unavailable for most of these
     shaders (same IM_LOAD root cause as shader creation itself bypassing
-    D3D9 hooks -- see PLAN_native_renderer.md), so this flag is the
+    D3D9 hooks -- see docs/ai/research.md), so this flag is the
     practical way to get a smaller but verified-correct native shader set
     instead of a larger but partially-wrong one. Pixel shaders are
     unaffected (no vertex-semantic heuristic exists for them).
@@ -87,7 +86,7 @@ def main() -> int:
         if proc.returncode == 0 and out_path.exists():
             results.append((stem, "ok"))
         elif proc.returncode == 2:
-            # Real fix (2026-08-17): build_synthetic_container.py's own
+            # build_synthetic_container.py's own
             # REJECTED line on stderr already distinguishes "no real vertex
             # declaration, --reject-heuristic given" from "references a
             # missing-literal-constant register" -- surface which one

--- a/tools/batch_build_synthetic_containers.py
+++ b/tools/batch_build_synthetic_containers.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Runs tools/build_synthetic_container.py against EVERY real raw-ucode
+capture in shaders_ucode_hash/ (produced by the renut_dump_ucode_hash cvar,
+keyed by the real runtime ucode_data_hash() -- NOT shader_dump.cpp's D3D9-
+hook-based captures, which structurally miss most of this game's actual
+draw-time shaders; see PLAN_native_renderer.md and this session's own
+investigation: 0% overlap between shader_dump.cpp's captures and real
+`renut color draw pair` draw identities, root-caused to IM_LOAD/
+IM_LOAD_IMMEDIATE GPU command-stream shader loads that never call D3D9's
+CreateVertexShader/CreatePixelShader at all).
+
+Builds one synthetic ShaderContainer .bin per real .ucode file into
+OUTPUT_DIR, using the same real vertex-fetch/texture-fetch analysis
+(tools/ucode_analyze) build_synthetic_container.py already uses for single
+shaders -- this script is purely the batch driver, no new container-building
+logic. OUTPUT_DIR is meant to be fed into tools/xenos_batch_convert.py
+exactly like shader_dump.cpp's shaders/ directory is.
+
+Usage:
+    batch_build_synthetic_containers.py <ucode_dir> <output_dir>
+        [<ucode_analyze_path>] [--reject-heuristic]
+
+--reject-heuristic: skip (don't emit a container for) any vertex shader
+    whose semantics needed the fallback POSITION-first/TEXCOORD-follows
+    heuristic (no real captured D3D9 vertex declaration available) --
+    real fix for a real, confirmed 2026-08-16 finding: applying that
+    heuristic broadly (not just to the one shader it was originally
+    verified against) produces genuinely wrong vertex data for shaders
+    with different real layouts (normals, colors, multiple UV sets in a
+    different order), causing visible in-game geometry corruption once
+    ~150 heuristic-based shaders went live simultaneously. Real vertex-
+    declaration capture is structurally unavailable for most of these
+    shaders (same IM_LOAD root cause as shader creation itself bypassing
+    D3D9 hooks -- see PLAN_native_renderer.md), so this flag is the
+    practical way to get a smaller but verified-correct native shader set
+    instead of a larger but partially-wrong one. Pixel shaders are
+    unaffected (no vertex-semantic heuristic exists for them).
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    if len(sys.argv) < 3:
+        print(__doc__)
+        return 1
+
+    ucode_dir = Path(sys.argv[1])
+    output_dir = Path(sys.argv[2])
+    remaining = sys.argv[3:]
+    reject_heuristic = "--reject-heuristic" in remaining
+    remaining = [a for a in remaining if a != "--reject-heuristic"]
+    ucode_analyze_path = remaining[0] if remaining else None
+
+    if not ucode_dir.is_dir():
+        print(f"batch_build_synthetic_containers: '{ucode_dir}' is not a directory")
+        return 1
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    build_script = Path(__file__).parent / "build_synthetic_container.py"
+
+    results = []  # (tag, status)
+    ucode_files = sorted(ucode_dir.glob("*.ucode"))
+    for ucode_path in ucode_files:
+        stem = ucode_path.stem  # e.g. "vs_1e6883fccde1f688"
+        if "_" not in stem:
+            continue
+        kind, hex_hash = stem.split("_", 1)
+        if kind not in ("vs", "ps"):
+            continue
+
+        out_path = output_dir / f"{stem}.bin"
+        cmd = [sys.executable, str(build_script), str(ucode_dir), kind, hex_hash, str(out_path)]
+        if ucode_analyze_path:
+            cmd += ["--ucode-analyze", ucode_analyze_path]
+        if reject_heuristic and kind == "vs":
+            cmd += ["--reject-heuristic"]
+
+        try:
+            proc = subprocess.run(cmd, capture_output=True, timeout=30)
+        except subprocess.TimeoutExpired:
+            results.append((stem, "timeout"))
+            continue
+
+        if proc.returncode == 0 and out_path.exists():
+            results.append((stem, "ok"))
+        elif proc.returncode == 2:
+            # Real fix (2026-08-17): build_synthetic_container.py's own
+            # REJECTED line on stderr already distinguishes "no real vertex
+            # declaration, --reject-heuristic given" from "references a
+            # missing-literal-constant register" -- surface which one
+            # instead of collapsing both into "rejected-heuristic", so the
+            # manifest can actually be used to see why without re-running
+            # the script by hand.
+            reason = "rejected-heuristic"
+            marker = b"build_synthetic_container: REJECTED"
+            idx = proc.stderr.find(marker)
+            if idx != -1:
+                line = proc.stderr[idx:].split(b"\n", 1)[0]
+                after_dashes = line.split(b" -- ", 1)
+                if len(after_dashes) == 2:
+                    reason = f"rejected:{after_dashes[1].decode(errors='replace')}"
+            results.append((stem, reason))
+        else:
+            results.append((stem, "fail"))
+
+    ok = sum(1 for _, s in results if s == "ok")
+    print(f"batch_build_synthetic_containers: {ok}/{len(results)} synthetic containers built "
+          f"({len(results) - ok} failed -- usually 'no vertex_bindings' for shaders with no "
+          f"real vfetch instructions, or a ucode_analyze crash on unusual control flow)")
+
+    fail_reasons = {}
+    for tag, status in results:
+        if status != "ok":
+            fail_reasons[status] = fail_reasons.get(status, 0) + 1
+    for reason, count in sorted(fail_reasons.items(), key=lambda kv: -kv[1]):
+        print(f"  {count} x {reason}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/build_synthetic_container.py
+++ b/tools/build_synthetic_container.py
@@ -3,14 +3,14 @@
 never captured by shader_dump.cpp's dump_guest_shaders hook (D3D9
 CreateVertexShader/CreatePixelShader), because it was loaded directly into
 GPU sequencer memory via IM_LOAD/IM_LOAD_IMMEDIATE PM4 packets -- confirmed
-real, structural gap, not a capture-timing bug (see PLAN_native_renderer.md).
+a structural gap, not a capture-timing bug (see docs/ai/research.md).
 
 Real raw microcode for such shaders IS available via the SDK's
 renut_dump_ucode_hash cvar (shaders_ucode_hash/<vs|ps>_<hash>.ucode), keyed
 by the real ucode_data_hash(). This script wraps that real microcode in a
 minimal, hand-built ShaderContainer.
 
-Automated end to end (2026-08-15 generalization): all per-shader vertex-fetch
+Automated end to end: all per-shader vertex-fetch
 and texture-fetch metadata (element count, data format, byte offset,
 instruction address, sampler fetch-constant/register mapping, interpolator
 count, color-output mask) is obtained by running tools/ucode_analyze -- a
@@ -79,9 +79,9 @@ _FORMAT_8_8_8_8 = 6
 # 11_11_10 get manual unpacking) -- but a real, consistent pattern was found
 # by sampling this game's actual captured shaders: 2-3 consecutive
 # 2_10_10_10 attributes immediately after POSITION, matching the exact
-# normal/tangent/binormal SHAPE, recurs across many real shaders (2026-08-16
-# sampling: vs_0112bc639335c58a, vs_054f86bb3d84dbb9, vs_07462764505df374,
-# etc all show this). Treating it the same as the documented normal formats
+# normal/tangent/binormal SHAPE, recurs across many real shaders (sampled:
+# vs_0112bc639335c58a, vs_054f86bb3d84dbb9, vs_07462764505df374, etc all
+# show this). Treating it the same as the documented normal formats
 # is a REAL INFERENCE from observed data, not a documented XenosRecomp
 # convention -- it gets the Vulkan input LOCATION right (location 1, per
 # USAGE_LOCATIONS) even though XenosRecomp won't apply special R11G11B10
@@ -117,7 +117,7 @@ def build_real_constant_table(float_regs: list[int], sampler_regs: list[int],
     kCondJmp handling) instead of the correct `g_Booleans & (1 << N)` form
     -- confirmed via direct source reading, not guessed.
 
-    Real fix (2026-08-17): the float4 entries used to be one ConstantInfo
+    the float4 entries used to be one ConstantInfo
     PER REGISTER (registerCount=1 each). shader_recompiler.cpp's recompile()
     (the ALU operand-formatting code) only emits the safe, bounds-clamped
     indexed accessor `constantName(index [+ a0|+ aL])` -- the ONLY form that
@@ -143,7 +143,7 @@ def build_real_constant_table(float_regs: list[int], sampler_regs: list[int],
     correctness risk for shaders that never use dynamic addressing, only a
     (harmless) widening of the declared range.
     """
-    # Real fix (2026-08-17, follow-up): shader_recompiler.cpp's own
+    # shader_recompiler.cpp's own
     # `tailCount = (isPixelShader ? 224 : 256) - registerIndex` is baked
     # into the grouped macro it emits REGARDLESS of what registerCount this
     # script declares -- so a grouped entry covering a pixel-shader register
@@ -267,7 +267,7 @@ def assign_usage_from_vertdecl(attributes: list[dict], vertdecl_elements: list[d
 def assign_usage_heuristic(attributes: list[dict]) -> None:
     """Fallback when no real captured D3D9 declaration is available yet.
 
-    REAL FIX (2026-08-16, second pass): the original version of this
+    REAL FIX (second pass): the original version of this
     heuristic (POSITION-first, everything else TEXCOORD0/1/2/...) was only
     ever verified against the ONE shader this whole native-renderer effort
     started with. Deployed broadly (1500+ shaders) it produced confirmed,
@@ -296,7 +296,7 @@ def assign_usage_heuristic(attributes: list[dict]) -> None:
     # whether this list is the full attribute set or a partial-match
     # remainder (assign_usage_from_vertdecl may have already claimed real
     # usage for some attributes before this function ever sees the rest).
-    # RE-ENABLED (2026-08-16, same session): consuming a 2nd/3rd
+    # RE-ENABLED (same session): consuming a 2nd/3rd
     # consecutive packed-normal-shaped attribute as TANGENT/BINORMAL was
     # tried, made things measurably WORSE, and was reverted -- but the real
     # root cause was NOT this heuristic itself, it was a separate,
@@ -321,8 +321,8 @@ def assign_usage_heuristic(attributes: list[dict]) -> None:
     # a 2nd/3rd packed attribute isn't really tangent/binormal.
     _NORMAL_LIKE_USAGES = [DECL_USAGE_NORMAL, DECL_USAGE_TANGENT, DECL_USAGE_BINORMAL]
     _NORMAL_LIKE_FORMATS = (_FORMAT_10_11_11, _FORMAT_11_11_10, _FORMAT_2_10_10_10)
-    # Real fix (2026-08-16, see build_vertex_container's own comment on
-    # binding_index): XenosRecomp deduplicates/names vertex-shader input
+    # See build_vertex_container's own comment on binding_index:
+    # XenosRecomp deduplicates/names vertex-shader input
     # parameters purely by (usage, usageIndex) -- shader_recompiler.cpp's
     # `semantic = usage<<4 | usageIndex` -- GLOBALLY across the whole
     # shader, not per real vertex-fetch binding. So every usage_index
@@ -341,8 +341,8 @@ def assign_usage_heuristic(attributes: list[dict]) -> None:
     # secondary vertex streams, exactly this fix's real repro shape (a
     # second binding with many repeating float4 attributes, real
     # bone-matrix-shaped data).
-    # Real fix (2026-08-16, second gap in the same class of bug the
-    # position_usage_index comment above describes): COLOR was still
+    # Same class of bug as the position_usage_index comment above:
+    # COLOR was still
     # hardcoded to usage_index=0 unconditionally, unlike TEXCOORD (which
     # already incremented). Any shader with 2+ real 8_8_8_8-shaped
     # attributes (confirmed real crash: "redefinition of parameter
@@ -379,19 +379,18 @@ def assign_usage_heuristic(attributes: list[dict]) -> None:
 
 class HeuristicRejected(Exception):
     """Raised when reject_heuristic=True and any vertex attribute needed the
-    fallback usage heuristic -- a real, requested opt-in filter (2026-08-16
-    session finding: the heuristic corrupts real geometry for shaders whose
-    layout isn't POSITION-then-TEXCOORDs, confirmed via real in-game visual
-    corruption once ~150 heuristic-based shaders went live simultaneously;
-    real vertex-declaration capture is structurally unavailable for these
-    shaders, same IM_LOAD root cause as shader creation itself -- see
-    PLAN_native_renderer.md), so callers that only want verified-correct
+    fallback usage heuristic -- an opt-in filter (the heuristic corrupts
+    real geometry for shaders whose layout isn't POSITION-then-TEXCOORDs,
+    confirmed via in-game visual corruption once ~150 heuristic-based
+    shaders went live simultaneously; vertex-declaration capture is
+    structurally unavailable for these shaders, same IM_LOAD root cause as
+    shader creation itself -- see docs/ai/research.md), so callers that
+    only want verified-correct
     containers can skip the rest instead of emitting a wrong one."""
 
 
 class MissingLiteralConstantData(Exception):
-    """Real fix (2026-08-17, user-requested "what does the game actually
-    need from a shader" investigation): raised when this shader's real,
+    """raised when this shader's real,
     ucode_analyze-detected float_constants includes a register in the real,
     empirically-confirmed "compiler-embedded literal constant" range
     (>= 252) -- checked directly against REAL captured shaders (shaders/*.bin
@@ -439,7 +438,7 @@ def read_ps_interpolator_usages(ps_container_path: Path) -> dict[int, tuple[int,
     interpolators[] array (PixelShader::interpolators, shader.h) and
     returns {register: (usage, usage_index)} for each entry.
 
-    Real idea this exists for (2026-08-16, from external research into
+    Real idea this exists for (from external research into
     Xenia's architecture -- see renut_shader_conversion_blockers.md
     memory): a vertex shader export register N and the paired pixel
     shader's import register N must carry the SAME real usage/usageIndex
@@ -502,7 +501,7 @@ def build_vertex_container(ucode_bytes: bytes, analysis: dict, vertdecl_elements
     # uses multiple bindings would need every attribute across all of them,
     # which this flattens rather than dropping).
     #
-    # Real bug found+fixed (2026-08-16): binding_index is now tracked and
+    # Real bug found+fixed: binding_index is now tracked and
     # carried through -- it did NOT exist before, and attributes were
     # sorted by offset_words GLOBALLY across every binding combined. Since
     # offset_words is relative to EACH BINDING's own stream (not a single
@@ -557,7 +556,7 @@ def build_vertex_container(ucode_bytes: bytes, analysis: dict, vertdecl_elements
     interpolator_count = bin(analysis["writes_interpolators"]).count("1")
 
     # VertexElement and Interpolator have DIFFERENT real on-disk bit layouts
-    # -- found EMPIRICALLY (2026-08-15) using a debug build of the real
+    # -- found EMPIRICALLY using a debug build of the real
     # XenosRecomp binary (fprintf added at each read site in
     # shader_recompiler.cpp), tested against a real container with single-
     # nibble/field-set test values swept across every bit position. This
@@ -577,7 +576,7 @@ def build_vertex_container(ucode_bytes: bytes, analysis: dict, vertdecl_elements
         pack_vertex_element(a["instr_addr"], a["usage"], a["usage_index"]) for a in attributes
     ]
 
-    # Real fix attempt (2026-08-16): interpolator OUTPUTS are a completely
+    # Interpolator OUTPUTS are a completely
     # different concept from vertex INPUTS (confirmed via direct
     # shader_recompiler.cpp reading: XenosRecomp's VS function signature
     # declares its interpolator outputs from a FIXED, global INTERPOLATORS[]
@@ -603,7 +602,7 @@ def build_vertex_container(ucode_bytes: bytes, analysis: dict, vertdecl_elements
     # XenosRecomp wires them together by index, this guarantees correct
     # linkage regardless of whether the usage NAME is "semantically real"
     # for this specific shader.
-    # Real, correct algorithm (2026-08-16, replaces the vertex-input-based
+    # Real, correct algorithm (replaces the vertex-input-based
     # guess above and the popcount-based interpolator_count from earlier):
     # confirmed via direct source reading (shader_code.h's ExportRegister
     # enum: VSInterpolator0..15 == literal values 0..15) that a vertex
@@ -691,7 +690,7 @@ def build_vertex_container(ucode_bytes: bytes, analysis: dict, vertdecl_elements
     vertex_shader_header += struct.pack(f">{len(vertex_elements)}I", *vertex_elements)
     vertex_shader_header += struct.pack(f">{len(interpolators)}I", *interpolators)
 
-    # Real fix (2026-08-17, follow-up): a shader using ONLY dynamic (a0/aL-
+    # A shader using ONLY dynamic (a0/aL-
     # relative) float constant addressing has NO entries in float_constants
     # at all (AnalyzeUcode only records STATIC register references there --
     # see translator.cpp's GatherOperandInformation, which sets
@@ -702,7 +701,7 @@ def build_vertex_container(ucode_bytes: bytes, analysis: dict, vertdecl_elements
     # c(...)` to resolve to. Matches xenos_synthesize_constant_table.py's
     # own real fix for the identical gap.
     float_constants = analysis.get("float_constants", [])
-    # Real fix (2026-08-17): check BEFORE the dynamic-addressing expansion
+    # check BEFORE the dynamic-addressing expansion
     # below -- that expansion legitimately claims the full 0-255 range for
     # an unrelated reason (the runtime can't know which specific registers
     # a dynamic a0/aL-relative access might touch), which would otherwise
@@ -761,7 +760,7 @@ def build_pixel_container(ucode_bytes: bytes, analysis: dict) -> bytes:
 
     field18 = 0
     interpolator_info = (len(interpolators) & 0x1F) << 5
-    # Real bug found+fixed (2026-08-16): only writes_color_targets bits were
+    # Real bug found+fixed: only writes_color_targets bits were
     # ever set here -- PIXEL_SHADER_OUTPUT_DEPTH was never included even
     # for shaders that genuinely write oDepth (real manual-depth-write
     # shaders, confirmed via real DXC "use of undeclared identifier
@@ -779,8 +778,8 @@ def build_pixel_container(ucode_bytes: bytes, analysis: dict) -> bytes:
     pixel_shader_header += struct.pack(f">{len(interpolator_words)}I", *interpolator_words)
 
     sampler_regs = sorted({tb["fetch_constant"] for tb in analysis["texture_bindings"]})
-    # Real fix (2026-08-17, follow-up): see the vertex-shader call site's
-    # own comment -- same real gap, pixel-shader side.
+    # See the vertex-shader call site's own comment -- same gap,
+    # pixel-shader side.
     float_constants = analysis.get("float_constants", [])
     check_for_missing_literal_constants(float_constants)
     if analysis.get("float_dynamic_addressing"):

--- a/tools/build_synthetic_container.py
+++ b/tools/build_synthetic_container.py
@@ -1,0 +1,887 @@
+#!/usr/bin/env python3
+"""Builds a synthetic XenosRecomp ShaderContainer .bin for a shader that was
+never captured by shader_dump.cpp's dump_guest_shaders hook (D3D9
+CreateVertexShader/CreatePixelShader), because it was loaded directly into
+GPU sequencer memory via IM_LOAD/IM_LOAD_IMMEDIATE PM4 packets -- confirmed
+real, structural gap, not a capture-timing bug (see PLAN_native_renderer.md).
+
+Real raw microcode for such shaders IS available via the SDK's
+renut_dump_ucode_hash cvar (shaders_ucode_hash/<vs|ps>_<hash>.ucode), keyed
+by the real ucode_data_hash(). This script wraps that real microcode in a
+minimal, hand-built ShaderContainer.
+
+Automated end to end (2026-08-15 generalization): all per-shader vertex-fetch
+and texture-fetch metadata (element count, data format, byte offset,
+instruction address, sampler fetch-constant/register mapping, interpolator
+count, color-output mask) is obtained by running tools/ucode_analyze -- a
+standalone binary linking the SDK's own real Shader::AnalyzeUcode() -- against
+the real .ucode file, NOT hardcoded per-shader tables. See
+tools/ucode_analyze.cpp / tools/build_ucode_analyze.sh.
+
+The one piece AnalyzeUcode cannot supply is D3D9 vertex-element Usage/
+UsageIndex (POSITION vs TEXCOORD0 vs COLOR etc.) -- Xenos vfetch instructions
+carry no D3D9 semantic name at all, confirmed by direct SDK source
+inspection (no DeclUsage/D3DDECLUSAGE inference exists anywhere in this SDK
+fork). This is now solved with a second REAL capture, not a guess: the
+shader_dump.cpp SetVertexShader/SetVertexDeclaration hooks (new this
+session) correlate the guest's own real D3DVERTEXELEMENT9 Usage/UsageIndex
+bytes to the exact ucode_data_hash of whichever vertex shader was bound at
+the time, writing shaders_vertdecl/vs_<hash>.vertdecl.txt keyed by real
+per-element byte offset (matches vertex_bindings()'s offset_words*4 exactly,
+no positional assumption). If that file isn't present yet (declaration never
+observed bound to this shader in a real play session), this script falls
+back to the same documented POSITION-first/TEXCOORD-follows heuristic used
+for the one shader pair proven by hand earlier this session -- flagged
+clearly in its output, not silently treated as equally trustworthy.
+
+Usage: build_synthetic_container.py <ucode_dir> <vs|ps> <hash> <output.bin>
+         [--vertdecl-dir DIR] [--ucode-analyze PATH]
+  <ucode_dir>: directory containing <vs|ps>_<hash>.ucode files
+  <vs|ps>: which shader type to build (vertex or pixel container layout differ)
+  <hash>: the target shader's real ucode_data_hash, hex, no 0x prefix
+  <output.bin>: where to write the synthetic container
+  --vertdecl-dir: directory containing vs_<hash>.vertdecl.txt files
+                  (default: <ucode_dir>/../shaders_vertdecl)
+  --ucode-analyze: path to the built ucode_analyze binary
+                    (default: alongside this script's repo, /tmp/ucode_analyze,
+                    or built on demand via build_ucode_analyze.sh)
+"""
+
+import argparse
+import json
+import struct
+import subprocess
+import sys
+from pathlib import Path
+
+# Real XenosRecomp DeclUsage enum values (XenosRecomp/shader.h).
+DECL_USAGE_POSITION = 0
+DECL_USAGE_NORMAL = 3
+DECL_USAGE_TEXCOORD = 5
+DECL_USAGE_TANGENT = 6
+DECL_USAGE_BINORMAL = 7
+DECL_USAGE_COLOR = 10
+
+# Real XenosRecomp PixelShaderOutputs bits (shader.h) -- COLOR0-3 come from
+# ucode_analyze's writes_color_targets bitmask directly (same bit
+# positions), DEPTH does not (it's a separate boolean, writes_depth).
+PIXEL_SHADER_OUTPUT_DEPTH = 0x10
+
+# Real Xenos xenos::VertexFormat numeric IDs (include/rex/graphics/xenos.h),
+# not just the ones this script otherwise names -- used ONLY for the
+# format-aware heuristic below, matching the raw values ucode_analyze.cpp's
+# "data_format" JSON field already reports.
+_FORMAT_10_11_11 = 16
+_FORMAT_11_11_10 = 17
+_FORMAT_8_8_8_8 = 6
+# NOT one of XenosRecomp's own documented R11G11B10-only special-unpack
+# formats (README.md's Vertex Fetch section is explicit: only 10_11_11/
+# 11_11_10 get manual unpacking) -- but a real, consistent pattern was found
+# by sampling this game's actual captured shaders: 2-3 consecutive
+# 2_10_10_10 attributes immediately after POSITION, matching the exact
+# normal/tangent/binormal SHAPE, recurs across many real shaders (2026-08-16
+# sampling: vs_0112bc639335c58a, vs_054f86bb3d84dbb9, vs_07462764505df374,
+# etc all show this). Treating it the same as the documented normal formats
+# is a REAL INFERENCE from observed data, not a documented XenosRecomp
+# convention -- it gets the Vulkan input LOCATION right (location 1, per
+# USAGE_LOCATIONS) even though XenosRecomp won't apply special R11G11B10
+# unpacking (this format isn't eligible for that regardless of usage
+# labeling); the vertex shader's own real ucode is responsible for
+# interpreting the raw packed bits either way, same as our own
+# VertexFormatToVkFormat already does via VK_FORMAT_A2B10G10R10_*_PACK32.
+_FORMAT_2_10_10_10 = 7
+
+REGISTER_SET_BOOL = 0
+REGISTER_SET_FLOAT4 = 2
+REGISTER_SET_SAMPLER = 3
+
+
+def build_real_constant_table(float_regs: list[int], sampler_regs: list[int],
+                              bool_regs: list[int] | None = None,
+                              is_pixel_shader: bool = False) -> bytes:
+    """Real D3DXSHADER_CONSTANTTABLE bytes (whole ConstantTableContainer,
+    including its own leading `size` field) listing one ConstantInfo entry
+    per float4/sampler/bool register a shader actually reads (from
+    ucode_analyze's float_constants/texture_bindings/bool_constants).
+    XenosRecomp doesn't care about real constant NAMES (only registerSet/
+    registerIndex/registerCount matter for the #defines it emits, see
+    shader_recompiler.cpp's recompile()), so synthetic names are fine --
+    same real technique as tools/xenos_synthesize_constant_table.py, shared
+    here since a synthetic container with an EMPTY constant table (this
+    script's original behavior) fails XenosRecomp identically to a real
+    capture with constantTableOffset == 0: "use of undeclared identifier
+    'c45'"/'b243' etc for every float/sampler/bool register the shader
+    references. Without a real RegisterSet::Bool entry, XenosRecomp falls
+    back to emitting a bare, never-declared `b<N>` identifier for boolean
+    control-flow conditions (shader_recompiler.cpp's ControlFlowOpcode::
+    kCondJmp handling) instead of the correct `g_Booleans & (1 << N)` form
+    -- confirmed via direct source reading, not guessed.
+
+    Real fix (2026-08-17): the float4 entries used to be one ConstantInfo
+    PER REGISTER (registerCount=1 each). shader_recompiler.cpp's recompile()
+    (the ALU operand-formatting code) only emits the safe, bounds-clamped
+    indexed accessor `constantName(index [+ a0|+ aL])` -- the ONLY form that
+    can express Xenos's real dynamic/relative constant addressing (`c[a0+N]`,
+    `c[aL+N]`, used pervasively for skeletal-animation/skinning bone-matrix
+    lookups) -- when the MATCHED ConstantInfo has registerCount > 1
+    (shader_recompiler.cpp:1205 branches on exactly this). With
+    registerCount always 1, every such shader instead hit the plain-name
+    fallback branch (shader_recompiler.cpp:479, guarded by
+    `assert(!instr.const0Relative && !instr.const1Relative)` -- compiles to
+    nothing in a release build), which silently DROPS the +a0/+aL offset
+    entirely and always reads the same static register regardless of the
+    real runtime index -- a confirmed, real, structural bug: any shader
+    doing dynamic constant addressing (skinning is the classic real-world
+    case) reads garbage/wrong bone data for every vertex, a strong match for
+    reported shattered/scattered-looking animated geometry. Fixed by
+    emitting ONE grouped float4 entry spanning the full real register range
+    (0..255 for vertex shaders, 0..223 for pixel shaders -- matching
+    shader_recompiler.cpp:1207's own `(isPixelShader ? 224 : 256)` tail-count
+    ceiling exactly) instead of one entry per individually-referenced
+    register -- XenosRecomp's own emitted macro already safely clamps/zero-
+    fills any index outside what's actually live, so this is not a
+    correctness risk for shaders that never use dynamic addressing, only a
+    (harmless) widening of the declared range.
+    """
+    # Real fix (2026-08-17, follow-up): shader_recompiler.cpp's own
+    # `tailCount = (isPixelShader ? 224 : 256) - registerIndex` is baked
+    # into the grouped macro it emits REGARDLESS of what registerCount this
+    # script declares -- so a grouped entry covering a pixel-shader register
+    # >= 224 wouldn't fail to compile, it would silently ALWAYS return 0.0
+    # for that register (even for a plain static reference), since the
+    # clamp is unconditional. 224 also matches this hardware's real,
+    # documented pixel-shader float-constant register-file size (vertex
+    # shaders get 256), so route any actually-used register >= that ceiling
+    # through an individual, real registerCount=1 entry instead (the
+    # ORIGINAL, proven-correct per-register scheme -- no dynamic-addressing
+    # support for it, but also no incorrect zero-clamp). Confirmed real
+    # regression this fixes: a heuristic-captured pixel shader statically
+    # referencing register 255 previously got excluded from BOTH the
+    # grouped range AND any per-register fallback, so XenosRecomp fell
+    # through to its "not found in float4Constants" path and emitted a
+    # bare, never-#define'd `c255` identifier -- a real DXC "undeclared
+    # identifier" compile failure that didn't exist before this
+    # constant-table rework.
+    float4_count = 224 if is_pixel_shader else 256
+    entries = [("c", REGISTER_SET_FLOAT4, 0, float4_count)] if any(r < float4_count for r in float_regs) else []
+    entries += [(f"c{r}", REGISTER_SET_FLOAT4, r, 1) for r in sorted(float_regs) if r >= float4_count]
+    entries += [(f"s{r}", REGISTER_SET_SAMPLER, r, 1) for r in sampler_regs]
+    entries += [(f"b{r}", REGISTER_SET_BOOL, r, 1) for r in (bool_regs or [])]
+
+    CONSTANT_TABLE_HEADER_SIZE = 28
+    CONSTANT_INFO_SIZE = 20
+    constant_info_offset = CONSTANT_TABLE_HEADER_SIZE
+    names_offset = constant_info_offset + len(entries) * CONSTANT_INFO_SIZE
+
+    name_bytes = b""
+    name_offsets = []
+    for name, _, _, _ in entries:
+        name_offsets.append(names_offset + len(name_bytes))
+        name_bytes += name.encode("ascii") + b"\x00"
+
+    constant_table_size = names_offset + len(name_bytes)
+
+    out = bytearray()
+    out += struct.pack(">I", 4 + constant_table_size)
+    out += struct.pack(">IIIIIII", constant_table_size, 0, 0, len(entries),
+                        constant_info_offset, 0, 0)
+    for i, (name, regset, regidx, regcount) in enumerate(entries):
+        out += struct.pack(">IHHHHII", name_offsets[i], regset, regidx, regcount, 0, 0, 0)
+    out += name_bytes
+    return bytes(out)
+
+
+def run_ucode_analyze(ucode_analyze_path: Path, shader_kind: str, ucode_path: Path) -> dict:
+    result = subprocess.run(
+        [str(ucode_analyze_path), shader_kind, str(ucode_path)],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        print(f"build_synthetic_container: ucode_analyze failed for {ucode_path}:\n{result.stderr}",
+              file=sys.stderr)
+        sys.exit(1)
+    return json.loads(result.stdout)
+
+
+def find_or_build_ucode_analyze(explicit: str | None) -> Path:
+    if explicit:
+        return Path(explicit)
+    candidates = [
+        Path("/tmp/ucode_analyze"),
+        Path(__file__).parent / "ucode_analyze_bin",
+    ]
+    for c in candidates:
+        if c.exists():
+            return c
+    # Build it on demand -- real, not a stub: invokes the same script a human
+    # would run, so a fresh checkout works without a separate manual step.
+    build_script = Path(__file__).parent / "build_ucode_analyze.sh"
+    out_path = Path("/tmp/ucode_analyze")
+    print(f"build_synthetic_container: building ucode_analyze via {build_script}...", file=sys.stderr)
+    result = subprocess.run(["sh", str(build_script), str(out_path)], capture_output=True, text=True)
+    if result.returncode != 0 or not out_path.exists():
+        print(f"build_synthetic_container: failed to build ucode_analyze:\n{result.stdout}\n{result.stderr}",
+              file=sys.stderr)
+        sys.exit(1)
+    return out_path
+
+
+def parse_vertdecl_file(path: Path) -> list[dict]:
+    """Parses a real shaders_vertdecl/vs_<hash>.vertdecl.txt file (written by
+    shader_dump.cpp's dumpVertexDeclUsageForBoundShader), one real captured
+    D3D9 element per line: 'offset=<n> type=<hex> usage=<n> usageIndex=<n>'.
+    """
+    elements = []
+    for line in path.read_text().splitlines():
+        parts = dict(p.split("=", 1) for p in line.split() if "=" in p)
+        if "offset" not in parts:
+            continue
+        elements.append({
+            "offset": int(parts["offset"]),
+            "usage": int(parts["usage"]),
+            "usage_index": int(parts["usageIndex"]),
+        })
+    return elements
+
+
+def assign_usage_from_vertdecl(attributes: list[dict], vertdecl_elements: list[dict]) -> bool:
+    """Matches real captured D3D9 elements to AnalyzeUcode's attributes by
+    real byte offset (attribute's offset_words*4 == captured element's
+    offset) -- both describe the same underlying vertex buffer layout, offset
+    is the natural join key, no assumption that array order matches. Returns
+    True if every attribute got a real match.
+    """
+    by_offset = {e["offset"]: e for e in vertdecl_elements}
+    matched_all = True
+    for attr in attributes:
+        real = by_offset.get(attr["offset_words"] * 4)
+        if real is None:
+            matched_all = False
+            continue
+        attr["usage"] = real["usage"]
+        attr["usage_index"] = real["usage_index"]
+        attr["usage_source"] = "captured"
+    return matched_all
+
+
+def assign_usage_heuristic(attributes: list[dict]) -> None:
+    """Fallback when no real captured D3D9 declaration is available yet.
+
+    REAL FIX (2026-08-16, second pass): the original version of this
+    heuristic (POSITION-first, everything else TEXCOORD0/1/2/...) was only
+    ever verified against the ONE shader this whole native-renderer effort
+    started with. Deployed broadly (1500+ shaders) it produced confirmed,
+    real in-game geometry corruption -- root-caused to XenosRecomp's own
+    FIXED usage->Vulkan-location table (shader_recompiler.cpp's
+    USAGE_LOCATIONS: Position=0, Normal=1, Tangent=2, Binormal=3,
+    TexCoord0=4, ..., Color0=8): mislabeling a real NORMAL attribute as
+    TexCoord0 doesn't just get the wrong NAME, it binds that attribute to
+    Vulkan input location 4 instead of the correct location 1 -- a real,
+    structural vertex-wiring mismatch, not a cosmetic one.
+
+    This version adds a second, real signal beyond ordering: the vertex
+    fetch's own `data_format` (already decoded by ucode_analyze from real
+    ucode, no guessing) strongly implies usage on this hardware, per
+    XenosRecomp's own documented conventions (README.md's Vertex Fetch
+    section): packed 10_11_11/11_11_10 formats are used almost exclusively
+    for NORMAL/TANGENT/BINORMAL, and 8_8_8_8 is the classic vertex-color
+    format. This is STILL an inference, not a capture -- correct for common
+    cases, not guaranteed for every shader -- but strictly more informed
+    than pure positional ordering. Attributes are still marked
+    usage_source="heuristic" either way so callers (e.g.
+    --reject-heuristic) can still treat this as unverified.
+    """
+    # offset_words == 0 (not list position) is the real, reliable POSITION
+    # signal -- it's always the first attribute in the buffer regardless of
+    # whether this list is the full attribute set or a partial-match
+    # remainder (assign_usage_from_vertdecl may have already claimed real
+    # usage for some attributes before this function ever sees the rest).
+    # RE-ENABLED (2026-08-16, same session): consuming a 2nd/3rd
+    # consecutive packed-normal-shaped attribute as TANGENT/BINORMAL was
+    # tried, made things measurably WORSE, and was reverted -- but the real
+    # root cause was NOT this heuristic itself, it was a separate,
+    # pre-existing bug in renut_xenos_pipeline_cache.cpp's
+    # GetOrCreatePipeline(): Vulkan vertex input LOCATIONS were assigned
+    # purely sequentially, but XenosRecomp compiles the shader expecting
+    # FIXED locations per D3D9 usage (shader_recompiler.cpp's
+    # USAGE_LOCATIONS: Position=0, Normal=1, Tangent=2, Binormal=3,
+    # TexCoord0=4, ...) -- confirmed via real Vulkan validation output
+    # ("pVertexAttributeDescriptions does not have a Location 4, but
+    # [VK_SHADER_STAGE_VERTEX_BIT] has [Input variable, Location 4] at that
+    # Location"). That bug is now FIXED: tools/xenos_cache_unpack.cpp's
+    # ExtractVertexLocations() computes the real per-attribute location
+    # (using the SAME USAGE_LOCATIONS table) from this container's own
+    # real vertex-element data at build time, stores it in
+    # RenutXenosShaderCacheEntry.vertexLocations[], and
+    # renut_xenos_pipeline_cache.cpp's GetOrCreatePipeline() now reads it
+    # instead of guessing sequentially. With that fixed, mislabeling
+    # TANGENT/BINORMAL as TEXCOORD (this heuristic's ORIGINAL bug) is safe
+    # to fix again -- it gets the correct location either way now, the only
+    # remaining risk is the USAGE NAME itself being wrong for shaders where
+    # a 2nd/3rd packed attribute isn't really tangent/binormal.
+    _NORMAL_LIKE_USAGES = [DECL_USAGE_NORMAL, DECL_USAGE_TANGENT, DECL_USAGE_BINORMAL]
+    _NORMAL_LIKE_FORMATS = (_FORMAT_10_11_11, _FORMAT_11_11_10, _FORMAT_2_10_10_10)
+    # Real fix (2026-08-16, see build_vertex_container's own comment on
+    # binding_index): XenosRecomp deduplicates/names vertex-shader input
+    # parameters purely by (usage, usageIndex) -- shader_recompiler.cpp's
+    # `semantic = usage<<4 | usageIndex` -- GLOBALLY across the whole
+    # shader, not per real vertex-fetch binding. So every usage_index
+    # counter here (position, texcoord, and each of the 3 normal-like
+    # slots) must keep incrementing across binding boundaries too, or a
+    # second binding's own "first/second/third attribute" collides with
+    # the same (usage, usageIndex) pair binding 0 already used -- the
+    # exact real bug this fix addresses (confirmed crash: XenosRecomp's
+    # generated HLSL declared duplicate `iPosition0` parameters for a
+    # shader with 2 real bindings, DXC's compile failed, and XenosRecomp's
+    # own zero error-handling on that turned it into a silent SIGSEGV).
+    # position_usage_index in particular gives a second binding's own
+    # offset-0 attribute POSITION1 instead of a colliding POSITION0 -- a
+    # real, XenosRecomp-recognized case (shader_recompiler.cpp's
+    # isMetaInstancer check), used for real instancing/skinning-style
+    # secondary vertex streams, exactly this fix's real repro shape (a
+    # second binding with many repeating float4 attributes, real
+    # bone-matrix-shaped data).
+    # Real fix (2026-08-16, second gap in the same class of bug the
+    # position_usage_index comment above describes): COLOR was still
+    # hardcoded to usage_index=0 unconditionally, unlike TEXCOORD (which
+    # already incremented). Any shader with 2+ real 8_8_8_8-shaped
+    # attributes (confirmed real crash: "redefinition of parameter
+    # 'iColor0'") hit the identical duplicate-parameter/DXC-compile-
+    # failure/XenosRecomp-SIGSEGV chain. XenosRecomp supports a real
+    # Color1 (USAGE_LOCATIONS has { DeclUsage::Color, 1, 11 }), so this
+    # mirrors position_usage_index's fix exactly.
+    position_usage_index = 0
+    texcoord_index = 0
+    color_index = 0
+    normal_like_run_index = 0
+    for attr in attributes:
+        if attr["offset_words"] == 0:
+            attr["usage"] = DECL_USAGE_POSITION
+            attr["usage_index"] = position_usage_index
+            attr["usage_source"] = "heuristic"
+            position_usage_index += 1
+            continue
+        fmt = attr.get("data_format")
+        if fmt in _NORMAL_LIKE_FORMATS and normal_like_run_index < len(_NORMAL_LIKE_USAGES):
+            attr["usage"] = _NORMAL_LIKE_USAGES[normal_like_run_index]
+            attr["usage_index"] = 0
+            normal_like_run_index += 1
+        elif fmt == _FORMAT_8_8_8_8:
+            attr["usage"] = DECL_USAGE_COLOR
+            attr["usage_index"] = color_index
+            color_index += 1
+        else:
+            attr["usage"] = DECL_USAGE_TEXCOORD
+            attr["usage_index"] = texcoord_index
+            texcoord_index += 1
+        attr["usage_source"] = "heuristic"
+
+
+class HeuristicRejected(Exception):
+    """Raised when reject_heuristic=True and any vertex attribute needed the
+    fallback usage heuristic -- a real, requested opt-in filter (2026-08-16
+    session finding: the heuristic corrupts real geometry for shaders whose
+    layout isn't POSITION-then-TEXCOORDs, confirmed via real in-game visual
+    corruption once ~150 heuristic-based shaders went live simultaneously;
+    real vertex-declaration capture is structurally unavailable for these
+    shaders, same IM_LOAD root cause as shader creation itself -- see
+    PLAN_native_renderer.md), so callers that only want verified-correct
+    containers can skip the rest instead of emitting a wrong one."""
+
+
+class MissingLiteralConstantData(Exception):
+    """Real fix (2026-08-17, user-requested "what does the game actually
+    need from a shader" investigation): raised when this shader's real,
+    ucode_analyze-detected float_constants includes a register in the real,
+    empirically-confirmed "compiler-embedded literal constant" range
+    (>= 252) -- checked directly against REAL captured shaders (shaders/*.bin
+    that DO have a real DefinitionTable): every one found covers exactly
+    registers 252-255, and the real embedded VALUES there are genuinely
+    shader-specific authored numbers (e.g. one real shader's real data was
+    (1.0, -1428.57, 0.0, 0.0), another's was (0.5, 0.25, 1.6, 0.0) -- no
+    universal default exists to fall back to). A game shader compiled this
+    way expects these registers' values to come from its own bytecode's
+    DefinitionTable (a real, separate mechanism XenosRecomp's own
+    shader_recompiler.cpp emits as a LOCAL VARIABLE, not the runtime
+    constant buffer this script's synthesized ConstantTable feeds), and a
+    shader that was only ever captured via raw IM_LOAD microcode (this
+    script's whole reason to exist) has NO DefinitionTable at all --
+    structurally, information-theoretically unrecoverable, not a bug to fix
+    by guessing. Confirmed real, in-the-wild symptom this explains: several
+    user-marked-broken shaders (objects that silently fail to render/
+    "don't spawn") reference exactly this register range with no real
+    declaration data available. Gracefully skip instead of shipping a
+    shader fed a garbage literal it was never designed to receive at
+    runtime -- falls back to the stock renderer, which DOES have the real
+    bytecode (and therefore the real DefinitionTable) via the normal D3D9
+    runtime-translation path."""
+
+
+# Real, empirically-confirmed threshold (see MissingLiteralConstantData's own
+# docstring) -- every real DefinitionTable checked across this game's
+# captured shaders covers exactly registers 252-255, never lower.
+_LITERAL_CONSTANT_REGISTER_THRESHOLD = 252
+
+
+def check_for_missing_literal_constants(float_regs: list[int]) -> None:
+    bad = [r for r in float_regs if r >= _LITERAL_CONSTANT_REGISTER_THRESHOLD]
+    if bad:
+        raise MissingLiteralConstantData(
+            f"references float constant register(s) {bad} with no real DefinitionTable "
+            "available to supply their real, shader-specific literal values")
+
+
+_SHADER_STRUCT = struct.Struct(">IIIII")  # physicalOffset,size,field8,fieldC,field10 (interpolatorInfo read separately)
+
+
+def read_ps_interpolator_usages(ps_container_path: Path) -> dict[int, tuple[int, int]]:
+    """Reads a REAL, D3D9-captured pixel shader container's own
+    interpolators[] array (PixelShader::interpolators, shader.h) and
+    returns {register: (usage, usage_index)} for each entry.
+
+    Real idea this exists for (2026-08-16, from external research into
+    Xenia's architecture -- see renut_shader_conversion_blockers.md
+    memory): a vertex shader export register N and the paired pixel
+    shader's import register N must carry the SAME real usage/usageIndex
+    for the pair to function at all on real hardware -- confirmed via
+    XenosRecomp's own shader_recompiler.cpp (PS side reads
+    `PixelShader::interpolators[i]`, decodes the SAME Interpolator bitfield
+    union `usageIndex:4, usage:4, reg:4` this file's own
+    pack_interpolator() writes for VS). So a REAL captured PS container
+    (shaders/ps_<hash>.bin, from the D3D9 hook path -- NOT one WE
+    synthesized, since build_pixel_container() invents its own numeric
+    interpolator convention rather than real usage data) can supply real
+    ground truth for what a paired, uncaptured VS's export registers
+    should be named, when the VS's own real data is missing.
+
+    Only useful when the target PS genuinely has a real container with
+    constantTableOffset/interpolator data intact -- returns {} (not an
+    error) if the container looks synthesized/empty, so callers can fall
+    back to the existing heuristic cleanly.
+    """
+    if not ps_container_path.exists():
+        return {}
+    data = ps_container_path.read_bytes()
+    if len(data) < 36:
+        return {}
+    flags, virtual_size, physical_size, field_c, ctbl_off, dtbl_off, shader_off, f1c, f20 = \
+        struct.unpack(">9I", data[0:36])
+    if (flags & 0xFFFFFF00) != 0x102A1100:
+        return {}
+    if shader_off + 24 > len(data):
+        return {}
+    # Shader base struct (24B): physicalOffset,size,field8,fieldC,field10,interpolatorInfo
+    interpolator_info = struct.unpack(">I", data[shader_off + 20:shader_off + 24])[0]
+    interpolator_count = (interpolator_info >> 5) & 0x1F
+    if interpolator_count == 0:
+        return {}
+    # PixelShader adds field18(4B), outputs(4B) before interpolators[] begins.
+    interpolators_offset = shader_off + 24 + 8
+    if interpolators_offset + interpolator_count * 4 > len(data):
+        return {}
+    result: dict[int, tuple[int, int]] = {}
+    for i in range(interpolator_count):
+        word = struct.unpack_from(">I", data, interpolators_offset + i * 4)[0]
+        usage_index = word & 0xF
+        usage = (word >> 4) & 0xF
+        reg = (word >> 8) & 0xF
+        result[reg] = (usage, usage_index)
+    return result
+
+
+def build_vertex_container(ucode_bytes: bytes, analysis: dict, vertdecl_elements: list[dict] | None,
+                           reject_heuristic: bool = False,
+                           ps_interpolator_usages: dict[int, tuple[int, int]] | None = None) -> bytes:
+    if not analysis["vertex_bindings"]:
+        print("build_synthetic_container: no vertex_bindings found by ucode_analyze -- "
+              "this shader has no real vfetch instructions, cannot build a vertex container",
+              file=sys.stderr)
+        sys.exit(1)
+    # A shader normally has exactly one real vertex-fetch binding group in
+    # this game (confirmed for the one proven shader; a shader that legitimately
+    # uses multiple bindings would need every attribute across all of them,
+    # which this flattens rather than dropping).
+    #
+    # Real bug found+fixed (2026-08-16): binding_index is now tracked and
+    # carried through -- it did NOT exist before, and attributes were
+    # sorted by offset_words GLOBALLY across every binding combined. Since
+    # offset_words is relative to EACH BINDING's own stream (not a single
+    # shared buffer), a second binding's first attribute also has
+    # offset_words==0, so it sorted next to binding 0's real position
+    # attribute and the heuristic (which keys "is this POSITION" purely off
+    # offset_words==0) labeled BOTH as POSITION0 -- a real, confirmed
+    # crash: XenosRecomp's generated HLSL declared the same `iPosition0`
+    # parameter twice ("redefinition of parameter 'iPosition0'"), DXC's
+    # compile failed, and XenosRecomp's own zero error-handling on that
+    # turned it into a silent SIGSEGV. Sorting is now done PER BINDING
+    # (stable sort preserves binding order, each binding's own attributes
+    # stay sorted by their own offset), and assign_usage_heuristic below
+    # uses binding_index to only ever treat ONE attribute per binding as a
+    # "position-like" (offset 0) attribute, assigning DECL_USAGE_POSITION
+    # with usage_index 0 for the first binding and usage_index 1 for a
+    # second (XenosRecomp has a real, recognized Position1 case -- see
+    # shader_recompiler.cpp's isMetaInstancer check -- used for real
+    # instancing/skinning-style secondary vertex streams, exactly the
+    # shape this fix was found against: a second binding with many
+    # repeating float4 attributes, real bone-matrix-shaped data).
+    attributes = []
+    for binding_index, vb in enumerate(analysis["vertex_bindings"]):
+        for a in vb["attributes"]:
+            attributes.append({
+                "instr_addr": a["instruction_address"],
+                "data_format": a["data_format"],
+                "offset_words": a["offset_words"],
+                "binding_index": binding_index,
+            })
+    attributes.sort(key=lambda a: (a["binding_index"], a["offset_words"]))
+
+    matched_all = False
+    if vertdecl_elements:
+        matched_all = assign_usage_from_vertdecl(attributes, vertdecl_elements)
+        if not matched_all:
+            print("build_synthetic_container: WARNING vertdecl file present but did not "
+                  "cover every real vfetch attribute by offset -- filling gaps with heuristic",
+                  file=sys.stderr)
+    if not vertdecl_elements or not matched_all:
+        # Only heuristic-fill attributes still missing usage (partial real
+        # coverage is trusted where it exists).
+        missing = [a for a in attributes if "usage" not in a]
+        if missing:
+            assign_usage_heuristic(missing)
+    for a in attributes:
+        a.setdefault("usage_source", "captured")
+
+    if reject_heuristic and any(a["usage_source"] == "heuristic" for a in attributes):
+        raise HeuristicRejected()
+
+    interpolator_count = bin(analysis["writes_interpolators"]).count("1")
+
+    # VertexElement and Interpolator have DIFFERENT real on-disk bit layouts
+    # -- found EMPIRICALLY (2026-08-15) using a debug build of the real
+    # XenosRecomp binary (fprintf added at each read site in
+    # shader_recompiler.cpp), tested against a real container with single-
+    # nibble/field-set test values swept across every bit position. This
+    # matters because `be<uint32_t>` (XenosRecomp/pch.h) unconditionally
+    # byte-swaps on every read via its `get()`/implicit-conversion operator
+    # with no "already native" guard, so naively packing bitfields in their
+    # STRUCT-DECLARED order and writing them as a plain big-endian integer
+    # does not universally work the same way for every struct -- verify
+    # against a real debug build before changing either formula below.
+    def pack_vertex_element(address, usage, usage_index):
+        return (address & 0xFFF) | ((usage & 0xF) << 12) | ((usage_index & 0xF) << 16)
+
+    def pack_interpolator(usage, usage_index, reg=0):
+        return (usage_index & 0xF) | ((usage & 0xF) << 4) | ((reg & 0xF) << 8)
+
+    vertex_elements = [
+        pack_vertex_element(a["instr_addr"], a["usage"], a["usage_index"]) for a in attributes
+    ]
+
+    # Real fix attempt (2026-08-16): interpolator OUTPUTS are a completely
+    # different concept from vertex INPUTS (confirmed via direct
+    # shader_recompiler.cpp reading: XenosRecomp's VS function signature
+    # declares its interpolator outputs from a FIXED, global INTERPOLATORS[]
+    # table -- Normal0-15/Tangent0/Binormal0/TexCoord0-15/Color0-1 ONLY,
+    # Position is not a valid interpolator usage at all -- and VS/PS
+    # interpolator arrays are wired together PURELY BY ARRAY INDEX, not by
+    # any register-number field; usage/usageIndex only control the
+    # generated HLSL variable NAME on each side, matched positionally).
+    # Building interpolator entries from vertex INPUT attributes (the old
+    # behavior below) fabricates entries with no relationship to what the
+    # shader's ALU code actually exports, and real shaders often need far
+    # fewer/more/different interpolators than they have vertex inputs
+    # (confirmed real crash: a shader with 14 non-position inputs but only
+    # 5 real interpolator writes).
+    #
+    # If a REAL captured pixel shader's own interpolator array is
+    # available (ps_interpolator_usages, see read_ps_interpolator_usages()
+    # -- only populated for shaders with a genuine D3D9-captured PS
+    # container, not one we synthesized), copy IT verbatim as this VS's
+    # own interpolator array instead of guessing from inputs. This makes
+    # the VS's array structurally IDENTICAL (same length, same per-index
+    # usage/usageIndex) to what the PS expects at each index -- since
+    # XenosRecomp wires them together by index, this guarantees correct
+    # linkage regardless of whether the usage NAME is "semantically real"
+    # for this specific shader.
+    # Real, correct algorithm (2026-08-16, replaces the vertex-input-based
+    # guess above and the popcount-based interpolator_count from earlier):
+    # confirmed via direct source reading (shader_code.h's ExportRegister
+    # enum: VSInterpolator0..15 == literal values 0..15) that a vertex
+    # shader's real ALU export register number IS the interpolator array
+    # INDEX XenosRecomp looks the export up by (shader_recompiler.cpp:650's
+    # `interpolators.find(instr.vectorDest)`, where the map was built by
+    # `interpolators.emplace(i, ...)` for array index i, line ~1508) -- and
+    # the SDK's own writes_interpolators() is a REAL BITMASK (confirmed:
+    # translator.cpp's GatherAluResultInformation sets
+    # `writes_interpolators_ |= 1 << result.storage_index` for
+    # kInterpolator writes), bit N meaning "this shader's ALU code writes
+    # export register N", not just a count. Popcount (the old code)
+    # collapses this real per-slot information into a single number,
+    # losing exactly the data needed to build a correct, non-sparse
+    # 0..count-1 array (XenosRecomp reads the array in a dense loop, no
+    # gaps possible -- shader_recompiler.cpp:1490).
+    #
+    # Correct construction: interpolator_count is (highest set bit + 1),
+    # and EVERY array position 0..count-1 needs a real, distinct
+    # (usage, usageIndex) pair from the fixed INTERPOLATORS[] table
+    # (Normal0-15/Tangent0/Binormal0/TexCoord0-15/Color0-1, 34 real slots,
+    # Position is NOT valid here) -- including "gap" positions the shader
+    # never actually writes to, since XenosRecomp default-initializes
+    # those to 0.0 rather than needing them omitted. The usage NAME
+    # assigned to each position doesn't need to be "semantically real" (it
+    # only becomes the generated HLSL variable name, used consistently
+    # within this one shader's own code) -- it just needs to be present
+    # and distinct, so this assigns them in INTERPOLATORS[] table order,
+    # which is always valid regardless of what the shader actually does
+    # with each slot.
+    # Must match XenosRecomp's OWN real INTERPOLATORS[] table exactly
+    # (shader_recompiler.cpp, upstream commit 990d03b -- verified directly
+    # against the actual _deps/xenosrecomp-src checkout CMake fetches, not
+    # assumed): only TexCoord0-15 + Color0-1, 18 entries total. There is NO
+    # Normal/Tangent/Binormal entry -- those are valid VERTEX INPUT usages
+    # (a completely separate table) but NOT valid VS output/interpolator
+    # usages upstream. An earlier version of this table wrongly included
+    # them (confirmed by cross-referencing a local experimental checkout
+    # that turned out to have unrelated, non-upstream, non-shipped patches
+    # rewriting the whole constant-buffer layout) which produced containers
+    # referencing e.g. "oNormal0" as a VS output -- undeclared in the real
+    # generated HLSL, causing DXC to emit compile errors and, worse,
+    # segfault outright on the resulting malformed source.
+    _INTERPOLATOR_USAGE_TABLE = (
+        [(DECL_USAGE_TEXCOORD, i) for i in range(16)] +
+        [(DECL_USAGE_COLOR, 0), (DECL_USAGE_COLOR, 1)]
+    )
+
+    if ps_interpolator_usages:
+        ordered = [ps_interpolator_usages[reg] for reg in sorted(ps_interpolator_usages)]
+        interpolators = [pack_interpolator(usage, usage_index) for usage, usage_index in ordered]
+        interpolator_count = len(interpolators)
+        print(f"build_synthetic_container: NOTE using {len(interpolators)} real interpolator "
+              "usage(s) from a captured pixel shader container instead of guessing from vertex "
+              "inputs", file=sys.stderr)
+    else:
+        writes_mask = analysis["writes_interpolators"]
+        interpolator_count = (writes_mask.bit_length()) if writes_mask else 0
+        if interpolator_count > len(_INTERPOLATOR_USAGE_TABLE):
+            print(f"build_synthetic_container: WARNING interpolator_count={interpolator_count} "
+                  f"exceeds the {len(_INTERPOLATOR_USAGE_TABLE)} real usage slots XenosRecomp's "
+                  "own INTERPOLATORS[] table supports -- clamping so the container's declared "
+                  "count and its physically-written array stay consistent (an uncapped count "
+                  "here previously caused XenosRecomp to read past the end of the array).",
+                  file=sys.stderr)
+            interpolator_count = len(_INTERPOLATOR_USAGE_TABLE)
+        interpolators = [
+            pack_interpolator(usage, usage_index)
+            for usage, usage_index in _INTERPOLATOR_USAGE_TABLE[:interpolator_count]
+        ]
+
+    field18 = 0
+    vertex_element_count = len(vertex_elements)
+    field20 = 0
+    interpolator_info = (interpolator_count & 0x1F) << 5
+
+    vertex_shader_header = struct.pack(
+        ">IIIIIIII",
+        0, len(ucode_bytes), 0, 0, 0, interpolator_info, field18, vertex_element_count,
+    ) + struct.pack(">I", field20)
+    # REAL BUG FOUND AND FIXED (see git history / memory for full writeup):
+    # vertexElementsAndInterpolators is be<uint32_t>[], whose get()
+    # unconditionally byte-swaps -- pack as big-endian here so the runtime's
+    # own swap produces the intended value.
+    vertex_shader_header += struct.pack(f">{len(vertex_elements)}I", *vertex_elements)
+    vertex_shader_header += struct.pack(f">{len(interpolators)}I", *interpolators)
+
+    # Real fix (2026-08-17, follow-up): a shader using ONLY dynamic (a0/aL-
+    # relative) float constant addressing has NO entries in float_constants
+    # at all (AnalyzeUcode only records STATIC register references there --
+    # see translator.cpp's GatherOperandInformation, which sets
+    # float_dynamic_addressing instead of touching float_bitmap for a
+    # relative-addressed operand) -- an empty float_regs list means
+    # build_real_constant_table's grouped-entry gate (`any(r < float4_count
+    # for r in float_regs)`) never fires, so `c(N + a0)` has no `#define
+    # c(...)` to resolve to. Matches xenos_synthesize_constant_table.py's
+    # own real fix for the identical gap.
+    float_constants = analysis.get("float_constants", [])
+    # Real fix (2026-08-17): check BEFORE the dynamic-addressing expansion
+    # below -- that expansion legitimately claims the full 0-255 range for
+    # an unrelated reason (the runtime can't know which specific registers
+    # a dynamic a0/aL-relative access might touch), which would otherwise
+    # make EVERY dynamically-addressed shader a false positive here. Only a
+    # real, STATIC reference to a literal-constant-range register is
+    # meaningful evidence this shader needs data we don't have.
+    check_for_missing_literal_constants(float_constants)
+    if analysis.get("float_dynamic_addressing"):
+        float_constants = list(range(256))
+    constant_table_container = build_real_constant_table(
+        float_constants, [], analysis.get("bool_constants", []),
+        is_pixel_shader=False)
+
+    header_size = 36
+    constant_table_offset = header_size
+    shader_offset = constant_table_offset + len(constant_table_container)
+    virtual_size = shader_offset + len(vertex_shader_header)
+    padding = (-virtual_size) % 4
+    virtual_size += padding
+    physical_size = len(ucode_bytes)
+
+    shader_container = struct.pack(
+        ">IIIIIIIII",
+        0x102A1101, virtual_size, physical_size, 0, constant_table_offset, 0, shader_offset, 0, 0,
+    )
+
+    usage_sources = {a["usage_source"] for a in attributes}
+    if "heuristic" in usage_sources:
+        print(f"build_synthetic_container: NOTE {sum(1 for a in attributes if a['usage_source']=='heuristic')}"
+              f"/{len(attributes)} vertex element(s) used the fallback usage heuristic, not a real capture "
+              "-- verify shaders_vertdecl/*.vertdecl.txt coverage if this shader renders incorrectly",
+              file=sys.stderr)
+
+    return (shader_container + constant_table_container + vertex_shader_header +
+            b"\x00" * padding + ucode_bytes)
+
+
+def build_pixel_container(ucode_bytes: bytes, analysis: dict) -> bytes:
+    interpolator_count = bin(analysis["writes_interpolators"]).count("1")
+    # Fixed convention (confirmed via direct SDK source inspection, not
+    # per-shader disassembly): interpolator index N is always read from ALU
+    # register N by the compiled pixel shader (spirv_translator.cpp's
+    # input_output_interpolators_[interpolator_index]) -- so this needs no
+    # per-texture src_register lookup at all, unlike the version of this
+    # script that hand-transcribed "reg" from real disassembly text earlier
+    # this session.
+    interpolators = [
+        {"usage": DECL_USAGE_TEXCOORD, "usage_index": i, "reg": i}
+        for i in range(interpolator_count)
+    ]
+
+    def pack_interpolator(usage, usage_index, reg):
+        return (usage_index & 0xF) | ((usage & 0xF) << 4) | ((reg & 0xF) << 8)
+
+    interpolator_words = [pack_interpolator(it["usage"], it["usage_index"], it["reg"]) for it in interpolators]
+
+    field18 = 0
+    interpolator_info = (len(interpolators) & 0x1F) << 5
+    # Real bug found+fixed (2026-08-16): only writes_color_targets bits were
+    # ever set here -- PIXEL_SHADER_OUTPUT_DEPTH was never included even
+    # for shaders that genuinely write oDepth (real manual-depth-write
+    # shaders, confirmed via real DXC "use of undeclared identifier
+    # 'oDepth'" compile failures -- XenosRecomp's shader_recompiler.cpp
+    # only DECLARES the oDepth output parameter when this bit is set,
+    # regardless of whether the shader's own instructions reference it).
+    outputs_mask = analysis["writes_color_targets"]
+    if analysis.get("writes_depth"):
+        outputs_mask |= PIXEL_SHADER_OUTPUT_DEPTH
+
+    pixel_shader_header = struct.pack(
+        ">IIIIIIII",
+        0, len(ucode_bytes), 0, 0, 0, interpolator_info, field18, outputs_mask,
+    )
+    pixel_shader_header += struct.pack(f">{len(interpolator_words)}I", *interpolator_words)
+
+    sampler_regs = sorted({tb["fetch_constant"] for tb in analysis["texture_bindings"]})
+    # Real fix (2026-08-17, follow-up): see the vertex-shader call site's
+    # own comment -- same real gap, pixel-shader side.
+    float_constants = analysis.get("float_constants", [])
+    check_for_missing_literal_constants(float_constants)
+    if analysis.get("float_dynamic_addressing"):
+        float_constants = list(range(256))
+    constant_table_container = build_real_constant_table(
+        float_constants, sampler_regs, analysis.get("bool_constants", []),
+        is_pixel_shader=True)
+
+    header_size = 36
+    constant_table_offset = header_size
+    shader_offset = constant_table_offset + len(constant_table_container)
+    virtual_size = shader_offset + len(pixel_shader_header)
+    padding = (-virtual_size) % 4
+    virtual_size += padding
+    physical_size = len(ucode_bytes)
+
+    # REAL BUG FOUND AND FIXED: XenosRecomp determines vertex-vs-pixel purely
+    # from `flags & 0x1` (bit 0 CLEAR means pixel shader). Real confirmed
+    # flags value for a pixel shader: 0x102A1100.
+    shader_container = struct.pack(
+        ">IIIIIIIII", 0x102A1100, virtual_size, physical_size, 0,
+        constant_table_offset, 0, shader_offset, 0, 0,
+    )
+
+    return (shader_container + constant_table_container + pixel_shader_header +
+            b"\x00" * padding + ucode_bytes)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("ucode_dir", type=Path)
+    parser.add_argument("shader_kind", choices=["vs", "ps"])
+    parser.add_argument("hash", help="hex, no 0x prefix")
+    parser.add_argument("output", type=Path)
+    parser.add_argument("--vertdecl-dir", type=Path, default=None)
+    parser.add_argument("--ucode-analyze", default=None)
+    parser.add_argument("--reject-heuristic", action="store_true",
+                        help="Exit with status 2 instead of emitting a container if any vertex "
+                             "attribute needed the fallback usage heuristic (no real captured "
+                             "D3D9 vertex declaration) -- for callers that only want "
+                             "verified-correct containers, not best-effort guesses.")
+    parser.add_argument("--pair-with-ps", type=Path, default=None,
+                        help="(vs only) Path to a REAL, D3D9-captured pixel shader container "
+                             "(shaders/ps_<hash>.bin) that is genuinely drawn paired with this "
+                             "vertex shader in real gameplay. If given and it has real "
+                             "interpolator data, that data is copied verbatim as this vertex "
+                             "shader's own interpolator array instead of guessing from vertex "
+                             "inputs -- see read_ps_interpolator_usages()'s docstring for why "
+                             "this is structurally correct (XenosRecomp wires VS/PS "
+                             "interpolators together by array index, not by name).")
+    args = parser.parse_args()
+
+    target_hash = int(args.hash, 16)
+    ucode_path = args.ucode_dir / f"{args.shader_kind}_{target_hash:016x}.ucode"
+    if not ucode_path.exists():
+        print(f"build_synthetic_container: '{ucode_path}' not found", file=sys.stderr)
+        return 1
+
+    ucode_analyze_path = find_or_build_ucode_analyze(args.ucode_analyze)
+    analysis = run_ucode_analyze(ucode_analyze_path, args.shader_kind, ucode_path)
+
+    ucode_bytes = ucode_path.read_bytes()
+
+    if args.shader_kind == "vs":
+        vertdecl_dir = args.vertdecl_dir or (args.ucode_dir.parent / "shaders_vertdecl")
+        vertdecl_path = vertdecl_dir / f"vs_{target_hash:016x}.vertdecl.txt"
+        vertdecl_elements = parse_vertdecl_file(vertdecl_path) if vertdecl_path.exists() else None
+        if vertdecl_elements is None:
+            print(f"build_synthetic_container: NOTE no real vertex-declaration capture at "
+                  f"'{vertdecl_path}' -- falling back to usage heuristic for this shader", file=sys.stderr)
+        ps_interpolator_usages = None
+        if args.pair_with_ps is not None:
+            ps_interpolator_usages = read_ps_interpolator_usages(args.pair_with_ps)
+            if not ps_interpolator_usages:
+                print(f"build_synthetic_container: NOTE --pair-with-ps '{args.pair_with_ps}' has "
+                      "no real interpolator data (not a real D3D9-captured container, or "
+                      "genuinely writes zero interpolators) -- falling back to guessing from "
+                      "vertex inputs", file=sys.stderr)
+        try:
+            container = build_vertex_container(ucode_bytes, analysis, vertdecl_elements,
+                                               reject_heuristic=args.reject_heuristic,
+                                               ps_interpolator_usages=ps_interpolator_usages)
+        except HeuristicRejected:
+            print(f"build_synthetic_container: REJECTED {ucode_path.stem} -- no real vertex "
+                  "declaration and --reject-heuristic was given", file=sys.stderr)
+            return 2
+        except MissingLiteralConstantData as e:
+            print(f"build_synthetic_container: REJECTED {ucode_path.stem} -- {e}", file=sys.stderr)
+            return 2
+    else:
+        try:
+            container = build_pixel_container(ucode_bytes, analysis)
+        except MissingLiteralConstantData as e:
+            print(f"build_synthetic_container: REJECTED {ucode_path.stem} -- {e}", file=sys.stderr)
+            return 2
+
+    args.output.write_bytes(container)
+    print(f"build_synthetic_container: wrote {len(container)} bytes to {args.output} "
+          f"({len(ucode_bytes)} bytes real microcode)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/build_ucode_analyze.sh
+++ b/tools/build_ucode_analyze.sh
@@ -15,7 +15,7 @@
 # use for.
 set -eu
 
-SDK="${SDK_SRC:-/home/nick/Desktop/reNut-build-scratch/rexglue-sdk-src}"
+SDK="${SDK_SRC:-/home/nick/Desktop/reNut-build-scratch/rexglue-sdk-clean}"
 OUT="${1:-/tmp/ucode_analyze}"
 
 cd "$SDK"

--- a/tools/build_ucode_analyze.sh
+++ b/tools/build_ucode_analyze.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+# Builds tools/ucode_analyze.cpp as a standalone binary, linked against real
+# rexglue-sdk shader-analysis source (Shader::AnalyzeUcode and its
+# dependencies) but NOT the game's Vulkan/PPC runtime -- this is a real,
+# working, offline tool, not a stub.
+#
+# The exact source list below was found empirically: started from just
+# shader.cpp+translator.cpp (confirmed via direct #include inspection to have
+# no Vulkan/PPC-runtime dependency) and resolved each real missing linker
+# symbol one at a time (fmt's compiled bits, rex::filesystem/env/cvar/memory,
+# ucode Disassemble() implementations, utf8 conversion) rather than guessing
+# a source list up front. dump_shaders is stubbed locally in
+# ucode_analyze.cpp instead of linking the real graphics/flags.cpp, because
+# that file pulls in a RenderDoc integration this analysis-only tool has no
+# use for.
+set -eu
+
+SDK="${SDK_SRC:-/home/nick/Desktop/reNut-build-scratch/rexglue-sdk-src}"
+OUT="${1:-/tmp/ucode_analyze}"
+
+cd "$SDK"
+g++ -std=gnu++23 -O2 -mssse3 -DNDEBUG \
+  -I include -I . \
+  -I thirdparty/spdlog/include -I thirdparty/fmt/include -I thirdparty/simde \
+  -I thirdparty/tomlplusplus/include -I thirdparty/cli11/include -I thirdparty/xxHash \
+  -I thirdparty/renderdoc -I thirdparty/utfcpp/source \
+  -DSPDLOG_FMT_EXTERNAL \
+  "$OLDPWD/tools/ucode_analyze.cpp" \
+  src/graphics/pipeline/shader/shader.cpp \
+  src/graphics/pipeline/shader/translator.cpp \
+  src/graphics/pipeline/shader/translator_disasm.cpp \
+  src/graphics/format/ucode.cpp \
+  src/core/string_buffer.cpp \
+  src/core/logging.cpp \
+  src/core/cvar.cpp \
+  src/core/memory.cpp \
+  src/core/filesystem_posix.cpp \
+  src/core/platform/env_posix.cpp \
+  src/core/utf8.cpp \
+  thirdparty/fmt/src/format.cc \
+  thirdparty/fmt/src/os.cc \
+  -o "$OUT"
+
+echo "build_ucode_analyze: wrote $OUT"

--- a/tools/compare_traces.py
+++ b/tools/compare_traces.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Compare renut/xenos frame traces produced by the renut_frame_trace cvar.
+
+Usage:
+    tools/compare_traces.py baseline.csv candidate.csv
+    tools/compare_traces.py single.csv
+
+Frames are filtered to a steady-state window before comparison: rows below
+--min-draws are treated as menus/loading screens rather than the workload under
+test, and the first --warmup qualifying frames are dropped so shader compilation
+and cache population do not count against the run.
+"""
+
+import argparse
+import csv
+import statistics
+import sys
+
+METRICS = [
+    ("frame_ms", "frame time", "ms"),
+    ("issuedraw_ms", "IssueDraw total", "ms"),
+    ("ns_per_draw", "per draw", "ns"),
+    ("tex_ms", "  RequestTextures", "ms"),
+    ("bind_ms", "  UpdateBindings", "ms"),
+    ("updsets_ms", "    vkUpdateDescriptorSets", "ms"),
+    ("sysconst_ms", "  UpdateSystemConstants", "ms"),
+    ("vfetch_ms", "  vertex fetch residency", "ms"),
+    ("post_ms", "  post-pipeline (superset)", "ms"),
+    ("samp_ms", "  samplers", "ms"),
+    ("rt_ms", "  render targets", "ms"),
+    ("prim_ms", "  primitive processing", "ms"),
+    ("pipe_ms", "  ConfigurePipeline", "ms"),
+    ("dyn_ms", "  dynamic state", "ms"),
+    ("fencewait_ms", "  GPU fence wait (BLOCKING)", "ms"),
+    ("issuecopy_ms", "IssueCopy / EDRAM resolve", "ms"),
+]
+
+# Redundancy rates: how often a draw could reuse the previous draw's state.
+# Reported as a fraction of draws, so they are comparable across scenes.
+RATES = [
+    ("pipe_same", "same pipeline as prev draw"),
+    ("layout_same", "same pipeline layout"),
+    ("texmask_same", "same used-texture mask"),
+    ("sets_valid", "all descriptor sets valid"),
+    ("samp_reused", "sampler setup reused"),
+    ("mergeable", "mergeable into prev draw"),
+    ("scissor_empty", "zero-area scissor (invisible)"),
+    ("viewport_tiny", "sub-pixel viewport"),
+    ("offscreen", "viewport outside scissor"),
+    ("depthonly", "depth-only (shadow/prepass)"),
+    ("nopixelshader", "no pixel shader"),
+    ("smallrt", "small render target (atlas)"),
+    ("rt_switch", "render target switches"),
+    ("issuecopy_n", "EDRAM resolves"),
+]
+
+
+def load(path, min_draws, warmup):
+    meta = {}
+    rows = []
+    malformed = 0
+    with open(path, newline="") as handle:
+        for line in handle:
+            if line.startswith("#"):
+                for token in line.lstrip("#").split():
+                    if "=" in token:
+                        key, value = token.split("=", 1)
+                        meta[key] = value
+                continue
+            handle.seek(0)
+            break
+        reader = csv.DictReader(row for row in handle if not row.startswith("#"))
+        for row in reader:
+            # A run killed mid-write leaves one truncated final line; anything
+            # beyond that means the trace is not trustworthy.
+            if None in row or any(v in (None, "") for v in row.values()):
+                malformed += 1
+                continue
+            try:
+                parsed = {k: float(v) for k, v in row.items()}
+            except (ValueError, TypeError):
+                malformed += 1
+                continue
+            if parsed["draws"] >= min_draws:
+                rows.append(parsed)
+    if malformed > 1:
+        print(f"  warning: {path}: {malformed} malformed rows skipped", file=sys.stderr)
+    return meta, rows[warmup:]
+
+
+def summarise(rows, key):
+    values = [r[key] for r in rows if key in r]
+    if not values:
+        return None
+    values.sort()
+    return {
+        "median": statistics.median(values),
+        "p95": values[min(int(len(values) * 0.95), len(values) - 1)],
+        "mean": statistics.fmean(values),
+    }
+
+
+def describe(path, meta, rows):
+    if not rows:
+        sys.exit(f"{path}: no frames matched the filter — lower --min-draws or capture more")
+    draws = summarise(rows, "draws")
+    label = meta.get("backend", "?")
+    warn = "  [RENDERDOC ATTACHED]" if meta.get("renderdoc") == "1" else ""
+    print(f"{path}\n  backend={label} frames={len(rows)} "
+          f"median draws/frame={draws['median']:.0f}{warn}")
+    return label
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("baseline")
+    parser.add_argument("candidate", nargs="?")
+    parser.add_argument("--min-draws", type=int, default=800,
+                        help="ignore frames below this draw count (default: 800)")
+    parser.add_argument("--warmup", type=int, default=120,
+                        help="drop this many qualifying frames first (default: 120)")
+    args = parser.parse_args()
+
+    base_meta, base_rows = load(args.baseline, args.min_draws, args.warmup)
+    print()
+    describe(args.baseline, base_meta, base_rows)
+
+    if not args.candidate:
+        print()
+        for key, label, unit in METRICS:
+            stat = summarise(base_rows, key)
+            if stat:
+                print(f"  {label:<26} {stat['median']:9.2f} {unit:<3} "
+                      f"(p95 {stat['p95']:.2f})")
+        draws = summarise(base_rows, "draws")
+        if draws and any(k in base_rows[0] for k, _ in RATES):
+            print("\n  redundancy rates (fraction of draws):")
+            for key, label in RATES:
+                stat = summarise(base_rows, key)
+                if stat:
+                    print(f"    {label:<30} {stat['median'] / draws['median'] * 100:5.1f}%")
+        print()
+        return
+
+    cand_meta, cand_rows = load(args.candidate, args.min_draws, args.warmup)
+    describe(args.candidate, cand_meta, cand_rows)
+
+    if base_meta.get("renderdoc") != cand_meta.get("renderdoc"):
+        print("\n  !! RenderDoc state differs between runs — results are NOT comparable")
+
+    print(f"\n  {'metric':<26} {'baseline':>10} {'candidate':>10} {'change':>10}")
+    print(f"  {'-' * 58}")
+    for key, label, unit in METRICS:
+        base = summarise(base_rows, key)
+        cand = summarise(cand_rows, key)
+        if not base or not cand:
+            continue
+        delta = cand["median"] - base["median"]
+        pct = (delta / base["median"] * 100) if base["median"] else 0.0
+        arrow = "faster" if delta < 0 else "slower" if delta > 0 else ""
+        print(f"  {label:<26} {base['median']:10.2f} {cand['median']:10.2f} "
+              f"{pct:+9.1f}% {arrow}")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/frame_inventory.py
+++ b/tools/frame_inventory.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Full per-frame cost inventory from a renut frame trace.
+
+Accounts for every millisecond of the GPU command thread, ranks each component
+by cost, and flags which ones are worth attacking. Use this to choose a target
+instead of guessing.
+
+    tools/frame_inventory.py trace.csv [--min-draws N]
+"""
+
+import argparse
+import csv
+import statistics
+import sys
+
+# label, csv key, kind, note
+# kind: "phase" = inside IssueDraw, "top" = sibling of IssueDraw, "count" = not a time
+COMPONENTS = [
+    ("IssueDraw (draw submission)", "issuedraw_ms", "top",
+     "sum of the phases below"),
+    ("  RequestTextures", "tex_ms", "phase",
+     "texture fetch parse + load; early-out already added"),
+    ("  UpdateBindings", "bind_ms", "phase",
+     "constant buffers + descriptor sets"),
+    ("    vkUpdateDescriptorSets", "updsets_ms", "phase",
+     "subset of UpdateBindings"),
+    ("  vertex fetch residency", "vfetch_ms", "phase",
+     "shared-memory range requests per vertex buffer"),
+    ("  UpdateSystemConstants", "sysconst_ms", "phase",
+     "system constant block"),
+    ("  samplers", "samp_ms", "phase",
+     "GetSamplerParameters + UseSampler per binding"),
+    ("  render targets", "rt_ms", "phase",
+     "render_target_cache_->Update"),
+    ("  primitive processing", "prim_ms", "phase",
+     "index buffer conversion"),
+    ("  ConfigurePipeline", "pipe_ms", "phase",
+     "pipeline state lookup"),
+    ("  dynamic state", "dyn_ms", "phase",
+     "viewport/scissor/depth bias"),
+    ("  post-pipeline (superset)", "post_ms", "phase",
+     "SUPERSET: contains bind/vfetch/sysconst/dyn"),
+    ("  GPU fence wait", "fencewait_ms", "phase",
+     "blocking wait on a frame in flight"),
+    ("IssueCopy (EDRAM resolve)", "issuecopy_ms", "top",
+     "Xenos tile memory resolve"),
+    ("IssueSwap (present)", "swap_ms", "top",
+     "gamma/FXAA/blit + queue present"),
+    ("ExecutePrimaryBuffer (PM4)", "execprimary_ms", "top",
+     "SUPERSET: packet parsing, contains IssueDraw/Copy"),
+    ("GPU thread stall (idle)", "stall_ms", "top",
+     "waiting for the guest CPU to produce commands"),
+    ("pending_fns (cross-thread)", "pendingfns_ms", "top",
+     "callbacks marshalled onto the GPU thread"),
+    ("CPU blocked on GPU", "gpuwait_ms", "top",
+     "presenter thread in vkWaitForFences - the REAL GPU cost"),
+]
+
+COUNTS = [
+    ("draws", "draws", "draws entering IssueDraw"),
+    ("PM4 type-3 packets", "pkt3", "command packets (draws, state, sync)"),
+    ("PM4 type-0 packets", "pkt0", "register-write packets"),
+    ("guest register writes", "regwrites", "WriteRegister calls"),
+    ("EDRAM resolves", "issuecopy_n", "IssueCopy invocations"),
+    ("render target switches", "rt_switch", "surface/mode changes"),
+    ("stalls", "stall_n", "times the thread ran out of work"),
+    ("primary buffer executions", "execprimary_n", "ring buffer batches"),
+    ("RequestTextures calls", "texcalls", "Vulkan texture-cache entries"),
+    ("  ...needing NO transition", "tex_notrans", "candidates for an early-out"),
+    ("GPU fence waits", "gpuwait_n", "times the CPU blocked on the GPU"),
+    ("render passes begun", "rp_n", "each does a full LOAD + STORE of its target"),
+    ("  ...small (<256x256)", "rp_small", "shadow atlases etc"),
+    ("  ...render-target transfers", "rp_transfer", "EDRAM tile copies"),
+    ("barrier submits", "barrier_submits", "each ENDS the render pass"),
+    ("  buffer barriers", "barrier_buf", ""),
+    ("  image barriers", "barrier_img", ""),
+    ("shared mem: read-write", "use_rw", "memexport with known extent"),
+    ("shared mem: read-write (conservative)", "use_rw_cons", "memexport-capable, unknown extent"),
+    ("shared mem: read-only", "use_read", "no memexport - needs no barrier"),
+]
+
+
+def load(path, min_draws, warmup):
+    meta, rows, bad = {}, [], 0
+    with open(path, newline="") as handle:
+        for line in handle:
+            if line.startswith("#"):
+                for tok in line.lstrip("#").split():
+                    if "=" in tok:
+                        k, v = tok.split("=", 1)
+                        meta[k] = v
+                continue
+            handle.seek(0)
+            break
+        for row in csv.DictReader(r for r in handle if not r.startswith("#")):
+            if None in row or any(v in (None, "") for v in row.values()):
+                bad += 1
+                continue
+            try:
+                p = {k: float(v) for k, v in row.items()}
+            except (ValueError, TypeError):
+                bad += 1
+                continue
+            if p["draws"] >= min_draws:
+                rows.append(p)
+    if bad > 1:
+        print(f"  warning: {bad} malformed rows skipped", file=sys.stderr)
+    return meta, rows[warmup:]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("trace")
+    ap.add_argument("--min-draws", type=int, default=3000)
+    ap.add_argument("--warmup", type=int, default=60)
+    args = ap.parse_args()
+
+    meta, rows = load(args.trace, args.min_draws, args.warmup)
+    if not rows:
+        sys.exit("no frames matched — lower --min-draws")
+
+    def med(key):
+        vals = [r[key] for r in rows if key in r]
+        return statistics.median(vals) if vals else None
+
+    frame = med("frame_ms")
+    draws = med("draws")
+    rdoc = meta.get("renderdoc") == "1"
+
+    print(f"\n{'=' * 74}")
+    print(f"FRAME COST INVENTORY  —  {meta.get('backend', '?')}"
+          f"{'  [RENDERDOC ATTACHED — inflated]' if rdoc else ''}")
+    print(f"{len(rows)} frames, median {draws:.0f} draws/frame, "
+          f"{frame:.2f} ms/frame = {1000 / frame:.0f} fps")
+    print(f"{'=' * 74}\n")
+
+    measured = []
+    for label, key, kind, note in COMPONENTS:
+        v = med(key)
+        if v is None:
+            continue
+        measured.append((label, key, kind, note, v))
+
+    print(f"{'component':<32}{'ms':>8}{'% frame':>9}   note")
+    print(f"{'-' * 74}")
+    for label, key, kind, note, v in measured:
+        print(f"{label:<32}{v:>8.2f}{v / frame * 100:>8.1f}%   {note}")
+
+    # Anything not covered by the top-level siblings is unmeasured.
+    tops = {k: v for _, k, kind, _, v in measured if kind == "top"}
+    # gpuwait_ms is on the presenter thread and overlaps this one, so it is not
+    # part of the GPU-command-thread budget.
+    accounted = (tops.get("execprimary_ms", 0) + tops.get("swap_ms", 0)
+                 + tops.get("stall_ms", 0) + tops.get("pendingfns_ms", 0))
+    print(f"{'-' * 74}")
+    print(f"{'accounted (top-level)':<32}{accounted:>8.2f}{accounted / frame * 100:>8.1f}%")
+    print(f"{'UNMEASURED':<32}{frame - accounted:>8.2f}"
+          f"{(frame - accounted) / frame * 100:>8.1f}%")
+
+    print(f"\n{'per-frame counts':<32}{'n':>10}{'per draw':>11}")
+    print(f"{'-' * 74}")
+    for label, key, note in COUNTS:
+        v = med(key)
+        if v is None:
+            continue
+        print(f"{label:<32}{v:>10.0f}{v / draws:>11.3f}   {note}")
+
+    # Render pass load/store traffic: every pass reads and writes its whole
+    # attachment (LOAD_OP_LOAD + STORE_OP_STORE), so this is real bandwidth.
+    rp_mpixels = med("rp_mpixels")
+    if rp_mpixels:
+        # rp_mpixels already counts each attachment separately; LOAD+STORE
+        # means every attachment pixel is read once and written once.
+        gb = rp_mpixels * 1e6 * 4 * 2 / 1e9
+        fps = 1000.0 / frame
+        print(f"\n{'=' * 74}")
+        print("RENDER PASS LOAD/STORE TRAFFIC (the GPU-side suspect)")
+        print(f"{'=' * 74}")
+        print(f"  {'attachment pixels (all targets)':<34}{rp_mpixels:>10.1f} Mpx/frame")
+        print(f"  {'implied bandwidth':<34}{gb:>10.2f} GB/frame"
+              f"  = {gb * fps:.0f} GB/s at {fps:.0f} fps")
+        print("  (read + write, 4 B/px, summed over every attachment)")
+        print("  RX 9070 peak is ~640 GB/s; near or above that means bandwidth-bound.")
+
+    # Rank only leaf phases — supersets would double-count.
+    superset = {"post_ms", "issuedraw_ms", "execprimary_ms", "updsets_ms"}
+    leaves = [(l, v) for l, k, kind, _, v in measured
+              if k not in superset and v > 0.01]
+    leaves.sort(key=lambda x: -x[1])
+    print(f"\n{'=' * 74}")
+    print("RANKED BY COST (leaf components only — supersets excluded)")
+    print(f"{'=' * 74}")
+    for i, (label, v) in enumerate(leaves[:12], 1):
+        ceiling = v / frame * 100
+        verdict = ("worth attacking" if v >= 2.0 else
+                   "marginal" if v >= 1.0 else "not worth it (<1 ms)")
+        print(f"{i:>2}. {label.strip():<30}{v:>7.2f} ms  "
+              f"max {ceiling:>4.1f}% of frame  — {verdict}")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/resolve_barrier_sites.sh
+++ b/tools/resolve_barrier_sites.sh
@@ -6,7 +6,7 @@
 #   tools/resolve_barrier_sites.sh [log-file]
 set -eu
 
-SO="${RENUT_PLUGIN:-/home/nick/Desktop/reNut/out/build/linux-amd64-relwithdebinfo/librexgpu-renutrd.so}"
+SO="${RENUT_PLUGIN:-/home/nick/Desktop/reNut/out/build/linux-amd64-relwithdebinfo/librexgpu-nativevkrd.so}"
 LOG="${1:-$(ls -t "$HOME"/.local/state/renut/logs/*.log | head -1)}"
 
 [ -f "$SO" ] || { echo "plugin not found: $SO" >&2; exit 1; }

--- a/tools/resolve_barrier_sites.sh
+++ b/tools/resolve_barrier_sites.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+# Resolves the barrier-site addresses logged by the renut plugin to source
+# locations. The plugin logs raw return addresses because tagging all 18
+# PushBufferMemoryBarrier call sites by hand would be error-prone.
+#
+#   tools/resolve_barrier_sites.sh [log-file]
+set -eu
+
+SO="${RENUT_PLUGIN:-/home/nick/Desktop/reNut/out/build/linux-amd64-relwithdebinfo/librexgpu-renutrd.so}"
+LOG="${1:-$(ls -t "$HOME"/.local/state/renut/logs/*.log | head -1)}"
+
+[ -f "$SO" ] || { echo "plugin not found: $SO" >&2; exit 1; }
+
+# spdlog rotates logs by size (renut_NNN.log, .1.log, .2.log, ...), so a single
+# play session - including the process-start line with the plugin base address
+# - can be split across several files. Search all rotated parts belonging to
+# the same base name, oldest first, so the last match is the most recent one.
+LOG_BASE=$(printf '%s' "$LOG" | sed -E 's/\.[0-9]+\.log$/.log/; s/\.log$//')
+LOG_PARTS=$(ls -tr "${LOG_BASE}".log "${LOG_BASE}".*.log 2>/dev/null || true)
+
+# The load address must be subtracted from the logged runtime address to get a
+# file offset addr2line can use.
+BASE=$(grep -h -oE "renut: plugin base 0x[0-9a-f]+" $LOG_PARTS 2>/dev/null | tail -1 | grep -oE "0x[0-9a-f]+" || true)
+
+echo "plugin: $SO"
+echo "log:    $LOG"
+if [ -n "$BASE" ]; then
+    echo "base:   $BASE"
+else
+    echo "base:   (not logged - addresses assumed to be file offsets)"
+fi
+echo
+
+grep -oE "renut barrier site 0x[0-9a-f]+ -> [0-9]+ per frame" "$LOG" \
+  | tail -20 \
+  | while read -r _ _ _ addr _ count _ _; do
+        if [ -n "$BASE" ]; then
+            off=$(printf '0x%x' $(( addr - BASE )))
+        else
+            off="$addr"
+        fi
+        loc=$(addr2line -e "$SO" -f -C -p "$off" 2>/dev/null | head -1)
+        printf '%8s/frame  %s\n' "$count" "${loc:-<unresolved> $addr}"
+    done

--- a/tools/syntax_check_sdk.sh
+++ b/tools/syntax_check_sdk.sh
@@ -5,7 +5,7 @@
 # or no args to check the Vulkan backend plus the renut plugin sources.
 set -eu
 
-SDK="${SDK_SRC:-/home/nick/Desktop/reNut-build-scratch/rexglue-sdk-src}"
+SDK="${SDK_SRC:-/home/nick/Desktop/reNut-build-scratch/rexglue-sdk-clean}"
 cd "$SDK"
 
 CXX="${CXX:-g++}"
@@ -13,8 +13,8 @@ CXX="${CXX:-g++}"
 set -- ${1:+"$@"}
 if [ "$#" -eq 0 ]; then
     set -- src/graphics/vulkan/*.cpp src/graphics/plugin_main.cpp
-    if [ -d src/graphics/renut ]; then
-        set -- "$@" src/graphics/renut/*.cpp
+    if [ -d src/graphics/nativevk ]; then
+        set -- "$@" src/graphics/nativevk/*.cpp
     fi
 fi
 

--- a/tools/syntax_check_sdk.sh
+++ b/tools/syntax_check_sdk.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+# Syntax-checks rexglue-sdk GPU sources with GCC (-fsyntax-only).
+# The real build uses clang; this exists so SDK-side edits can be verified
+# without clang present. Pass file paths relative to the SDK source root,
+# or no args to check the Vulkan backend plus the renut plugin sources.
+set -eu
+
+SDK="${SDK_SRC:-/home/nick/Desktop/reNut-build-scratch/rexglue-sdk-src}"
+cd "$SDK"
+
+CXX="${CXX:-g++}"
+
+set -- ${1:+"$@"}
+if [ "$#" -eq 0 ]; then
+    set -- src/graphics/vulkan/*.cpp src/graphics/plugin_main.cpp
+    if [ -d src/graphics/renut ]; then
+        set -- "$@" src/graphics/renut/*.cpp
+    fi
+fi
+
+# -I../reNut/src (RENUT_REPO_SRC below) is REQUIRED for renut_xenos_pipeline_cache.cpp
+# to actually type-check its real body: that file gates most of its own code on
+# `#if __has_include("renut_engine/renut_xenos_shader_cache.h")`, a build-generated
+# header that lives in reNut's own repo, not this SDK checkout. Without this include
+# path, RENUT_HAVE_XENOS_SHADER_CACHE silently evaluates to 0 and the ENTIRE real
+# function bodies go unchecked -- confirmed real: a genuine duplicate-variable-
+# declaration bug in that file passed this exact script with EXIT=0 before this path
+# was added, because the code containing the bug was never actually compiled.
+RENUT_REPO_SRC="${RENUT_REPO_SRC:-/home/nick/Desktop/reNut/src}"
+
+FLAGS="-std=gnu++23 -fsyntax-only
+-DVK_ENABLE_BETA_EXTENSIONS -DVK_USE_PLATFORM_XCB_KHR -DSPDLOG_FMT_EXTERNAL -DREX_HAS_VULKAN=1
+-Iinclude -I. -I$RENUT_REPO_SRC
+-Ithirdparty/spdlog/include -Ithirdparty/fmt/include -Ithirdparty/renderdoc
+-Ithirdparty/vulkan-headers/include -Ithirdparty/volk
+-Ithirdparty/vulkan-memory-allocator/include -Ithirdparty/xxHash -Ithirdparty/snappy
+-Ithirdparty/simde -Ithirdparty/tracy/public -Ithirdparty/tomlplusplus/include
+-Ithirdparty/utfcpp/source -Ithirdparty/disruptorplus/include
+-Ithirdparty/glslang -Ithirdparty/glslang/glslang/Include -Ithirdparty/imgui"
+
+# Both configurations must build: the renut plugin defines RENUT_OPTIMISATIONS,
+# xenos does not, and code inside #if blocks is only checked in one of them.
+status=0
+for f in "$@"; do
+    [ -f "$f" ] || continue
+    for def in "-DRENUT_OPTIMISATIONS=1" ""; do
+        label=$([ -n "$def" ] && echo "renut" || echo "xenos")
+        printf '%-52s %-6s ' "$f" "$label"
+        if out=$($CXX $FLAGS $def "$f" 2>&1); then
+            echo "OK"
+        else
+            echo "FAIL"
+            echo "$out" | head -25
+            status=1
+        fi
+    done
+done
+exit $status

--- a/tools/ucode_analyze.cpp
+++ b/tools/ucode_analyze.cpp
@@ -1,0 +1,201 @@
+// Standalone offline analyzer: given a real captured .ucode file (Xenos GPU
+// shader microcode, as written by shaders_ucode_hash/<vs|ps>_<hash>.ucode or
+// shaders/<vs|ps>_<hash>.ucode), links the SDK's own real shader-analysis
+// code (Shader::AnalyzeUcode, the same code the Vulkan pipeline cache uses
+// at runtime) and prints structured JSON describing everything
+// build_synthetic_container.py needs to build a XenosRecomp-compatible
+// container: vertex-fetch bindings (fetch constant, stride, per-attribute
+// format/offset/instruction-address), texture bindings (fetch constant to
+// ALU register), interpolator count, and pixel-shader color-output mask.
+//
+// This is a genuinely standalone build, NOT linked against the game's
+// Vulkan/PPC runtime -- see build_ucode_analyze.sh for the exact real
+// source list this was proven to link against (found by iteratively
+// resolving each real missing symbol, not guessed).
+//
+// Usage: ucode_analyze <vs|ps> <ucode_file>
+// Output: one JSON object to stdout.
+
+#include <rex/cvar.h>
+#include <rex/graphics/pipeline/shader/shader.h>
+#include <rex/string/buffer.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <sstream>
+#include <vector>
+
+// Real definition normally lives in graphics/flags.cpp, which this tool
+// deliberately does not link (it pulls in a RenderDoc integration this
+// analysis-only tool has no use for) -- AnalyzeUcode's optional shader-dump
+// path reads this cvar but this tool never wants it enabled, so an empty
+// local stub is the real, correct value, not a placeholder standing in for
+// missing logic.
+REXCVAR_DEFINE_STRING(dump_shaders, "", "GPU", "unused by ucode_analyze");
+
+using namespace rex::graphics;
+
+namespace {
+
+std::vector<uint32_t> ReadUcodeDwordsBigEndian(const char* path) {
+	std::ifstream file(path, std::ios::binary | std::ios::ate);
+	if (!file) {
+		std::fprintf(stderr, "ucode_analyze: cannot open '%s'\n", path);
+		std::exit(1);
+	}
+	const std::streamsize size = file.tellg();
+	file.seekg(0);
+	std::vector<uint8_t> bytes(static_cast<size_t>(size));
+	file.read(reinterpret_cast<char*>(bytes.data()), size);
+
+	// Real captures are written exactly as the guest holds them (big-endian,
+	// see shader_dump.cpp's own comment on this), and Shader's constructor
+	// takes ucode_source_endian explicitly -- pass the raw dwords through
+	// unmodified and let the Shader constructor perform the real byte-swap
+	// to native order itself, matching how the runtime path already does it.
+	std::vector<uint32_t> dwords(bytes.size() / 4);
+	std::memcpy(dwords.data(), bytes.data(), dwords.size() * 4);
+	return dwords;
+}
+
+const char* VertexFormatName(xenos::VertexFormat format) {
+	switch (format) {
+		case xenos::VertexFormat::kUndefined: return "undefined";
+		case xenos::VertexFormat::k_8_8_8_8: return "8_8_8_8";
+		case xenos::VertexFormat::k_2_10_10_10: return "2_10_10_10";
+		case xenos::VertexFormat::k_10_11_11: return "10_11_11";
+		case xenos::VertexFormat::k_11_11_10: return "11_11_10";
+		case xenos::VertexFormat::k_16_16: return "16_16";
+		case xenos::VertexFormat::k_16_16_16_16: return "16_16_16_16";
+		case xenos::VertexFormat::k_16_16_FLOAT: return "16_16_FLOAT";
+		case xenos::VertexFormat::k_16_16_16_16_FLOAT: return "16_16_16_16_FLOAT";
+		case xenos::VertexFormat::k_32: return "32";
+		case xenos::VertexFormat::k_32_32: return "32_32";
+		case xenos::VertexFormat::k_32_32_32_32: return "32_32_32_32";
+		case xenos::VertexFormat::k_32_FLOAT: return "32_FLOAT";
+		case xenos::VertexFormat::k_32_32_FLOAT: return "32_32_FLOAT";
+		case xenos::VertexFormat::k_32_32_32_32_FLOAT: return "32_32_32_32_FLOAT";
+		case xenos::VertexFormat::k_32_32_32_FLOAT: return "32_32_32_FLOAT";
+		default: return "unknown";
+	}
+}
+
+void PrintJsonString(const char* s) {
+	std::printf("\"%s\"", s);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+	if (argc != 3 || (std::string_view(argv[1]) != "vs" && std::string_view(argv[1]) != "ps")) {
+		std::fprintf(stderr, "usage: ucode_analyze <vs|ps> <ucode_file>\n");
+		return 1;
+	}
+	const bool is_vertex = std::string_view(argv[1]) == "vs";
+	const std::vector<uint32_t> ucode_dwords = ReadUcodeDwordsBigEndian(argv[2]);
+	if (ucode_dwords.empty()) {
+		std::fprintf(stderr, "ucode_analyze: empty ucode file '%s'\n", argv[2]);
+		return 1;
+	}
+
+	Shader shader(is_vertex ? xenos::ShaderType::kVertex : xenos::ShaderType::kPixel,
+	              /*ucode_data_hash=*/0, ucode_dwords.data(), ucode_dwords.size(),
+	              std::endian::big);
+	rex::string::StringBuffer disasm;
+	shader.AnalyzeUcode(disasm);
+
+	std::printf("{\n");
+	std::printf("  \"shader_type\": %s,\n", is_vertex ? "\"vs\"" : "\"ps\"");
+	std::printf("  \"writes_interpolators\": %u,\n", shader.writes_interpolators());
+	std::printf("  \"writes_color_targets\": %u,\n", shader.writes_color_targets());
+	std::printf("  \"writes_depth\": %s,\n", shader.writes_depth() ? "true" : "false");
+
+	std::printf("  \"vertex_bindings\": [\n");
+	const auto& vbindings = shader.vertex_bindings();
+	for (size_t i = 0; i < vbindings.size(); ++i) {
+		const auto& vb = vbindings[i];
+		std::printf("    {\n");
+		std::printf("      \"binding_index\": %d,\n", vb.binding_index);
+		std::printf("      \"fetch_constant\": %u,\n", vb.fetch_constant);
+		std::printf("      \"stride_words\": %u,\n", vb.stride_words);
+		std::printf("      \"attributes\": [\n");
+		for (size_t j = 0; j < vb.attributes.size(); ++j) {
+			const auto& fi = vb.attributes[j].fetch_instr;
+			std::printf("        {\n");
+			std::printf("          \"data_format\": %u,\n", uint32_t(fi.attributes.data_format));
+			std::printf("          \"data_format_name\": ");
+			PrintJsonString(VertexFormatName(fi.attributes.data_format));
+			std::printf(",\n");
+			std::printf("          \"offset_words\": %d,\n", fi.attributes.offset);
+			std::printf("          \"stride_words\": %u,\n", fi.attributes.stride);
+			std::printf("          \"is_signed\": %s,\n", fi.attributes.is_signed ? "true" : "false");
+			std::printf("          \"is_integer\": %s,\n", fi.attributes.is_integer ? "true" : "false");
+			std::printf("          \"exp_adjust\": %d,\n", fi.attributes.exp_adjust);
+			std::printf("          \"signed_rf_mode\": %u,\n", uint32_t(fi.attributes.signed_rf_mode));
+			std::printf("          \"is_mini_fetch\": %s\n", fi.is_mini_fetch ? "true" : "false");
+			std::printf("        }%s\n", (j + 1 < vb.attributes.size()) ? "," : "");
+		}
+		std::printf("      ]\n");
+		std::printf("    }%s\n", (i + 1 < vbindings.size()) ? "," : "");
+	}
+	std::printf("  ],\n");
+
+	std::printf("  \"texture_bindings\": [\n");
+	const auto& tbindings = shader.texture_bindings();
+	for (size_t i = 0; i < tbindings.size(); ++i) {
+		const auto& tb = tbindings[i];
+		// The tfetch instruction's own UV/coordinate source operand -- its
+		// storage_index is the ALU register the pixel shader reads the
+		// interpolator's value from, real and structured (InstructionOperand,
+		// shader.h), no disassembly-text parsing needed.
+		uint32_t src_reg = 0;
+		bool has_src_reg = false;
+		if (tb.fetch_instr.operand_count > 0 &&
+		    tb.fetch_instr.operands[0].storage_source == InstructionStorageSource::kRegister) {
+			src_reg = tb.fetch_instr.operands[0].storage_index;
+			has_src_reg = true;
+		}
+		std::printf("    {\n");
+		std::printf("      \"binding_index\": %zu,\n", tb.binding_index);
+		std::printf("      \"fetch_constant\": %u,\n", tb.fetch_constant);
+		std::printf("      \"dimension\": %u,\n", uint32_t(tb.fetch_instr.dimension));
+		if (has_src_reg) {
+			std::printf("      \"src_register\": %u\n", src_reg);
+		} else {
+			std::printf("      \"src_register\": null\n");
+		}
+		std::printf("    }%s\n", (i + 1 < tbindings.size()) ? "," : "");
+	}
+	std::printf("  ],\n");
+
+	std::printf("  \"float_constants\": [");
+	const auto& cmap = shader.constant_register_map();
+	bool first_const = true;
+	for (uint32_t reg = 0; reg < 256; ++reg) {
+		uint32_t block_index = reg / 64;
+		uint32_t bit_index = reg % 64;
+		if (cmap.float_bitmap[block_index] & (uint64_t(1) << bit_index)) {
+			std::printf("%s%u", first_const ? "" : ", ", reg);
+			first_const = false;
+		}
+	}
+	std::printf("],\n");
+	std::printf("  \"float_dynamic_addressing\": %s,\n",
+	             cmap.float_dynamic_addressing ? "true" : "false");
+
+	std::printf("  \"bool_constants\": [");
+	bool first_bool = true;
+	for (uint32_t reg = 0; reg < 256; ++reg) {
+		uint32_t block_index = reg / 32;
+		uint32_t bit_index = reg % 32;
+		if (cmap.bool_bitmap[block_index] & (uint32_t(1) << bit_index)) {
+			std::printf("%s%u", first_bool ? "" : ", ", reg);
+			first_bool = false;
+		}
+	}
+	std::printf("]\n");
+
+	std::printf("}\n");
+	return 0;
+}

--- a/tools/xenos_batch_convert.py
+++ b/tools/xenos_batch_convert.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+"""Batch-convert a directory of dumped guest shaders to compiled SPIR-V via
+XenosRecomp, isolating each shader in its own subprocess so a crash (26/748
+real Banjo shaders segfault XenosRecomp's own directory-scan mode, confirmed
+2026-08-17 -- see PLAN_native_renderer.md) only drops that one shader instead
+of aborting the whole batch.
+
+XenosRecomp's directory-scan mode (see its main.cpp) is what actually invokes
+DXC and smol-v-encodes SPIR-V -- single-file mode only emits HLSL text. But
+directory mode processes every shader it finds in one process with bare
+asserts and no per-shader recovery, so a bad shader takes the whole run down.
+This script gets the same directory-mode output (a real multi-shader cache)
+by feeding XenosRecomp ONE synthetic single-shader directory per invocation:
+copy (well, symlink) exactly one dumped shader into a scratch directory, run
+XenosRecomp against that directory, check the exit code, then merge every
+successful shader's cache entries into one combined output.
+
+Usage:
+    xenos_batch_convert.py <xenos_recomp_binary> <shader_dump_dir>
+        <shader_common_header> <output_cpp> [<output_manifest>] [<output_remap>]
+
+<output_cpp> gets XenosRecomp's own generated shader-cache C++ (the
+ShaderCacheEntry table + compressed DXIL/SPIR-V blobs), but built only from
+the shaders that converted successfully. <output_manifest>, if given, gets a
+plain-text list of "<hash> <status>" lines (ok/crash/error) for visibility
+into what got skipped. <output_remap>, if given, gets a length-prefixed
+binary stream of every successfully-converted shader's real, whole container
+bytes -- consumed by xenos_cache_unpack.cpp to fix a real hash mismatch (see
+the comment where remap_entries is populated below): XenosRecomp's own
+cache-entry hash is NOT the same value the Vulkan pipeline cache looks
+shaders up by at runtime.
+"""
+
+import concurrent.futures
+import hashlib
+import json
+import os
+import re
+import shutil
+import struct
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Real ShaderContainer layout (see XenosRecomp/XenosRecomp/shader.h):
+#   flags, virtualSize, physicalSize, fieldC, constantTableOffset,
+#   definitionTableOffset, shaderOffset, field1C, field20 -- all big-endian
+#   uint32. Magic gate: (flags & 0xFFFFFF00) == 0x102A1100.
+_MAGIC_MASK = 0xFFFFFF00
+_MAGIC_VALUE = 0x102A1100
+_CONTAINER_STRUCT = struct.Struct(">IIIIIIIII")  # 9 big-endian uint32 = 36 bytes
+
+
+def find_containers(data: bytes):
+    """Yield (offset, size, virtual_size, physical_size) for each real
+    ShaderContainer found in data, mirroring XenosRecomp main.cpp's own
+    directory-mode scan exactly so we isolate the same units it would.
+    virtual_size/physical_size are exposed so callers can locate the real
+    ucode bytes (the physical section, appended right after the virtual
+    section) without re-parsing the header themselves."""
+    i = 0
+    n = len(data)
+    header_size = _CONTAINER_STRUCT.size
+    while i + header_size < n:
+        (flags, virtual_size, physical_size, field_c, ctbl_off, dtbl_off,
+         shader_off, field1c, field20) = _CONTAINER_STRUCT.unpack_from(data, i)
+        data_size = virtual_size + physical_size
+        if ((flags & _MAGIC_MASK) == _MAGIC_VALUE and data_size <= (n - i) and
+                field1c == 0 and field20 == 0):
+            yield i, data_size, virtual_size, physical_size
+            i += data_size
+        else:
+            i += 4
+
+
+# Real per-shader result cache (2026-08-16): each real capture/recapture
+# session re-touches or re-adds files across the WHOLE shader_dump_dir (a
+# fresh play session writes many files with new mtimes even for shaders
+# whose CONTENT is unchanged from before), and CMake's own DEPENDS on that
+# directory's contents means any such touch triggers a full rebuild here --
+# real, confirmed cost: ~2200 shaders x one XenosRecomp subprocess each,
+# every single recapture, even when only a handful of shaders are actually
+# new. XenosRecomp's own per-shader result depends ONLY on that shader's
+# real container bytes (content), not on its filename/mtime/position in the
+# directory -- so a real content-hash keyed cache is exactly correct, not
+# an approximation: identical bytes always convert to the identical result.
+# Keyed on a real cryptographic hash (not XXH3, which the compressed cache
+# entries themselves already use for a DIFFERENT purpose -- see the hash-
+# remap comment lower in this file; reusing it here would risk confusion
+# between two unrelated hash spaces) of the shader's own container bytes.
+_CACHE_VERSION = 1
+
+
+def _load_result_cache(cache_path: Path) -> dict[str, dict]:
+    if not cache_path.exists():
+        return {}
+    try:
+        data = json.loads(cache_path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {}
+    if data.get("version") != _CACHE_VERSION:
+        return {}
+    return data.get("entries", {})
+
+
+def _save_result_cache(cache_path: Path, entries: dict[str, dict]) -> None:
+    cache_path.write_text(json.dumps({"version": _CACHE_VERSION, "entries": entries}))
+
+
+def _run_one_shader(xenos_recomp: Path, common_header: Path, tag: str, chunk: bytes) -> str:
+    """Runs XenosRecomp against exactly one shader in its own isolated temp
+    directory/subprocess -- identical isolation to what the old strictly-
+    sequential loop did per shader, just pulled into a function so many of
+    these can run concurrently (see the ThreadPoolExecutor in main()).
+    Returns the same status strings the old inline loop produced: "timeout",
+    "crash", "error", "no-output", "skipped-by-xenosrecomp:<reason>", or "ok"."""
+    with tempfile.TemporaryDirectory(prefix="xenos_batch_try_") as trial_dir:
+        trial_path = Path(trial_dir)
+        shader_path = trial_path / f"{tag}.bin"
+        shader_path.write_bytes(chunk)
+        out_path = trial_path / f"{tag}_cache.cpp"
+
+        try:
+            proc = subprocess.run(
+                [str(xenos_recomp), str(trial_path), str(out_path), str(common_header)],
+                capture_output=True, timeout=60)
+        except subprocess.TimeoutExpired:
+            return "timeout"
+
+        if proc.returncode != 0:
+            return "crash" if proc.returncode < 0 else "error"
+
+        if not out_path.exists():
+            return "no-output"
+
+        # See the historical comment on this same check in the old inline
+        # loop (removed here, kept in git blame): a gracefully-skipped
+        # shader still exits 0 and still writes out_path, so returncode/
+        # out_path.exists() alone can't distinguish "converted" from
+        # "skipped".
+        if b"Skipping shader" in proc.stdout:
+            reason_match = re.search(rb"Skipping shader [0-9A-Fa-f]+: (.+?)\.?\r?\n", proc.stdout)
+            reason = reason_match.group(1).decode(errors="replace") if reason_match else "unknown"
+            return f"skipped-by-xenosrecomp:{reason}"
+
+        return "ok"
+
+
+def main() -> int:
+    if len(sys.argv) < 5:
+        print(__doc__)
+        return 1
+
+    xenos_recomp = Path(sys.argv[1])
+    dump_dir = Path(sys.argv[2])
+    common_header = Path(sys.argv[3])
+    output_cpp = Path(sys.argv[4])
+    manifest_path = Path(sys.argv[5]) if len(sys.argv) > 5 else None
+    remap_path = Path(sys.argv[6]) if len(sys.argv) > 6 else None
+
+    if not dump_dir.is_dir():
+        print(f"xenos_batch_convert: '{dump_dir}' is not a directory, nothing to do")
+        output_cpp.write_text("// no shader dump directory found\n")
+        return 0
+
+    bin_files = sorted(dump_dir.glob("*.bin"))
+    if not bin_files:
+        print(f"xenos_batch_convert: no .bin files in '{dump_dir}', nothing to do")
+        output_cpp.write_text("// no shaders found\n")
+        return 0
+
+    # Real, persistent, content-keyed cache -- lives next to output_cpp so
+    # it survives across full reconfigures (it's a real build BY-PRODUCT,
+    # not build INPUT, so it's safe to keep outside version control the
+    # same way the rest of the shader dump/synthesis pipeline already is).
+    cache_path = Path(str(output_cpp) + ".resultcache.json")
+    result_cache = _load_result_cache(cache_path)
+    cache_hits = 0
+
+    results = []  # (hash_hex, status)
+    remap_entries = []  # (tag, ucode_bytes) for successfully-converted shaders
+    good_dir_root = Path(tempfile.mkdtemp(prefix="xenos_batch_ok_"))
+    good_shaders_dir = good_dir_root / "shaders"
+    good_shaders_dir.mkdir()
+
+    new_cache_entries = {}  # content_hash -> {"status": ..., "tag": ...}, this run's fresh results
+
+    kept = 0
+    pending = []  # (tag, content_hash, chunk) -- needs a real XenosRecomp run
+    for bin_file in bin_files:
+        data = bin_file.read_bytes()
+        containers = list(find_containers(data))
+        if not containers:
+            continue
+        # A dumped .bin is expected to hold exactly one real shader
+        # (shader_dump.cpp writes header+ucode for one CreateVertexShader/
+        # CreatePixelShader call), but scan generically in case that changes.
+        for idx, (offset, size, virtual_size, physical_size) in enumerate(containers):
+            chunk = data[offset:offset + size]
+            tag = bin_file.stem if idx == 0 else f"{bin_file.stem}_{idx}"
+            content_hash = hashlib.sha256(chunk).hexdigest()
+
+            cached = result_cache.get(content_hash)
+            if cached is not None:
+                # Real cache hit: this EXACT shader (by content, not name/
+                # mtime) has already been run through XenosRecomp before,
+                # with this same real result -- skip the subprocess entirely.
+                cache_hits += 1
+                status = cached["status"]
+                results.append((tag, status))
+                new_cache_entries[content_hash] = cached
+                if status == "ok":
+                    (good_shaders_dir / f"{tag}.bin").write_bytes(chunk)
+                    kept += 1
+                    remap_entries.append(chunk)
+                continue
+
+            pending.append((tag, content_hash, chunk))
+
+    # Real fix (2026-08-17, "only 4 cores used" report): this per-shader
+    # isolation loop used to run every pending shader through its own
+    # XenosRecomp subprocess ONE AT A TIME on the main thread -- for a
+    # ~2200-shader corpus that meant almost the entire batch-convert
+    # wall-clock was spent with a single subprocess in flight (whatever
+    # internal DXC/LLVM codegen threads that one process spun up was all the
+    # parallelism the machine ever showed). Each pending shader already runs
+    # in its own subprocess + temp dir, so running many concurrently is
+    # exactly as crash-safe as running them one at a time -- a crash still
+    # only drops that one shader's result. Deliberately NOT applied to the
+    # "combined pass" below or to XenosRecomp's own internal directory-mode
+    # loop, which stays on std::execution::seq (see
+    # cmake/patches/xenosrecomp_graceful_skip.patch) because of a real,
+    # confirmed thread_local DxcCompiler state leak across shaders sharing a
+    # worker thread inside ONE process -- that risk doesn't apply here since
+    # each of these is a fresh XenosRecomp process with its own memory space.
+    max_workers = os.cpu_count() or 4
+    if pending:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
+            future_to_item = {
+                pool.submit(_run_one_shader, xenos_recomp, common_header, tag, chunk): (tag, content_hash, chunk)
+                for tag, content_hash, chunk in pending
+            }
+            for future in concurrent.futures.as_completed(future_to_item):
+                tag, content_hash, chunk = future_to_item[future]
+                try:
+                    status = future.result()
+                except Exception as e:
+                    status = f"error:{e}"
+
+                results.append((tag, status))
+
+                if status == "timeout":
+                    # Real, deliberate exclusion: NOT cached. A timeout can
+                    # be a transient machine-load fluke, not a property of
+                    # the shader's bytes -- caching it risks permanently
+                    # skipping a shader that would actually succeed on a
+                    # quieter run.
+                    continue
+
+                new_cache_entries[content_hash] = {"status": status}
+                if status != "ok":
+                    continue
+
+                # Success: keep the source shader for the real combined pass
+                # below (re-running XenosRecomp once over ALL good shaders
+                # together, so the combined cache is one real dedup'd table
+                # rather than a hand-merge of N single-shader C++ files).
+                (good_shaders_dir / f"{tag}.bin").write_bytes(chunk)
+                kept += 1
+
+                # Real bug found 2026-08-16: XenosRecomp's own cache-entry hash
+                # (XXH3_64bits over the WHOLE container -- main.cpp's
+                # `XXH3_64bits(shaderContainer, dataSize)`) is NOT the same
+                # value the runtime looks shaders up by. The Vulkan pipeline
+                # cache keys native-pipeline lookups on `ucode_data_hash()`
+                # (pipeline_cache.cpp's `LoadShader`), which hashes ONLY the
+                # ucode dwords the GPU command stream loads -- a different byte
+                # range, different hash. This mismatch meant the generalized
+                # native-pipeline cache (HasNativePipeline/GetOrCreatePipeline)
+                # has never matched ANY batch-converted shader in this
+                # project's history -- confirmed via zero real "native pipeline
+                # created" log lines ever. Record the real whole container here
+                # (see the remap file write below for how it's used) so
+                # xenos_cache_unpack.cpp can remap XenosRecomp's container hash
+                # to the real one the runtime actually looks up by.
+                remap_entries.append(chunk)
+
+    _save_result_cache(cache_path, new_cache_entries)
+    print(f"xenos_batch_convert: {cache_hits}/{len(bin_files)} shaders skipped "
+          f"(cached result from a previous run)")
+
+    if kept == 0:
+        print("xenos_batch_convert: 0/%d shaders converted successfully" % len(results))
+        output_cpp.write_text("// all shaders failed to convert\n")
+    else:
+        # Real, compressed (ZSTD+smol-v) XenosRecomp output -- written
+        # directly to output_cpp. Decompressing this into plain SPIR-V words
+        # is a SEPARATE build step (tools/xenos_cache_unpack.cpp, chained
+        # after this script by renut_xenos_shader_batch() in
+        # cmake/rexglue_xenosrecomp.cmake), not done here.
+        proc = subprocess.run(
+            [str(xenos_recomp), str(good_shaders_dir), str(output_cpp), str(common_header)],
+            capture_output=True, timeout=1800)
+        if proc.returncode != 0:
+            print("xenos_batch_convert: combined pass over %d good shaders FAILED "
+                  "unexpectedly (rc=%d) -- stderr:\n%s" % (kept, proc.returncode,
+                                                             proc.stderr.decode(errors="replace")))
+            return 1
+
+        # Real bug found 2026-08-16 (after the XenosRecomp crash-safety patch
+        # -- see cmake/patches/xenosrecomp_graceful_skip.patch -- started
+        # letting per-shader compile failures inside a MULTI-shader batch
+        # skip gracefully instead of crashing the whole process): shaders
+        # that convert successfully in ISOLATION (this script's own per-
+        # shader subprocess above, the real source of truth for "does this
+        # shader work") can still silently fail when recompiled together
+        # with ~2000 others in this one combined pass -- confirmed real,
+        # deterministic (same exact ~450/2135 shaders fail on repeated runs
+        # with identical input, not a race/resource-exhaustion fluke),
+        # cause not yet root-caused (suspected thread_local DxcCompiler
+        # state leaking between shaders processed by the same worker
+        # thread, since main.cpp's std::execution::par_unseq resets
+        # ShaderRecompiler but not DxcCompiler between shaders). Detect and
+        # report it loudly rather than silently shipping a smaller cache
+        # than what individually verified as working -- this real gap
+        # would otherwise be invisible (proc.returncode == 0, no error our
+        # old code would have noticed).
+        combined_skip_count = proc.stdout.count(b"Skipping shader")
+        if combined_skip_count > 0:
+            print(f"xenos_batch_convert: WARNING {combined_skip_count} shader(s) verified OK in "
+                  f"ISOLATION were silently dropped by the combined multi-shader pass (real, "
+                  f"confirmed XenosRecomp bug, not this script's own logic -- see this line's own "
+                  f"comment). The output cache is missing these shaders even though they "
+                  f"individually convert fine.", file=sys.stderr)
+
+    shutil.rmtree(good_dir_root, ignore_errors=True)
+
+    ok = sum(1 for _, s in results if s == "ok")
+    print(f"xenos_batch_convert: {ok}/{len(results)} shaders converted "
+          f"({len(results) - ok} skipped: crashes/errors isolated per-shader)")
+
+    if manifest_path is not None:
+        with manifest_path.open("w") as f:
+            for tag, status in results:
+                f.write(f"{tag} {status}\n")
+
+    # Real hash-mismatch fix (2026-08-16, see the comment above where
+    # remap_entries is populated): write the REAL, WHOLE container bytes
+    # (virtual+physical sections, exactly what XenosRecomp itself hashes) for
+    # every successfully-converted shader. xenos_cache_unpack.cpp reads this
+    # and, for each entry, computes BOTH the container hash (matching
+    # XenosRecomp's own `XXH3_64bits(shaderContainer, dataSize)` -- the key
+    # already in its emitted table) and the real ucode-only hash (matching
+    # pipeline_cache.cpp's `LoadShader`/`ucode_data_hash()` -- what the
+    # Vulkan pipeline cache's HasNativePipeline()/GetOrCreatePipeline()
+    # actually look shaders up by), then remaps the table to use the latter.
+    # A length-prefixed stream (not one-per-line text) since container bytes
+    # are arbitrary binary, not necessarily printable/newline-safe.
+    if remap_path is not None:
+        with remap_path.open("wb") as f:
+            for container_bytes in remap_entries:
+                f.write(len(container_bytes).to_bytes(4, "little"))
+                f.write(container_bytes)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/xenos_batch_convert.py
+++ b/tools/xenos_batch_convert.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
 """Batch-convert a directory of dumped guest shaders to compiled SPIR-V via
 XenosRecomp, isolating each shader in its own subprocess so a crash (26/748
-real Banjo shaders segfault XenosRecomp's own directory-scan mode, confirmed
-2026-08-17 -- see PLAN_native_renderer.md) only drops that one shader instead
-of aborting the whole batch.
+real Banjo shaders segfault XenosRecomp's own directory-scan mode) only
+drops that one shader instead of aborting the whole batch.
 
 XenosRecomp's directory-scan mode (see its main.cpp) is what actually invokes
 DXC and smol-v-encodes SPIR-V -- single-file mode only emits HLSL text. But
@@ -74,7 +73,7 @@ def find_containers(data: bytes):
             i += 4
 
 
-# Real per-shader result cache (2026-08-16): each real capture/recapture
+# Real per-shader result cache: each real capture/recapture
 # session re-touches or re-adds files across the WHOLE shader_dump_dir (a
 # fresh play session writes many files with new mtimes even for shaders
 # whose CONTENT is unchanged from before), and CMake's own DEPENDS on that
@@ -218,7 +217,7 @@ def main() -> int:
 
             pending.append((tag, content_hash, chunk))
 
-    # Real fix (2026-08-17, "only 4 cores used" report): this per-shader
+    # "Only 4 cores used" report: this per-shader
     # isolation loop used to run every pending shader through its own
     # XenosRecomp subprocess ONE AT A TIME on the main thread -- for a
     # ~2200-shader corpus that meant almost the entire batch-convert
@@ -269,7 +268,7 @@ def main() -> int:
                 (good_shaders_dir / f"{tag}.bin").write_bytes(chunk)
                 kept += 1
 
-                # Real bug found 2026-08-16: XenosRecomp's own cache-entry hash
+                # Real bug found XenosRecomp's own cache-entry hash
                 # (XXH3_64bits over the WHOLE container -- main.cpp's
                 # `XXH3_64bits(shaderContainer, dataSize)`) is NOT the same
                 # value the runtime looks shaders up by. The Vulkan pipeline
@@ -308,10 +307,10 @@ def main() -> int:
                                                              proc.stderr.decode(errors="replace")))
             return 1
 
-        # Real bug found 2026-08-16 (after the XenosRecomp crash-safety patch
-        # -- see cmake/patches/xenosrecomp_graceful_skip.patch -- started
-        # letting per-shader compile failures inside a MULTI-shader batch
-        # skip gracefully instead of crashing the whole process): shaders
+        # After the XenosRecomp crash-safety patch (see
+        # cmake/patches/xenosrecomp_graceful_skip.patch) started letting
+        # per-shader compile failures inside a MULTI-shader batch skip
+        # gracefully instead of crashing the whole process, shaders
         # that convert successfully in ISOLATION (this script's own per-
         # shader subprocess above, the real source of truth for "does this
         # shader work") can still silently fail when recompiled together
@@ -345,7 +344,7 @@ def main() -> int:
             for tag, status in results:
                 f.write(f"{tag} {status}\n")
 
-    # Real hash-mismatch fix (2026-08-16, see the comment above where
+    # Real hash-mismatch fix (see the comment above where
     # remap_entries is populated): write the REAL, WHOLE container bytes
     # (virtual+physical sections, exactly what XenosRecomp itself hashes) for
     # every successfully-converted shader. xenos_cache_unpack.cpp reads this

--- a/tools/xenos_cache_unpack.cpp
+++ b/tools/xenos_cache_unpack.cpp
@@ -86,7 +86,7 @@ uint32_t ReadBigEndianU32(const uint8_t* p) {
   return (uint32_t(p[0]) << 24) | (uint32_t(p[1]) << 16) | (uint32_t(p[2]) << 8) | uint32_t(p[3]);
 }
 
-// Real fix (2026-08-16): the compiled SPIR-V vertex shader stage declares a
+// the compiled SPIR-V vertex shader stage declares a
 // FIXED Vulkan input location per D3D9 usage/usageIndex (XenosRecomp's own
 // shader_recompiler.cpp, at the point it emits "in {type} i{var}{idx} :
 // {semantic}{idx}" for each element of VertexShader::
@@ -131,7 +131,7 @@ constexpr DeclUsageLocation kUsageLocations[] = {
 uint32_t VertexElementUsage(uint32_t raw) { return (raw >> 12) & 0xF; }
 uint32_t VertexElementUsageIndex(uint32_t raw) { return (raw >> 16) & 0xF; }
 
-// SUPERSEDED (2026-08-17) by positional location assignment in
+// SUPERSEDED by positional location assignment in
 // ExtractVertexLocations below; retained only to document the scheme this
 // build used to mirror from XenosRecomp's USAGE_LOCATIONS table.
 [[maybe_unused]] uint8_t LookUpVertexLocation(uint32_t usage, uint32_t usageIndex) {
@@ -195,7 +195,7 @@ std::array<uint8_t, kRenutMaxVertexLocations> ExtractVertexLocations(
     return locations;
   }
 
-  // Real fix (2026-08-17): locations are now POSITIONAL -- the i-th vertex
+  // locations are now POSITIONAL -- the i-th vertex
   // element gets location i -- exactly mirroring the [[vk::location(i)]]
   // XenosRecomp now emits for the same element, in the same
   // vertexElementsAndInterpolators[] order. This function and that emission
@@ -261,7 +261,7 @@ std::array<uint8_t, kRenutMaxVertexLocations> ExtractVertexTexCoordSemanticIndic
   return semanticIndices;
 }
 
-// Real fix (2026-08-16): XenosRecomp's own cache-entry hash
+// XenosRecomp's own cache-entry hash
 // (XXH3_64bits over the WHOLE container, main.cpp's
 // `XXH3_64bits(shaderContainer, dataSize)`) is NOT the same value the
 // Vulkan pipeline cache looks shaders up by at runtime -- that's
@@ -279,7 +279,7 @@ std::array<uint8_t, kRenutMaxVertexLocations> ExtractVertexTexCoordSemanticIndic
 // successfully-converted shader.
 struct RemapResult {
   std::unordered_map<uint64_t, uint64_t> hashRemap;
-  // Real fix (2026-08-16): keyed by the SAME real ucode hash hashRemap maps
+  // keyed by the SAME real ucode hash hashRemap maps
   // to (the runtime lookup key), not the container hash -- so this can be
   // applied to outEntries using the entry's ALREADY-remapped .hash field
   // directly, no second lookup needed.
@@ -475,7 +475,7 @@ int main(int argc, char** argv) {
                    "any real draw at runtime\n",
                    (unsigned long long)e.hash);
     }
-    // Real fix (2026-08-16): keyed by e.hash AFTER remapping above, since
+    // keyed by e.hash AFTER remapping above, since
     // vertexLocations was built keyed by the same real ucode hash (see
     // BuildHashRemap/RemapResult's own comments).
     auto locIt = remapResult.vertexLocations.find(e.hash);

--- a/tools/xenos_cache_unpack.cpp
+++ b/tools/xenos_cache_unpack.cpp
@@ -1,0 +1,563 @@
+// Standalone helper for tools/xenos_batch_convert.py.
+//
+// XenosRecomp's directory-mode output (see XenosRecomp/main.cpp) is a C++
+// source defining a ShaderCacheEntry table plus one ZSTD-compressed,
+// smol-v-encoded SPIR-V blob shared by all shaders (offsets/sizes into it
+// live in each entry). That's convenient for a project that already links
+// zstd+smol-v into its runtime (as XenosRecomp's own upstream consumers do),
+// but reNut's Vulkan GPU plugin (rexgpu-renut) is a separate CMake build
+// from reNut's own executable (which is the only place XenosRecomp's
+// FetchContent-provided zstd/smol-v targets exist) -- wiring that dependency
+// across the plugin boundary is real, avoidable complexity for what this
+// needs.
+//
+// So: decompress everything at BUILD TIME instead. This tool takes
+// XenosRecomp's own generated cache .cpp, extracts+decompresses+decodes the
+// real per-shader SPIR-V bytes, and re-emits a plain, self-contained C++
+// source with one flat uint8_t array holding every shader's real (already
+// decoded, ready-to-pass-to-vkCreateShaderModule) SPIR-V back to back, plus
+// an entry table of (hash, offset, size) pairs -- zero runtime dependencies
+// beyond what's already linked into rexgpu-renut.
+//
+// This is a source-to-source rewrite: it does NOT re-invoke XenosRecomp or
+// touch shader semantics, only decodes the compression XenosRecomp itself
+// applied. Parses the exact textual format XenosRecomp's main.cpp emits
+// (fmt::println calls with fixed field order) rather than a general C++
+// parser -- brittle by nature of matching one specific generator's output,
+// documented and isolated on purpose so if XenosRecomp's output format ever
+// changes, only this one file needs updating.
+
+#include <zstd.h>
+
+#include "smolv.h"
+
+#define XXH_INLINE_ALL
+#include <xxhash.h>
+
+#include "renut_engine/renut_xenos_shader_cache.h"
+
+#include <array>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace {
+
+struct Entry {
+  uint64_t hash = 0;
+  size_t spirvOffset = 0;
+  size_t spirvSize = 0;
+  uint32_t specConstantsMask = 0;
+  // Filled in from the remap file's vertexLocations map after hash
+  // remapping (main()); left all-unset (kRenutVertexLocationUnset) for
+  // pixel shaders and for anything with no remap match, matching
+  // RenutXenosShaderCacheEntry's own real, documented field semantics.
+  std::array<uint8_t, kRenutMaxVertexLocations> vertexLocations{};
+  // See kRenutTexCoordSemanticUnset's header comment -- same fill/remap
+  // treatment as vertexLocations above.
+  std::array<uint8_t, kRenutMaxVertexLocations> vertexTexCoordSemanticIndex{};
+};
+
+// Real ShaderContainer header layout (see XenosRecomp/XenosRecomp/shader.h),
+// big-endian on disk -- matches tools/xenos_batch_convert.py's own
+// _CONTAINER_STRUCT exactly. Only the fields needed to locate the physical
+// (ucode) section are read here; the rest exist only to keep the struct's
+// real size (36 bytes) correct for pointer arithmetic.
+struct ShaderContainerHeader {
+  uint32_t flags;
+  uint32_t virtualSize;
+  uint32_t physicalSize;
+  uint32_t fieldC;
+  uint32_t constantTableOffset;
+  uint32_t definitionTableOffset;
+  uint32_t shaderOffset;
+  uint32_t field1C;
+  uint32_t field20;
+};
+static_assert(sizeof(ShaderContainerHeader) == 36, "must match the real 36-byte ShaderContainer header");
+
+uint32_t ReadBigEndianU32(const uint8_t* p) {
+  return (uint32_t(p[0]) << 24) | (uint32_t(p[1]) << 16) | (uint32_t(p[2]) << 8) | uint32_t(p[3]);
+}
+
+// Real fix (2026-08-16): the compiled SPIR-V vertex shader stage declares a
+// FIXED Vulkan input location per D3D9 usage/usageIndex (XenosRecomp's own
+// shader_recompiler.cpp, at the point it emits "in {type} i{var}{idx} :
+// {semantic}{idx}" for each element of VertexShader::
+// vertexElementsAndInterpolators[]) -- NOT sequential 0,1,2,... in
+// vfetch-instruction order, which is what the runtime pipeline cache
+// (renut_xenos_pipeline_cache.cpp) previously assumed. This table is a
+// direct, verbatim port of XenosRecomp's real USAGE_LOCATIONS array (same
+// file) -- must be kept in sync if XenosRecomp's own table ever changes.
+struct DeclUsageLocation {
+  uint32_t usage;
+  uint32_t usageIndex;
+  uint32_t location;
+};
+// DeclUsage enum values (XenosRecomp/shader.h): Position=0, BlendWeight=1,
+// BlendIndices=2, Normal=3, PointSize=4, TexCoord=5, Tangent=6, Binormal=7,
+// TessFactor=8, PositionT=9, Color=10, Fog=11, Depth=12, Sample=13.
+constexpr DeclUsageLocation kUsageLocations[] = {
+    {0, 0, 0},   // Position0
+    {3, 0, 1},   // Normal0
+    {6, 0, 2},   // Tangent0
+    {7, 0, 3},   // Binormal0
+    {5, 0, 4},   // TexCoord0
+    {5, 1, 5},   // TexCoord1
+    {5, 2, 6},   // TexCoord2
+    {5, 3, 7},   // TexCoord3
+    {10, 0, 8},  // Color0
+    {2, 0, 9},   // BlendIndices0
+    {1, 0, 10},  // BlendWeight0
+    {10, 1, 11}, // Color1
+    {5, 4, 12},  // TexCoord4
+    {5, 5, 13},  // TexCoord5
+    {5, 6, 14},  // TexCoord6
+    {5, 7, 15},  // TexCoord7
+    {0, 1, 15},  // Position1
+};
+
+// Real VertexElement bitfield layout (XenosRecomp/shader.h): 12 bits
+// address, 4 bits usage, 4 bits usageIndex, packed into one be<uint32_t>
+// (big-endian on disk, byte-swapped like every other be<T> in this format).
+// Reading the raw 32-bit value and masking/shifting avoids relying on this
+// TU's own bitfield layout matching the real on-disk one exactly.
+uint32_t VertexElementUsage(uint32_t raw) { return (raw >> 12) & 0xF; }
+uint32_t VertexElementUsageIndex(uint32_t raw) { return (raw >> 16) & 0xF; }
+
+// SUPERSEDED (2026-08-17) by positional location assignment in
+// ExtractVertexLocations below; retained only to document the scheme this
+// build used to mirror from XenosRecomp's USAGE_LOCATIONS table.
+[[maybe_unused]] uint8_t LookUpVertexLocation(uint32_t usage, uint32_t usageIndex) {
+  for (const DeclUsageLocation& entry : kUsageLocations) {
+    if (entry.usage == usage && entry.usageIndex == usageIndex) {
+      return uint8_t(entry.location);
+    }
+  }
+  return kRenutVertexLocationUnset;
+}
+
+// Real ShaderContainer's Shader base (XenosRecomp/shader.h's `struct
+// Shader`) is 24 bytes (6 be<uint32_t> fields) before any VertexShader/
+// PixelShader-specific fields begin. VertexShader adds field18 (offset 24),
+// vertexElementCount (offset 28), field20 (offset 32), then
+// vertexElementsAndInterpolators[] starts at offset 36 -- all relative to
+// shaderOffset (the container-relative offset the real ShaderContainer
+// header's own shaderOffset field points to), not the container start.
+constexpr uint32_t kShaderBaseSize = 24;
+constexpr uint32_t kVertexShaderFieldsSize = 12;  // field18 + vertexElementCount + field20
+
+// Extracts real per-attribute Vulkan locations for a vertex shader's
+// container, in vertexElementsAndInterpolators[] order (the SAME order
+// tools/ucode_analyze.cpp's real Shader::AnalyzeUcode()-derived
+// vertex_bindings() walks, since both describe the same underlying real
+// vfetch-instruction sequence) -- up to kRenutMaxVertexLocations entries,
+// unused slots left at kRenutVertexLocationUnset. Returns an all-unset
+// array for anything that doesn't look like a real, well-formed vertex
+// shader container (pixel shaders, malformed data) rather than asserting --
+// this is diagnostic/best-effort data, a miss here just means the runtime
+// falls back to its own (real, but not always correct) sequential
+// assignment, not a hard failure.
+std::array<uint8_t, kRenutMaxVertexLocations> ExtractVertexLocations(
+    const std::vector<uint8_t>& container, uint32_t shaderOffset, bool isVertexShader) {
+  std::array<uint8_t, kRenutMaxVertexLocations> locations{};
+  locations.fill(kRenutVertexLocationUnset);
+  if (!isVertexShader) return locations;
+
+  if (size_t(shaderOffset) + kShaderBaseSize + kVertexShaderFieldsSize > container.size()) {
+    std::fprintf(stderr, "xenos_cache_unpack DIAG: reject bounds1 shaderOffset=%u container=%zu\n",
+                 shaderOffset, container.size());
+    return locations;
+  }
+  const uint8_t* shaderData = container.data() + shaderOffset;
+  const uint32_t vertexElementCount =
+      ReadBigEndianU32(shaderData + kShaderBaseSize + 4);  // field18, vertexElementCount, field20
+  const uint32_t field18 = ReadBigEndianU32(shaderData + kShaderBaseSize);
+  const uint32_t elementsStart = kShaderBaseSize + kVertexShaderFieldsSize;
+
+  if (vertexElementCount == 0 || vertexElementCount > kRenutMaxVertexLocations) {
+    std::fprintf(stderr, "xenos_cache_unpack DIAG: reject count vertexElementCount=%u field18=%u\n",
+                 vertexElementCount, field18);
+    return locations;
+  }
+  const size_t elementsEnd =
+      size_t(shaderOffset) + elementsStart + size_t(field18 + vertexElementCount) * 4;
+  if (elementsEnd > container.size()) {
+    std::fprintf(stderr, "xenos_cache_unpack DIAG: reject bounds2 elementsEnd=%zu container=%zu "
+                 "field18=%u count=%u\n",
+                 elementsEnd, container.size(), field18, vertexElementCount);
+    return locations;
+  }
+
+  // Real fix (2026-08-17): locations are now POSITIONAL -- the i-th vertex
+  // element gets location i -- exactly mirroring the [[vk::location(i)]]
+  // XenosRecomp now emits for the same element, in the same
+  // vertexElementsAndInterpolators[] order. This function and that emission
+  // site are the two halves of one contract; changing either alone silently
+  // binds the wrong buffer data to the wrong shader input.
+  //
+  // Previously both sides looked the usage up in XenosRecomp's
+  // Unleashed-specific USAGE_LOCATIONS table, which (a) had no entry for the
+  // POSITION2..12 / TEXCOORD8..12 this game uses, so 198 vertex shaders
+  // failed to compile at all, and (b) mapped both (Position,1) and
+  // (TexCoord,7) to location 15, so widening it would have aliased two
+  // attributes onto one location. Indexing positionally removes the lookup,
+  // and with it both failure modes -- and it matches the hardware, where a
+  // vertex shader pulls its own data via vfetch and the D3D9 usage semantic
+  // never reaches the GPU at all.
+  for (uint32_t i = 0; i < vertexElementCount; ++i) {
+    locations[i] = uint8_t(i);
+  }
+  return locations;
+}
+
+// Real per-raw-attribute D3D9 TexCoord usageIndex (0-7), or
+// kRenutTexCoordSemanticUnset for any non-TexCoord usage -- see
+// kRenutTexCoordSemanticUnset's header comment for why this is still needed
+// even though vertex locations themselves went positional. Reads the SAME
+// raw vertexElementsAndInterpolators[] entries ExtractVertexLocations reads,
+// just decoding the usage/usageIndex bitfields (VertexElementUsage/
+// VertexElementUsageIndex) instead of discarding them for a plain index.
+// DeclUsage::TexCoord == 5, see the enum-value comment above kUsageLocations.
+constexpr uint32_t kDeclUsageTexCoord = 5;
+
+std::array<uint8_t, kRenutMaxVertexLocations> ExtractVertexTexCoordSemanticIndices(
+    const std::vector<uint8_t>& container, uint32_t shaderOffset, bool isVertexShader) {
+  std::array<uint8_t, kRenutMaxVertexLocations> semanticIndices{};
+  semanticIndices.fill(kRenutTexCoordSemanticUnset);
+  if (!isVertexShader) return semanticIndices;
+
+  if (size_t(shaderOffset) + kShaderBaseSize + kVertexShaderFieldsSize > container.size()) {
+    return semanticIndices;
+  }
+  const uint8_t* shaderData = container.data() + shaderOffset;
+  const uint32_t vertexElementCount =
+      ReadBigEndianU32(shaderData + kShaderBaseSize + 4);  // field18, vertexElementCount, field20
+  const uint32_t field18 = ReadBigEndianU32(shaderData + kShaderBaseSize);
+  const uint32_t elementsStart = kShaderBaseSize + kVertexShaderFieldsSize;
+
+  if (vertexElementCount == 0 || vertexElementCount > kRenutMaxVertexLocations) {
+    return semanticIndices;
+  }
+  const size_t elementsEnd =
+      size_t(shaderOffset) + elementsStart + size_t(field18 + vertexElementCount) * 4;
+  if (elementsEnd > container.size()) {
+    return semanticIndices;
+  }
+
+  const uint8_t* elementsData = shaderData + elementsStart + field18 * 4;
+  for (uint32_t i = 0; i < vertexElementCount; ++i) {
+    const uint32_t raw = ReadBigEndianU32(elementsData + i * 4);
+    if (VertexElementUsage(raw) == kDeclUsageTexCoord) {
+      semanticIndices[i] = uint8_t(VertexElementUsageIndex(raw));
+    }
+  }
+  return semanticIndices;
+}
+
+// Real fix (2026-08-16): XenosRecomp's own cache-entry hash
+// (XXH3_64bits over the WHOLE container, main.cpp's
+// `XXH3_64bits(shaderContainer, dataSize)`) is NOT the same value the
+// Vulkan pipeline cache looks shaders up by at runtime -- that's
+// `ucode_data_hash()` (pipeline_cache.cpp's `LoadShader`), which hashes
+// ONLY the ucode dwords the GPU command stream loads. Confirmed via direct
+// empirical hash computation this session: these are two different,
+// non-overlapping 64-bit values for every real captured shader checked.
+// This mismatch meant the generalized native-pipeline cache
+// (HasNativePipeline/GetOrCreatePipeline in renut_xenos_pipeline_cache.cpp)
+// has never matched ANY batch-converted shader in this project's history --
+// confirmed via zero real "native pipeline created" log lines ever, across
+// every saved session log. Builds a remap table (container hash -> real
+// ucode-only hash) from the real, whole container bytes
+// tools/xenos_batch_convert.py writes to <output_remap> for every
+// successfully-converted shader.
+struct RemapResult {
+  std::unordered_map<uint64_t, uint64_t> hashRemap;
+  // Real fix (2026-08-16): keyed by the SAME real ucode hash hashRemap maps
+  // to (the runtime lookup key), not the container hash -- so this can be
+  // applied to outEntries using the entry's ALREADY-remapped .hash field
+  // directly, no second lookup needed.
+  std::unordered_map<uint64_t, std::array<uint8_t, kRenutMaxVertexLocations>> vertexLocations;
+  // Same keying/lifetime contract as vertexLocations above.
+  std::unordered_map<uint64_t, std::array<uint8_t, kRenutMaxVertexLocations>> vertexTexCoordSemanticIndex;
+};
+
+RemapResult BuildHashRemap(const char* remapPath) {
+  RemapResult result;
+  if (!remapPath) return result;
+
+  std::ifstream file(remapPath, std::ios::binary);
+  if (!file) {
+    // Not fatal -- an older/no-remap-arg invocation should still work,
+    // just without the fix (entries stay keyed by the old, wrong hash).
+    std::fprintf(stderr, "xenos_cache_unpack: no remap file at %s, hash remap skipped\n", remapPath);
+    return result;
+  }
+
+  while (true) {
+    uint32_t lengthLE = 0;
+    file.read(reinterpret_cast<char*>(&lengthLE), sizeof(lengthLE));
+    if (file.gcount() != sizeof(lengthLE)) break;  // clean EOF
+
+    std::vector<uint8_t> container(lengthLE);
+    file.read(reinterpret_cast<char*>(container.data()), lengthLE);
+    if (size_t(file.gcount()) != container.size()) {
+      std::fprintf(stderr, "xenos_cache_unpack: truncated remap entry, stopping remap parse early\n");
+      break;
+    }
+    if (container.size() < sizeof(ShaderContainerHeader)) {
+      continue;  // real container is always >= header size; skip anything malformed
+    }
+
+    const uint32_t flags = ReadBigEndianU32(container.data() + offsetof(ShaderContainerHeader, flags));
+    const uint32_t virtualSize = ReadBigEndianU32(container.data() + offsetof(ShaderContainerHeader, virtualSize));
+    const uint32_t physicalSize = ReadBigEndianU32(container.data() + offsetof(ShaderContainerHeader, physicalSize));
+    const uint32_t shaderOffset = ReadBigEndianU32(container.data() + offsetof(ShaderContainerHeader, shaderOffset));
+    if (size_t(virtualSize) + size_t(physicalSize) != container.size() || physicalSize == 0) {
+      std::fprintf(stderr, "xenos_cache_unpack: remap entry has inconsistent virtual/physical size, skipping\n");
+      continue;
+    }
+
+    // Same formula as XenosRecomp's own main.cpp: XXH3_64bits over the
+    // whole container (virtual+physical), matching what's already keying
+    // the entry table this remap will be applied to.
+    const uint64_t containerHash = XXH3_64bits(container.data(), container.size());
+    // Same formula as pipeline_cache.cpp's real LoadShader/ucode_data_hash():
+    // XXH3_64bits over ONLY the physical (ucode) section, which is appended
+    // immediately after the virtual section in a real ShaderContainer.
+    const uint64_t ucodeHash = XXH3_64bits(container.data() + virtualSize, physicalSize);
+
+    result.hashRemap[containerHash] = ucodeHash;
+
+    // flags & 0x1 CLEAR means pixel shader (same real convention
+    // build_synthetic_container.py's build_pixel_container already uses,
+    // confirmed against XenosRecomp's own shader_recompiler.cpp).
+    const bool isVertexShader = (flags & 0x1) != 0;
+    result.vertexLocations[ucodeHash] = ExtractVertexLocations(container, shaderOffset, isVertexShader);
+    result.vertexTexCoordSemanticIndex[ucodeHash] =
+        ExtractVertexTexCoordSemanticIndices(container, shaderOffset, isVertexShader);
+  }
+
+  return result;
+}
+
+std::string ReadFile(const char* path) {
+  std::ifstream file(path, std::ios::binary);
+  if (!file) {
+    std::fprintf(stderr, "xenos_cache_unpack: cannot open %s\n", path);
+    std::exit(1);
+  }
+  std::ostringstream ss;
+  ss << file.rdbuf();
+  return ss.str();
+}
+
+// Parses one "{ 0xHASH, dxilOff, dxilSize, spirvOff, spirvSize, specMask },"
+// line, matching XenosRecomp main.cpp's exact fmt::println format string:
+//   "\t{{ 0x{:X}, {}, {}, {}, {}, {} }},"
+std::vector<Entry> ParseEntries(const std::string& source) {
+  std::vector<Entry> entries;
+  size_t pos = source.find("g_shaderCacheEntries[]");
+  if (pos == std::string::npos) {
+    std::fprintf(stderr, "xenos_cache_unpack: g_shaderCacheEntries not found in input\n");
+    std::exit(1);
+  }
+  size_t braceOpen = source.find('{', pos);
+  size_t arrayEnd = source.find("};", braceOpen);
+  std::string body = source.substr(braceOpen + 1, arrayEnd - braceOpen - 1);
+
+  size_t i = 0;
+  while (true) {
+    size_t entryOpen = body.find('{', i);
+    if (entryOpen == std::string::npos) break;
+    size_t entryClose = body.find('}', entryOpen);
+    std::string entryText = body.substr(entryOpen + 1, entryClose - entryOpen - 1);
+
+    Entry e;
+    // hash, dxilOffset, dxilSize, spirvOffset, spirvSize, specConstantsMask
+    unsigned long long hash = 0, dxilOff = 0, dxilSize = 0, spirvOff = 0, spirvSize = 0, specMask = 0;
+    if (std::sscanf(entryText.c_str(), " 0x%llX , %llu , %llu , %llu , %llu , %llu", &hash, &dxilOff,
+                     &dxilSize, &spirvOff, &spirvSize, &specMask) != 6) {
+      std::fprintf(stderr, "xenos_cache_unpack: failed to parse entry '%s'\n", entryText.c_str());
+      std::exit(1);
+    }
+    e.hash = uint64_t(hash);
+    e.spirvOffset = size_t(spirvOff);
+    e.spirvSize = size_t(spirvSize);
+    e.specConstantsMask = uint32_t(specMask);
+    entries.push_back(e);
+
+    i = entryClose + 1;
+  }
+  return entries;
+}
+
+// Parses "const uint8_t g_compressedSpirvCache[] = {n,n,n,...};" into raw
+// bytes.
+std::vector<uint8_t> ParseByteArray(const std::string& source, const char* varName) {
+  size_t pos = source.find(varName);
+  if (pos == std::string::npos) {
+    std::fprintf(stderr, "xenos_cache_unpack: %s not found in input\n", varName);
+    std::exit(1);
+  }
+  size_t braceOpen = source.find('{', pos);
+  size_t braceClose = source.find('}', braceOpen);
+  std::string body = source.substr(braceOpen + 1, braceClose - braceOpen - 1);
+
+  std::vector<uint8_t> bytes;
+  bytes.reserve(body.size() / 3);
+  size_t i = 0;
+  while (i < body.size()) {
+    while (i < body.size() && (body[i] == ',' || body[i] == ' ' || body[i] == '\n' || body[i] == '\t')) ++i;
+    if (i >= body.size()) break;
+    size_t start = i;
+    while (i < body.size() && body[i] != ',') ++i;
+    if (i > start) {
+      bytes.push_back(uint8_t(std::strtoul(body.substr(start, i - start).c_str(), nullptr, 10)));
+    }
+  }
+  return bytes;
+}
+
+size_t ParseSizeT(const std::string& source, const char* varName) {
+  size_t pos = source.find(varName);
+  if (pos == std::string::npos) {
+    std::fprintf(stderr, "xenos_cache_unpack: %s not found in input\n", varName);
+    std::exit(1);
+  }
+  size_t eq = source.find('=', pos);
+  size_t semi = source.find(';', eq);
+  return size_t(std::strtoull(source.substr(eq + 1, semi - eq - 1).c_str(), nullptr, 10));
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  if (argc < 3) {
+    std::fprintf(stderr,
+                 "usage: %s <xenos-recomp-generated-cache.cpp> <output.cpp> [<remap-file>]\n",
+                 argv[0]);
+    return 1;
+  }
+
+  std::string source = ReadFile(argv[1]);
+  std::vector<Entry> entries = ParseEntries(source);
+  std::vector<uint8_t> compressed = ParseByteArray(source, "g_compressedSpirvCache");
+  size_t decompressedSize = ParseSizeT(source, "g_spirvCacheDecompressedSize");
+
+  // Real hash-mismatch fix -- see BuildHashRemap's own comment. Remap each
+  // entry's key from XenosRecomp's own whole-container hash to the real
+  // ucode-only hash the Vulkan pipeline cache actually looks shaders up by.
+  // Entries with no remap match (shouldn't happen for anything that came
+  // through xenos_batch_convert.py's isolation loop, since every successful
+  // conversion is recorded) are left with their original hash and a warning
+  // -- kept in the cache rather than silently dropped, since a stale/wrong
+  // key is a real, visible failure mode (just never matches at runtime, same
+  // as before this fix), not a crash risk.
+  RemapResult remapResult = BuildHashRemap(argc > 3 ? argv[3] : nullptr);
+  size_t remapped = 0;
+  size_t withVertexLocations = 0;
+  for (Entry& e : entries) {
+    auto it = remapResult.hashRemap.find(e.hash);
+    if (it != remapResult.hashRemap.end()) {
+      e.hash = it->second;
+      ++remapped;
+    } else if (!remapResult.hashRemap.empty()) {
+      std::fprintf(stderr,
+                   "xenos_cache_unpack: WARNING no hash remap found for entry 0x%llX -- "
+                   "keeping XenosRecomp's own container hash, this entry will not match "
+                   "any real draw at runtime\n",
+                   (unsigned long long)e.hash);
+    }
+    // Real fix (2026-08-16): keyed by e.hash AFTER remapping above, since
+    // vertexLocations was built keyed by the same real ucode hash (see
+    // BuildHashRemap/RemapResult's own comments).
+    auto locIt = remapResult.vertexLocations.find(e.hash);
+    if (locIt != remapResult.vertexLocations.end()) {
+      e.vertexLocations = locIt->second;
+      if (locIt->second[0] != kRenutVertexLocationUnset) ++withVertexLocations;
+    }
+    auto texCoordIt = remapResult.vertexTexCoordSemanticIndex.find(e.hash);
+    if (texCoordIt != remapResult.vertexTexCoordSemanticIndex.end()) {
+      e.vertexTexCoordSemanticIndex = texCoordIt->second;
+    }
+  }
+  if (!remapResult.hashRemap.empty()) {
+    std::fprintf(stderr, "xenos_cache_unpack: remapped %zu/%zu entries to their real ucode hash "
+                 "(%zu with real vertex locations)\n",
+                 remapped, entries.size(), withVertexLocations);
+  }
+
+  std::vector<uint8_t> smolvBlob(decompressedSize);
+  size_t zstdResult = ZSTD_decompress(smolvBlob.data(), smolvBlob.size(), compressed.data(), compressed.size());
+  if (ZSTD_isError(zstdResult) || zstdResult != decompressedSize) {
+    std::fprintf(stderr, "xenos_cache_unpack: ZSTD_decompress failed (%s)\n", ZSTD_getErrorName(zstdResult));
+    return 1;
+  }
+
+  // Decode each shader's smol-v-encoded SPIR-V slice back to real SPIR-V
+  // (uint32_t words), and lay them all out contiguously in one flat buffer.
+  std::vector<uint32_t> flatSpirv;
+  std::vector<Entry> outEntries;
+  for (const Entry& e : entries) {
+    if (e.spirvSize == 0 || e.spirvOffset + e.spirvSize > smolvBlob.size()) {
+      std::fprintf(stderr, "xenos_cache_unpack: entry 0x%llX has an invalid SPIR-V slice, skipping\n",
+                   (unsigned long long)e.hash);
+      continue;
+    }
+    size_t decodedSpirvSize = smolv::GetDecodedBufferSize(smolvBlob.data() + e.spirvOffset, e.spirvSize);
+    if (decodedSpirvSize == 0) {
+      std::fprintf(stderr, "xenos_cache_unpack: entry 0x%llX smol-v size query failed, skipping\n",
+                   (unsigned long long)e.hash);
+      continue;
+    }
+    std::vector<uint32_t> spirv(decodedSpirvSize / sizeof(uint32_t));
+    if (!smolv::Decode(smolvBlob.data() + e.spirvOffset, e.spirvSize, spirv.data(), decodedSpirvSize)) {
+      std::fprintf(stderr, "xenos_cache_unpack: entry 0x%llX smol-v decode failed, skipping\n",
+                   (unsigned long long)e.hash);
+      continue;
+    }
+
+    Entry outEntry = e;
+    outEntry.spirvOffset = flatSpirv.size();
+    outEntry.spirvSize = spirv.size();
+    outEntries.push_back(outEntry);
+    flatSpirv.insert(flatSpirv.end(), spirv.begin(), spirv.end());
+  }
+
+  std::ofstream out(argv[2]);
+  out << "// Generated by tools/xenos_cache_unpack.cpp from XenosRecomp's real compiled shader cache.\n";
+  out << "// Plain, decompressed SPIR-V words -- no zstd/smol-v dependency needed to consume this.\n";
+  out << "#include \"renut_engine/renut_xenos_shader_cache.h\"\n\n";
+  out << "const uint32_t g_renutXenosSpirvWords[] = {\n";
+  for (size_t i = 0; i < flatSpirv.size(); ++i) {
+    out << flatSpirv[i] << ",";
+    if ((i % 16) == 15) out << "\n";
+  }
+  out << "\n};\n\n";
+  out << "const RenutXenosShaderCacheEntry g_renutXenosShaderCacheEntries[] = {\n";
+  for (const Entry& e : outEntries) {
+    out << "\t{ 0x" << std::hex << e.hash << std::dec << "ULL, " << e.spirvOffset << ", " << e.spirvSize
+        << ", " << e.specConstantsMask << ", { ";
+    for (size_t i = 0; i < kRenutMaxVertexLocations; ++i) {
+      out << uint32_t(e.vertexLocations[i]) << (i + 1 < kRenutMaxVertexLocations ? ", " : "");
+    }
+    out << " }, { ";
+    for (size_t i = 0; i < kRenutMaxVertexLocations; ++i) {
+      out << uint32_t(e.vertexTexCoordSemanticIndex[i]) << (i + 1 < kRenutMaxVertexLocations ? ", " : "");
+    }
+    out << " } },\n";
+  }
+  out << "};\n\n";
+  out << "const size_t g_renutXenosShaderCacheEntryCount = " << outEntries.size() << ";\n";
+
+  std::fprintf(stderr, "xenos_cache_unpack: wrote %zu shaders (%zu SPIR-V words) to %s\n", outEntries.size(),
+               flatSpirv.size(), argv[2]);
+  return 0;
+}

--- a/tools/xenos_synthesize_constant_table.py
+++ b/tools/xenos_synthesize_constant_table.py
@@ -73,7 +73,7 @@ def build_constant_table(float_regs, sampler_regs, bool_regs=(), is_pixel_shader
     ConstantTableContainer, ready to append to a container's physical
     section and point constantTableOffset at).
 
-    Real fix (2026-08-17): float4 registers used to get one ConstantInfo
+    float4 registers used to get one ConstantInfo
     EACH (registerCount=1), which makes XenosRecomp emit a plain #define per
     register -- shader_recompiler.cpp's recompile() can only express real
     Xenos dynamic/relative constant addressing (`c[a0+N]`/`c[aL+N]`, used
@@ -100,7 +100,7 @@ def build_constant_table(float_regs, sampler_regs, bool_regs=(), is_pixel_shader
     are present and NOT in definition_table_regs -- still safe/indexed for
     every real run, just split at any excluded register.
     """
-    # Real fix (2026-08-17, follow-up): shader_recompiler.cpp's own
+    # shader_recompiler.cpp's own
     # `tailCount = (isPixelShader ? 224 : 256) - registerIndex` is baked
     # into the grouped macro it emits (`select((INDEX) < tailCount, ...,
     # 0.0)`) REGARDLESS of what registerCount this script declares -- so a
@@ -135,7 +135,7 @@ def build_constant_table(float_regs, sampler_regs, bool_regs=(), is_pixel_shader
             prev = reg
             continue
         if run_start is not None:
-            # Real fix: each run needs its OWN macro name -- XenosRecomp
+            # Each run needs its OWN macro name -- XenosRecomp
             # emits one `#define {name}(INDEX) ...` per ConstantInfo entry
             # processed, so two entries sharing a name would silently
             # redefine/collide instead of each covering its own real
@@ -210,7 +210,7 @@ def parse_definition_table_float_registers(data: bytes, dtbl_off: int, is_pixel_
     numbering) that this container's REAL definition table already gives a
     literal, hardcoded value to.
 
-    Real bug this exists to prevent (2026-08-16): XenosRecomp's own
+    Real bug this exists to prevent: XenosRecomp's own
     shader_recompiler.cpp (recompile(), ~line 1447) emits a LOCAL variable
     `float4 c<N> = asfloat(uint4(...))` for every register the definition
     table covers -- a real, distinct mechanism from the constant table this
@@ -313,8 +313,8 @@ def main() -> int:
             # ConstantRegisterMap's own documented semantics for this case.
             float_regs = list(range(256))
 
-        # Real fix (2026-08-16, see parse_definition_table_float_registers's
-        # own header comment): exclude any register the REAL definition
+        # See parse_definition_table_float_registers's own header
+        # comment: exclude any register the REAL definition
         # table already gives a literal value to -- adding it to the
         # synthesized constant table too creates a real `c<N>` macro/local-
         # variable naming collision, which fails DXC's compile and (since

--- a/tools/xenos_synthesize_constant_table.py
+++ b/tools/xenos_synthesize_constant_table.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""Patches real captured Xbox 360 shader containers (shader_dump.cpp output,
+shaders/<vs|ps>_<hash>.bin) that have constantTableOffset == 0 -- meaning the
+game's build stripped the D3DX9 constant-reflection table XenosRecomp needs
+(see XenosRecomp's own README: "Constant buffer registers are populated
+using reflection data embedded in the shader binaries. If this data is
+missing, the recompiler will not function.") -- by synthesizing a real,
+valid D3DXSHADER_CONSTANTTABLE-format blob from what our OWN ucode analysis
+(tools/ucode_analyze.cpp, using the same Shader::AnalyzeUcode the runtime
+pipeline cache already relies on) already knows about the shader: which
+float4 constant registers (c0-c255) it reads, and which sampler registers
+(s0-s31, from real texture_bindings()) it uses. XenosRecomp doesn't care
+about the constant NAMES (only registerSet/registerIndex/registerCount
+matter for the #defines it emits), so synthetic names ("c0", "s0", ...) are
+fine -- it never needs to match the game's real original names.
+
+Real D3DXSHADER_CONSTANTTABLE layout confirmed by reading XenosRecomp's own
+XenosRecomp/constant_table.h and XenosRecomp/shader_recompiler.cpp
+(recompile()) directly, not guessed:
+    ConstantTableContainer { uint32 size; ConstantTable constantTable; }
+    ConstantTable { uint32 size, creator, version, constants, constantInfo,
+                     flags, target; }
+    ConstantInfo { uint32 name; uint16 registerSet; uint16 registerIndex;
+                    uint16 registerCount; uint16 reserved; uint32 typeInfo;
+                    uint32 defaultValue; }
+All big-endian (be<T> in XenosRecomp's own headers, matching the real Xbox
+360 shader bytecode's own endianness). `constantTableOffset` (in
+ShaderContainer, at container-relative byte 16) points at the
+ConstantTableContainer; `constantTable.constantInfo`/`constantInfo->name`
+are offsets relative to the ConstantTable struct's OWN start (i.e.
+constantTableOffset + 4), not the container or file start -- confirmed via
+direct reading of shader_recompiler.cpp's recompile() pointer arithmetic.
+
+`typeInfo`/`defaultValue` are read by XenosRecomp for Float4/Sampler
+registerSets? -- confirmed NO (see recompile()'s Float4/Sampler cases: only
+name/registerIndex/registerCount are dereferenced) so they're left zeroed;
+real TypeInfo synthesis is unnecessary for this recompiler's actual needs.
+
+Usage:
+    xenos_synthesize_constant_table.py <ucode_analyze_binary> <shader_dir>
+        [<output_manifest>]
+
+Scans <shader_dir> for every *.bin whose real ShaderContainer header has
+constantTableOffset == 0, runs <ucode_analyze_binary> against the matching
+*.ucode file, and if the shader references NO float constants and NO
+samplers, leaves it alone (the missing table doesn't matter, matches this
+project's "16 ok shaders with ctbl_off==0" real finding). Otherwise,
+synthesizes a real constant table, appends it to the container's PHYSICAL
+section (extending physicalSize accordingly, matching how real XenosRecomp
+containers grow), and overwrites constantTableOffset in-place. Rewrites the
+.bin in place; a .orig backup is kept alongside it the first time only.
+"""
+
+import json
+import re
+import struct
+import subprocess
+import sys
+from pathlib import Path
+
+_CONTAINER_STRUCT = struct.Struct(">IIIIIIIII")  # flags,vsize,psize,fieldC,ctbl,dtbl,shader,f1c,f20
+_MAGIC_MASK = 0xFFFFFF00
+_MAGIC_VALUE = 0x102A1100
+
+_REGSET_BOOL = 0
+_REGSET_FLOAT4 = 2
+_REGSET_SAMPLER = 3
+
+
+def build_constant_table(float_regs, sampler_regs, bool_regs=(), is_pixel_shader=False,
+                          definition_table_regs=frozenset()):
+    """Returns real, big-endian D3DXSHADER_CONSTANTTABLE bytes (the whole
+    ConstantTableContainer, ready to append to a container's physical
+    section and point constantTableOffset at).
+
+    Real fix (2026-08-17): float4 registers used to get one ConstantInfo
+    EACH (registerCount=1), which makes XenosRecomp emit a plain #define per
+    register -- shader_recompiler.cpp's recompile() can only express real
+    Xenos dynamic/relative constant addressing (`c[a0+N]`/`c[aL+N]`, used
+    pervasively for skeletal-animation/skinning bone-matrix lookups) via the
+    safe, bounds-clamped INDEXED macro it emits for a registerCount > 1
+    entry (shader_recompiler.cpp:1205-1219) -- with registerCount always 1,
+    any shader doing dynamic addressing silently fell through to a
+    plain-name fallback that DROPS the +a0/+aL offset entirely (guarded
+    only by an assert() that compiles to nothing in a release build) and
+    always reads the same static register regardless of the real runtime
+    index. Confirmed real, structural bug -- a strong match for reported
+    shattered/scattered-looking animated geometry. Fixed by emitting ONE
+    grouped float4 entry spanning contiguous runs of registers, instead of
+    one per individually-referenced register, so XenosRecomp takes its own
+    safe indexed-macro path.
+
+    definition_table_regs must still be excluded (a real, already-fixed
+    crash: XenosRecomp emits a LOCAL VARIABLE `float4 c<N> = ...` for every
+    register a container's real DefinitionTable covers -- including one of
+    those registers in this constant table too would double-define it and
+    fail DXC's compile). A single contiguous registerIndex/registerCount
+    span can't "skip" specific registers, so this walks float_regs and
+    emits one grouped entry per maximal contiguous run of registers that
+    are present and NOT in definition_table_regs -- still safe/indexed for
+    every real run, just split at any excluded register.
+    """
+    # Real fix (2026-08-17, follow-up): shader_recompiler.cpp's own
+    # `tailCount = (isPixelShader ? 224 : 256) - registerIndex` is baked
+    # into the grouped macro it emits (`select((INDEX) < tailCount, ...,
+    # 0.0)`) REGARDLESS of what registerCount this script declares -- so a
+    # grouped entry covering a pixel-shader register >= 224 wouldn't fail to
+    # compile, it would silently ALWAYS return 0.0 for that register (even
+    # for a plain static reference, not just a dynamic one), since the
+    # clamp is unconditional. 224 also matches this hardware's real,
+    # documented pixel-shader float-constant register-file size (vertex
+    # shaders get 256) -- so registers at/above it are a real edge case, not
+    # something to force into the grouped/safe scheme. Route those through
+    # the ORIGINAL, proven-correct per-register #define scheme instead
+    # (registerCount=1, no dynamic-addressing support, but also no incorrect
+    # zero-clamp) -- confirmed real regression this fixes: a heuristic-
+    # captured pixel shader statically referencing register 255 previously
+    # got excluded from BOTH schemes entirely (capped out of the grouped
+    # range with no per-register fallback), causing XenosRecomp to fall
+    # through to its "not found in float4Constants" path
+    # (shader_recompiler.cpp:483-487) and emit a bare, never-#define'd
+    # `c255` identifier -- a real DXC "undeclared identifier" compile
+    # failure that didn't exist before this constant-table rework.
+    max_float4_registers = 224 if is_pixel_shader else 256
+    entries = []
+    grouped = sorted(r for r in float_regs
+                      if r not in definition_table_regs and r < max_float4_registers)
+    for r in sorted(float_regs):
+        if r not in definition_table_regs and r >= max_float4_registers:
+            entries.append((f"c{r}", _REGSET_FLOAT4, r, 1))
+    run_start = None
+    prev = None
+    for reg in grouped + [None]:  # sentinel to flush the final run
+        if reg is not None and prev is not None and reg == prev + 1:
+            prev = reg
+            continue
+        if run_start is not None:
+            # Real fix: each run needs its OWN macro name -- XenosRecomp
+            # emits one `#define {name}(INDEX) ...` per ConstantInfo entry
+            # processed, so two entries sharing a name would silently
+            # redefine/collide instead of each covering its own real
+            # register range.
+            entries.append((f"c{run_start}", _REGSET_FLOAT4, run_start, prev - run_start + 1))
+        run_start = reg
+        prev = reg
+    for reg in sampler_regs:
+        entries.append((f"s{reg}", _REGSET_SAMPLER, reg, 1))
+    for reg in bool_regs:
+        entries.append((f"b{reg}", _REGSET_BOOL, reg, 1))
+
+    # Layout (relative to constantTable's own start, i.e. right after the
+    # ConstantTableContainer.size field):
+    #   ConstantTable header (28 bytes: size,creator,version,constants,
+    #     constantInfo,flags,target)
+    #   ConstantInfo[len(entries)] (20 bytes each)
+    #   name strings, back to back, NUL-terminated
+    CONSTANT_TABLE_HEADER_SIZE = 28
+    CONSTANT_INFO_SIZE = 20
+    constant_info_offset = CONSTANT_TABLE_HEADER_SIZE
+    names_offset = constant_info_offset + len(entries) * CONSTANT_INFO_SIZE
+
+    name_bytes = b""
+    name_offsets = []
+    for name, _, _, _ in entries:
+        name_offsets.append(names_offset + len(name_bytes))
+        name_bytes += name.encode("ascii") + b"\x00"
+
+    constant_table_size = names_offset + len(name_bytes)
+
+    out = bytearray()
+    # ConstantTableContainer.size (whole container size incl. this field)
+    out += struct.pack(">I", 4 + constant_table_size)
+    # ConstantTable: size, creator, version, constants, constantInfo, flags, target
+    out += struct.pack(">IIIIIII", constant_table_size, 0, 0, len(entries),
+                        constant_info_offset, 0, 0)
+    assert len(out) == 4 + CONSTANT_TABLE_HEADER_SIZE
+    for i, (name, regset, regidx, regcount) in enumerate(entries):
+        out += struct.pack(">IHHHHII", name_offsets[i], regset, regidx, regcount,
+                            0, 0, 0)
+    assert len(out) == 4 + names_offset
+    out += name_bytes
+    assert len(out) == 4 + constant_table_size
+    return bytes(out)
+
+
+def patch_container(data: bytes, table_bytes: bytes) -> bytes:
+    flags, vsize, psize, fieldc, ctbl_off, dtbl_off, shader_off, f1c, f20 = \
+        _CONTAINER_STRUCT.unpack_from(data, 0)
+    assert ctbl_off == 0, "container already has a constant table -- refusing to overwrite"
+
+    # Real containers place the constant table inside the PHYSICAL section
+    # (appended after virtualSize bytes) -- mirror that by appending the
+    # synthesized table right after the existing physical section and
+    # growing physicalSize/constantTableOffset accordingly. The offset is
+    # relative to the container start (shaderData in recompile()'s own
+    # pointer arithmetic), so it's simply the container's current total size.
+    new_ctbl_off = len(data)
+    new_psize = psize + len(table_bytes)
+    new_header = _CONTAINER_STRUCT.pack(flags, vsize, new_psize, fieldc,
+                                         new_ctbl_off, dtbl_off, shader_off, f1c, f20)
+    return new_header + data[36:] + table_bytes
+
+
+_DEFINITION_TABLE_HEADER = struct.Struct(">IIIII")  # field0,field4,field8,fieldC,size
+
+
+def parse_definition_table_float_registers(data: bytes, dtbl_off: int, is_pixel_shader: bool) -> set[int]:
+    """Returns the set of unified float4 register indices (c0-c511, pixel
+    shader registers already offset by +256 to match ucode_analyze's own
+    numbering) that this container's REAL definition table already gives a
+    literal, hardcoded value to.
+
+    Real bug this exists to prevent (2026-08-16): XenosRecomp's own
+    shader_recompiler.cpp (recompile(), ~line 1447) emits a LOCAL variable
+    `float4 c<N> = asfloat(uint4(...))` for every register the definition
+    table covers -- a real, distinct mechanism from the constant table this
+    script builds (RegisterSet::Float4 emits a `vk::RawBufferLoad<float4>`
+    MACRO named `c<N>` instead). If the SAME register N appears in both,
+    the generated HLSL has two conflicting `c<N>` definitions (one local
+    var, one macro) and DXC's compile fails outright -- confirmed via a
+    real crash: ps_09d00ca638df4271 has a real captured definitionTable
+    entry for register 255 (a real game-authored default constant), and
+    this script was ALSO adding register 255 to the synthesized constant
+    table (register 255 is genuinely read by the shader per ucode_analyze,
+    but ucode_analyze has no way to know it's ALREADY supplied by the
+    definition table, not something that needs runtime supply) --
+    `#define c255 vk::RawBufferLoad<...>` then collided with the literal
+    `float4 c255 = ...` XenosRecomp itself emits, and XenosRecomp's own
+    zero error-handling on a failed DXC compile turned that into a real,
+    silent SIGSEGV (main.cpp:139 dereferences a null IDxcBlob*).
+
+    Mirrors shader_recompiler.cpp's real parse exactly: DefinitionTable's
+    `definitions` field is a be<uint32_t> stream, read as repeating
+    (Float4Definition{registerIndex:u16, count:u16, physicalOffset:u32},
+    i.e. 8 bytes / 2 uint32s per entry) until a 0 terminator, then a
+    SEPARATE Int4Definition stream follows (irrelevant here -- those are
+    integer registers, a disjoint numbering space, never collide with
+    float4 c<N> macros)."""
+    if dtbl_off == 0:
+        return set()
+    header_end = dtbl_off + _DEFINITION_TABLE_HEADER.size
+    if header_end > len(data):
+        return set()
+    registers: set[int] = set()
+    offset = header_end
+    register_offset = 256 if is_pixel_shader else 0
+    while offset + 8 <= len(data):
+        (word0,) = struct.unpack_from(">I", data, offset)
+        if word0 == 0:
+            break
+        register_index, count = struct.unpack_from(">HH", data, offset)
+        for i in range((count + 3) // 4):
+            registers.add(register_index + i - register_offset)
+        offset += 8
+    return registers
+
+
+def run_ucode_analyze(binary: Path, kind: str, ucode_path: Path) -> dict:
+    proc = subprocess.run([str(binary), kind, str(ucode_path)],
+                           capture_output=True, timeout=30)
+    if proc.returncode != 0:
+        raise RuntimeError(f"ucode_analyze failed for {ucode_path}: {proc.stderr.decode(errors='replace')}")
+    return json.loads(proc.stdout)
+
+
+def main() -> int:
+    if len(sys.argv) < 3:
+        print(__doc__)
+        return 1
+
+    analyze_bin = Path(sys.argv[1])
+    shader_dir = Path(sys.argv[2])
+    manifest_path = Path(sys.argv[3]) if len(sys.argv) > 3 else None
+
+    results = []  # (tag, action)
+    for bin_path in sorted(shader_dir.glob("*.bin")):
+        tag = bin_path.stem
+        data = bin_path.read_bytes()
+        if len(data) < 36:
+            results.append((tag, "too-small"))
+            continue
+        flags, vsize, psize, fieldc, ctbl_off, dtbl_off, shader_off, f1c, f20 = \
+            _CONTAINER_STRUCT.unpack_from(data, 0)
+        if (flags & _MAGIC_MASK) != _MAGIC_VALUE:
+            results.append((tag, "not-a-container"))
+            continue
+        if ctbl_off != 0:
+            results.append((tag, "already-has-table"))
+            continue
+
+        ucode_path = bin_path.with_suffix(".ucode")
+        if not ucode_path.exists():
+            results.append((tag, "no-ucode-file"))
+            continue
+
+        kind = "vs" if tag.startswith("vs_") else ("ps" if tag.startswith("ps_") else None)
+        if kind is None:
+            results.append((tag, "unknown-kind"))
+            continue
+
+        try:
+            info = run_ucode_analyze(analyze_bin, kind, ucode_path)
+        except Exception as e:
+            results.append((tag, f"analyze-failed:{e}"))
+            continue
+
+        float_regs = info.get("float_constants", [])
+        sampler_regs = sorted({tb["fetch_constant"] for tb in info.get("texture_bindings", [])})
+        bool_regs = info.get("bool_constants", [])
+
+        if info.get("float_dynamic_addressing"):
+            # All 256 registers must be assumed live -- matches
+            # ConstantRegisterMap's own documented semantics for this case.
+            float_regs = list(range(256))
+
+        # Real fix (2026-08-16, see parse_definition_table_float_registers's
+        # own header comment): exclude any register the REAL definition
+        # table already gives a literal value to -- adding it to the
+        # synthesized constant table too creates a real `c<N>` macro/local-
+        # variable naming collision, which fails DXC's compile and (since
+        # XenosRecomp has zero error handling for a failed compile) crashes
+        # XenosRecomp outright.
+        definition_table_regs = parse_definition_table_float_registers(data, dtbl_off, kind == "ps")
+        float_regs = [r for r in float_regs if r not in definition_table_regs]
+
+        if not float_regs and not sampler_regs and not bool_regs:
+            results.append((tag, "no-constants-needed"))
+            continue
+
+        table_bytes = build_constant_table(float_regs, sampler_regs, bool_regs, is_pixel_shader=(kind == "ps"))
+        patched = patch_container(data, table_bytes)
+
+        backup_path = bin_path.with_suffix(".bin.orig")
+        if not backup_path.exists():
+            backup_path.write_bytes(data)
+        bin_path.write_bytes(patched)
+        results.append((tag, f"patched:{len(float_regs)}floats,{len(sampler_regs)}samplers"))
+
+    patched_count = sum(1 for _, a in results if a.startswith("patched"))
+    print(f"xenos_synthesize_constant_table: {patched_count}/{len(results)} shaders patched")
+
+    if manifest_path is not None:
+        with manifest_path.open("w") as f:
+            for tag, action in results:
+                f.write(f"{tag} {action}\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- **NativeVK** — custom Vulkan renderer, in-progress. Not functional yet: still
  depends on rexglue-sdk's rendering pipeline, being fully detached from it in a
  future rewrite. Treat as scaffolding, not a working feature.
- **Debug Panel** — one F5 window (Performance / A-B Benchmark / Native Shaders tabs)
- **Linux Support** — https://github.com/masterspike52/reNut/pull/39
- **Shader tooling** — captures guest shader microcode, batch-converts via
  XenosRecomp. Builds/runs standalone.
- **Bug fix** — `sleep.h` called an undefined macro (`PPC_HOOK`), didn't compile
  as shipped. Fixed to `REX_HOOK`.
- **`docs/ai/`** — entry-point docs for contributors picking this up.

No existing content replaced — shared files extended, not overwritten.
`mullhwucrash.cpp` untouched (byte-identical to `Renderer`/`main`).

## Not ready

- NativeVK doesn't activate on a normal build and is experimental even once it
  does (known visual corruption on some shaders).
- Debug panel is Linux-only for now (`dlopen`/`dlsym`, no Windows path yet).
