### PR TITLE
Linux support: audio backend/UAF fix, XDG paths, POSIX file access, p…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,14 @@ set(RENUT_SOURCES
 
 )
 
+if(UNIX AND NOT APPLE)
+    list(APPEND RENUT_SOURCES
+        src/renut_engine/linuxfixes/audio_client_guard.cpp
+        src/renut_engine/linuxfixes/audio_backend.cpp
+        src/renut_engine/linuxfixes/posix_file_access.cpp
+    )
+endif()
+
 if(WIN32)
 list(APPEND RENUT_SOURCES icon/app.rc)
     add_executable(renut WIN32 ${RENUT_SOURCES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,3 +45,28 @@ else()
 endif()
 
 rexglue_setup_target(renut)
+
+if(UNIX AND NOT APPLE)
+    # src/renut_engine/linuxfixes/posix_file_access.cpp redefines
+    # rex::filesystem::FileHandle::OpenExisting to fix the broken O_RDONLY/
+    # O_WRONLY/O_RDWR bitwise-OR in the SDK's POSIX backend. Every caller lives
+    # inside librexruntimerd.so, so our definition only wins if it is in renut's
+    # dynamic symbol table -- the executable is searched first when the library's
+    # PLT entry is resolved. Export just that one symbol rather than using
+    # -rdynamic, which would export everything.
+    #
+    # If a toolchain change ever alters this mangled name, the override silently
+    # stops applying, so the build checks for it below.
+    set(RENUT_OPENEXISTING_SYMBOL
+        "_ZN3rex10filesystem10FileHandle12OpenExistingERKNSt10filesystem7__cxx114pathEjb")
+    target_link_options(renut PRIVATE
+        "-Wl,--export-dynamic-symbol=${RENUT_OPENEXISTING_SYMBOL}")
+
+    # Fail loudly if the symbol did not make it into .dynsym.
+    add_custom_command(TARGET renut POST_BUILD
+        COMMAND ${CMAKE_COMMAND}
+                -DRENUT_BINARY=$<TARGET_FILE:renut>
+                -DRENUT_SYMBOL=${RENUT_OPENEXISTING_SYMBOL}
+                -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/check_exported_symbol.cmake
+        VERBATIM)
+endif()

--- a/cmake/check_exported_symbol.cmake
+++ b/cmake/check_exported_symbol.cmake
@@ -1,0 +1,36 @@
+# Verifies that a symbol reached the built binary's dynamic symbol table.
+#
+# Used for the rex::filesystem::FileHandle::OpenExisting override in
+# src/renut_engine/linuxfixes/posix_file_access.cpp: that fix only takes effect
+# if the symbol is exported, and a silent failure would quietly bring back the
+# save-data corruption. Better to break the build than to ship a no-op fix.
+
+find_program(RENUT_NM NAMES nm llvm-nm)
+if(NOT RENUT_NM)
+    message(WARNING "nm not found - skipping exported symbol check for ${RENUT_SYMBOL}")
+    return()
+endif()
+
+execute_process(
+    COMMAND ${RENUT_NM} -D --defined-only ${RENUT_BINARY}
+    OUTPUT_VARIABLE nm_output
+    ERROR_VARIABLE nm_error
+    RESULT_VARIABLE nm_result)
+
+if(NOT nm_result EQUAL 0)
+    message(WARNING "nm failed on ${RENUT_BINARY}: ${nm_error}")
+    return()
+endif()
+
+if(NOT nm_output MATCHES "${RENUT_SYMBOL}")
+    message(FATAL_ERROR
+        "${RENUT_SYMBOL} is missing from the dynamic symbol table of ${RENUT_BINARY}.\n"
+        "The FileHandle::OpenExisting override in "
+        "src/renut_engine/linuxfixes/posix_file_access.cpp will NOT take effect, "
+        "and save data will be corrupted again.\n"
+        "The mangled name has most likely changed - re-derive it with:\n"
+        "  nm -D --defined-only <path to librexruntimerd.so> | grep FileHandle12OpenExisting\n"
+        "and update RENUT_OPENEXISTING_SYMBOL in CMakeLists.txt.")
+endif()
+
+message(STATUS "Verified exported override symbol: ${RENUT_SYMBOL}")

--- a/packaging/AppRun
+++ b/packaging/AppRun
@@ -1,0 +1,182 @@
+#!/bin/sh
+# reNut AppImage entrypoint.
+#
+# Two jobs before handing off to the binary:
+#   1. First-run game data setup -- offer to extract a disc image the user owns
+#      into ~/.local/share/renut/game and write the path config the runtime
+#      reads. Entirely optional: declining or cancelling just launches renut,
+#      whose built-in path wizard covers the same ground.
+#   2. Supply a default GPU plugin, since the cvar defaults to empty.
+#
+# POSIX sh only -- /bin/sh is dash on Debian/Ubuntu.
+
+set -u
+
+HERE="$(dirname "$(readlink -f "$0")")"
+BIN="$HERE/usr/bin/renut"
+XISO="$HERE/usr/bin/extract-xiso"
+
+CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/renut"
+# Written by PathConfigStore (src/renut_engine/path_config_store.h). Distinct
+# from renut.toml, which holds cvars.
+PATHS_CFG="$CONFIG_DIR/renut.cfg"
+CVAR_CFG="$CONFIG_DIR/renut.toml"
+DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/renut"
+
+# ---------------------------------------------------------------- dialogs --
+# zenity on GNOME-ish systems, kdialog on KDE. With neither, every helper below
+# reports failure and the whole first-run block is skipped in favour of the
+# in-app wizard.
+DIALOG=""
+if command -v zenity >/dev/null 2>&1; then
+    DIALOG=zenity
+elif command -v kdialog >/dev/null 2>&1; then
+    DIALOG=kdialog
+fi
+
+ask_yes_no() {
+    case "$DIALOG" in
+        zenity)  zenity --question --title="reNut" --width=420 --text="$1" ;;
+        kdialog) kdialog --title "reNut" --yesno "$1" ;;
+        *)       return 1 ;;
+    esac
+}
+
+show_error() {
+    case "$DIALOG" in
+        zenity)  zenity --error --title="reNut" --width=420 --text="$1" ;;
+        kdialog) kdialog --title "reNut" --error "$1" ;;
+        *)       printf 'reNut: %s\n' "$1" >&2 ;;
+    esac
+}
+
+pick_iso() {
+    case "$DIALOG" in
+        zenity)  zenity --file-selection --title="Select your game disc image" \
+                        --file-filter="Disc images | *.iso *.ISO" \
+                        --file-filter="All files | *" ;;
+        kdialog) kdialog --title "Select your game disc image" \
+                         --getopenfilename "$HOME" "*.iso *.ISO|Disc images" ;;
+        *)       return 1 ;;
+    esac
+}
+
+# Runs "$@", showing an indeterminate progress dialog while it works. The exit
+# status is the command's, not the dialog's, so callers can tell what happened.
+run_with_progress() {
+    _label="$1"; shift
+    case "$DIALOG" in
+        zenity)
+            "$@" 2>/dev/null | zenity --progress --title="reNut" --pulsate \
+                --auto-close --no-cancel --width=420 --text="$_label" 2>/dev/null
+            ;;
+        *)
+            printf 'reNut: %s\n' "$_label"
+            "$@"
+            ;;
+    esac
+}
+
+# ------------------------------------------------------- game data present --
+# True when the config names a game_data_root that still exists. A config
+# pointing at a deleted or unplugged directory counts as absent, so the user
+# gets offered setup again rather than a confusing runtime failure.
+have_game_data() {
+    [ -f "$PATHS_CFG" ] || return 1
+    _root=$(sed -n \
+        's/^[[:space:]]*game_data_root[[:space:]]*=[[:space:]]*"\(.*\)"[[:space:]]*$/\1/p' \
+        "$PATHS_CFG" | head -n 1)
+    [ -n "$_root" ] && [ -d "$_root" ]
+}
+
+# ------------------------------------------------------------- extraction --
+# extract-xiso lays the disc root out either directly in the target directory or
+# one level down, depending on version and image layout. Rather than guess, find
+# the directory that actually holds default.xex.
+find_game_root() {
+    _stage="$1"
+    _xex=$(find "$_stage" -maxdepth 3 -iname 'default.xex' -type f 2>/dev/null | head -n 1)
+    [ -n "$_xex" ] || return 1
+    dirname "$_xex"
+}
+
+extract_iso() {
+    _iso="$1"
+    _stage="$DATA_DIR/.extract-staging"
+
+    rm -rf "$_stage"
+    if ! mkdir -p "$_stage"; then
+        show_error "Could not create $_stage."
+        return 1
+    fi
+
+    # -x extract, -d target directory.
+    if ! run_with_progress "Extracting game files. This can take several minutes." \
+            "$XISO" -x -d "$_stage" "$_iso"; then
+        rm -rf "$_stage"
+        show_error "extract-xiso could not read that image.
+
+Xbox 360 discs come in several layouts and not every dump is supported. If this
+image is a redump-style ISO it should work; trimmed or compressed formats (CCI,
+GOD, ZAR) need converting to a plain ISO first."
+        return 1
+    fi
+
+    _root=$(find_game_root "$_stage")
+    if [ -z "$_root" ]; then
+        rm -rf "$_stage"
+        show_error "Extraction finished but no default.xex was found.
+
+That usually means the image is not the right game, or it is an Xbox (original)
+disc rather than an Xbox 360 one."
+        return 1
+    fi
+
+    rm -rf "$DATA_DIR/game"
+    mkdir -p "$DATA_DIR"
+    if ! mv "$_root" "$DATA_DIR/game"; then
+        rm -rf "$_stage"
+        show_error "Could not move the extracted files into $DATA_DIR/game."
+        return 1
+    fi
+    rm -rf "$_stage"
+
+    mkdir -p "$DATA_DIR/user" "$CONFIG_DIR"
+    # Matches PathConfigStore::Save's format so the runtime and the in-app
+    # wizard both read it back.
+    {
+        printf '# renut path configuration\n'
+        printf 'game_data_root   = "%s"\n' "$DATA_DIR/game"
+        printf 'user_data_root   = "%s"\n' "$DATA_DIR/user"
+        printf 'update_data_root = ""\n'
+    } > "$PATHS_CFG"
+
+    return 0
+}
+
+# --------------------------------------------------------------- first run --
+# Skipped silently when extract-xiso was not bundled or no dialog tool exists;
+# the in-app wizard is always there as the fallback.
+if ! have_game_data && [ -x "$XISO" ] && [ -n "$DIALOG" ]; then
+    if ask_yes_no "reNut needs the files from your game disc.
+
+Extract them from a disc image now? You will need an ISO of a game you own.
+
+Choosing No opens reNut's own path setup instead."; then
+        iso=$(pick_iso) || iso=""
+        if [ -n "$iso" ]; then
+            extract_iso "$iso" || true
+        fi
+    fi
+fi
+
+# ----------------------------------------------------------------- launch --
+# The gpu_plugin cvar defaults to empty, which loads no renderer at all. Supply
+# xenos on a first run, but never override an explicit flag or a saved config.
+case " $* " in
+    *" --gpu_plugin"*) exec "$BIN" "$@" ;;
+esac
+if [ -f "$CVAR_CFG" ]; then
+    exec "$BIN" "$@"
+fi
+exec "$BIN" --gpu_plugin=xenos "$@"

--- a/packaging/container/Dockerfile
+++ b/packaging/container/Dockerfile
@@ -1,0 +1,153 @@
+# Build image for a low-glibc-floor reNut, with the rexglue SDK baked in.
+#
+# The problem this solves: an AppImage bundles libraries but not libc, so the
+# binary inherits whatever glibc the build host has. Building on CachyOS
+# (glibc 2.43) yields an AppImage that runs only on CachyOS-era distros. None of
+# the >2.28 symbols are features the source asks for -- pthread_rwlock_*@2.34 is
+# the libpthread/libc merge, __isoc23_strtoul@2.38 is the C23 strtol family,
+# sqrtf@2.43 is the errno-setting variant, strlcat@2.38 is feature-detected by
+# SDL -- so they all resolve downward on their own once the build simply happens
+# against an older glibc. No source changes are required.
+#
+# The catch is that an old distro also means an old libstdc++, and this is a
+# C++23 codebase. Hence the split: glibc comes from the old base image, while
+# the C++ toolchain is layered on top at a modern version. clang++ takes its
+# libstdc++ headers from the highest GCC installation it finds, so g++-13
+# supplies <expected>/<print>/etc. while libc stays back at the base version.
+# packaging/make-appimage.sh then bundles *this image's* libstdc++, so the
+# player's machine never needs a matching one.
+#
+# The SDK is compiled in stage two and copied into the final image, so building
+# reNut against it costs nothing -- pull or load the image and the SDK is
+# already there. Only bumping SDK_REF requires paying for that stage again.
+#
+# Default base is Ubuntu 22.04 (glibc 2.35). Override to go lower, e.g.
+#   --build-arg BASE=ubuntu:20.04 --build-arg CODENAME=focal \
+#   --build-arg PYTHON_VENV=python3.8-venv        (glibc 2.31)
+# The further back you go, the likelier apt.llvm.org or the toolchain PPA has
+# stopped publishing for that release -- check before assuming a failure is ours.
+
+# ---------------------------------------------------------------- toolchain --
+ARG BASE=ubuntu:22.04
+FROM ${BASE} AS toolchain
+
+ARG LLVM_VERSION=20
+ARG GCC_VERSION=13
+# Distro codename, used for the apt.llvm.org, Kitware and LunarG repo URLs.
+ARG CODENAME=jammy
+# The SDK build wants a venv module: python3.10 on jammy, python3.8 on focal.
+ARG PYTHON_VENV=python3.10-venv
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      wget gnupg lsb-release ca-certificates software-properties-common \
+ && rm -rf /var/lib/apt/lists/*
+
+# CMake, from Kitware. The distro package is too old -- reNut's CMakeLists.txt
+# requires 3.25 and jammy ships 3.22.
+RUN wget -qO- https://apt.kitware.com/keys/kitware-archive-latest.asc \
+      | gpg --dearmor -o /etc/apt/trusted.gpg.d/kitware.gpg \
+ && echo "deb https://apt.kitware.com/ubuntu/ ${CODENAME} main" \
+      > /etc/apt/sources.list.d/kitware.list
+
+# clang, via the same llvm.sh flow as .github/workflows/_build-platform.yaml.
+RUN wget -qO /tmp/llvm.sh https://apt.llvm.org/llvm.sh \
+ && chmod +x /tmp/llvm.sh \
+ && /tmp/llvm.sh ${LLVM_VERSION} \
+ && apt-get install -y --no-install-recommends \
+      clang-${LLVM_VERSION} lld-${LLVM_VERSION} \
+ && update-alternatives --install /usr/bin/clang   clang   /usr/bin/clang-${LLVM_VERSION}   200 \
+ && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${LLVM_VERSION} 200 \
+ && rm -rf /var/lib/apt/lists/* /tmp/llvm.sh
+
+# A C++23-capable libstdc++ on top of the old glibc.
+RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends g++-${GCC_VERSION} \
+ && rm -rf /var/lib/apt/lists/*
+
+# Vulkan SDK, from LunarG.
+RUN wget -qO- https://packages.lunarg.com/lunarg-signing-key-pub.asc \
+      | tee /etc/apt/trusted.gpg.d/lunarg.asc >/dev/null \
+ && wget -qO /etc/apt/sources.list.d/lunarg-vulkan-${CODENAME}.list \
+      http://packages.lunarg.com/vulkan/lunarg-vulkan-${CODENAME}.list \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends vulkan-sdk \
+ && rm -rf /var/lib/apt/lists/*
+
+# Build dependencies, mirroring the CI workflow's list, plus imagemagick and
+# file for packaging/make-appimage.sh.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      cmake ninja-build build-essential git curl unzip zip autoconf ${PYTHON_VENV} \
+      libgtk-3-dev libx11-xcb-dev libxss-dev \
+      libasound2-dev libpulse-dev libpipewire-0.3-dev \
+      imagemagick file desktop-file-utils \
+ && rm -rf /var/lib/apt/lists/*
+
+ENV CC=clang CXX=clang++
+
+# -------------------------------------------------------------------- sdk ----
+# Expensive and cached: this layer only reruns when SDK_REF changes.
+FROM toolchain AS sdk
+
+ARG SDK_REPO=https://github.com/rexglue/rexglue-sdk.git
+ARG SDK_REF=nightly-20260809-f5c85215
+
+RUN git clone --recursive --depth 1 --branch ${SDK_REF} ${SDK_REPO} /tmp/rexglue-sdk \
+ && cd /tmp/rexglue-sdk \
+ && cmake --preset linux-amd64 \
+ && cmake --build --preset linux-amd64-relwithdebinfo --target install --parallel \
+ && mkdir -p /opt \
+ && mv out/install/linux-amd64 /opt/rexglue-sdk \
+ && rm -rf /tmp/rexglue-sdk
+
+# ----------------------------------------------------------- extract-xiso ----
+# Bundled into the AppImage so the first-run flow in packaging/AppRun can pull
+# game data out of a disc image without the user installing anything.
+#
+# This fork rather than XboxDev/extract-xiso: upstream targets original Xbox
+# XISO images and documents no XGD2/XGD3 support, where 360 discs put the
+# XDVDFS header at a different offset. This one carries somsky's XGD3 patches.
+FROM toolchain AS extract-xiso
+
+ARG XISO_REPO=https://github.com/rikyperdana/extract-xiso.git
+ARG XISO_REF=master
+
+# The repo ships a prebuilt binary and that is what we use. Building from source
+# here fails anyway -- the bundled libftp is compiled without -fPIE while
+# Ubuntu's gcc defaults to PIE, so the link dies on an R_X86_64_32 relocation.
+RUN git clone --depth 1 --branch ${XISO_REF} ${XISO_REPO} /tmp/extract-xiso \
+ && install -Dm755 /tmp/extract-xiso/extract-xiso /opt/extract-xiso/extract-xiso \
+ && rm -rf /tmp/extract-xiso
+
+# A prebuilt binary carries whatever glibc it was linked against, so check it
+# against this image rather than trusting it. Today it needs only 2.15, well
+# under any base we would pick, but a future update to the fork could silently
+# raise the AppImage's floor and undo the point of this whole image.
+#
+# Kept as its own RUN, and written with if/exit rather than a && || chain, so a
+# failure stops the build here instead of surfacing as a confusing COPY error in
+# the final stage.
+RUN need=$(objdump -T /opt/extract-xiso/extract-xiso \
+             | grep -oE 'GLIBC_[0-9.]+' | sed 's/GLIBC_//' | sort -V | tail -n 1); \
+    have=$(ldd --version | head -n 1 | grep -oE '[0-9]+\.[0-9]+$'); \
+    if [ "$(printf '%s\n%s\n' "$need" "$have" | sort -V | tail -n 1)" != "$have" ]; then \
+        echo "error: extract-xiso needs glibc $need, image provides $have" >&2; \
+        exit 1; \
+    fi; \
+    echo "extract-xiso ok: needs glibc $need, image provides $have"
+
+# ------------------------------------------------------------------ final ----
+FROM toolchain AS final
+
+# The built SDK only, without the source tree or object files behind it.
+COPY --from=sdk /opt/rexglue-sdk /opt/rexglue-sdk
+COPY --from=extract-xiso /opt/extract-xiso /opt/extract-xiso
+
+# Where reNut's generated/rexglue.cmake find_package() call will look.
+ENV CMAKE_PREFIX_PATH=/opt/rexglue-sdk
+# appimagetool is itself an AppImage and there is no FUSE in here.
+ENV APPIMAGE_EXTRACT_AND_RUN=1
+
+WORKDIR /src/reNut

--- a/packaging/container/README.md
+++ b/packaging/container/README.md
@@ -1,0 +1,105 @@
+# Low-glibc build container
+
+Builds reNut against an old glibc so the AppImage runs on distros other than
+bleeding-edge ones. The rexglue SDK is compiled **into the image**, so building
+reNut against it is cheap and nobody has to build the SDK themselves.
+
+## Why this exists
+
+An AppImage bundles libraries but not libc, so the binary inherits whatever
+glibc the build host has. Built on CachyOS (glibc 2.43), the result runs on
+almost nothing else.
+
+There were two separate floors, and they move independently:
+
+| Floor | Cause | Fix |
+| --- | --- | --- |
+| `GLIBC_2.43` | build host's libc | this container |
+| `GLIBCXX_3.4.35` | build host's libstdc++ headers | bundled by `make-appimage.sh` |
+
+The second one is easy to miss and was in practice the stricter of the two:
+`librexruntimerd.so` called the C++20 atomic-wait symbols behind
+`std::atomic::wait`/`latch`/`barrier`, which only a GCC 15-or-newer libstdc++
+exports. Ubuntu 24.04 and Debian 13 have new enough glibc but too old a
+libstdc++, so they failed regardless of the glibc number.
+`packaging/make-appimage.sh` now stages `libstdc++.so.6` and `libgcc_s.so.1`
+next to the binary unconditionally, which removes that floor everywhere —
+including on host builds that never touch this container.
+
+None of the glibc symbols above 2.28 are features the source actually asks for.
+`pthread_rwlock_*@2.34` is the libpthread/libc merge, `__isoc23_strtoul@2.38` is
+the C23 strtol family, `sqrtf@2.43` is the errno-setting variant, and
+`strlcat@2.38` is feature-detected by SDL. They are all chosen by the build
+host, which is why building against an older glibc fixes them with no source
+changes — and why the `polyfill-glibc` symbol rewriting in `make-appimage.sh`
+was only ever treating symptoms.
+
+## Usage
+
+```sh
+packaging/container/build.sh image      # once: toolchain + SDK (slow)
+packaging/container/build.sh all        # per change: build + package (fast)
+```
+
+Output lands in `dist/reNut-x86_64.AppImage`. The container builds into
+`out/container/` rather than `out/`, so it will not fight with a host build over
+the same CMake cache.
+
+Packaging runs *inside* the container deliberately. `make-appimage.sh` bundles
+whichever libstdc++ `$CXX` points at, so running that step on the host would
+re-import the host's newer libstdc++ and undo the exercise.
+
+## Sharing the image
+
+Contributors should never build the SDK. Publish the image once and have them
+pull it:
+
+```sh
+docker tag renut-build:jammy ghcr.io/<owner>/renut-build:jammy
+docker push ghcr.io/<owner>/renut-build:jammy
+```
+
+```sh
+RENUT_IMAGE=ghcr.io/<owner>/renut-build:jammy packaging/container/build.sh all
+```
+
+Or, without a registry: `docker save renut-build:jammy | zstd > renut-build.tar.zst`
+and `zstd -d < renut-build.tar.zst | docker load`.
+
+Rebuild the image only when `SDK_REF` changes — that is the one argument that
+invalidates the expensive layer.
+
+## Choosing the floor
+
+Default is Ubuntu 22.04, giving **glibc 2.35**: Ubuntu 22.04+, Debian 12+,
+Fedora 36+, and current SteamOS. To go lower:
+
+```sh
+BASE=ubuntu:20.04 CODENAME=focal PYTHON_VENV=python3.8-venv \
+  RENUT_IMAGE=renut-build:focal packaging/container/build.sh image
+```
+
+That targets glibc 2.31 and covers essentially every distro still receiving
+updates. The tradeoff is that the further back you go, the likelier
+`apt.llvm.org` or the `ubuntu-toolchain-r` PPA has stopped publishing for that
+release — check that before assuming a failure is ours.
+
+One confusing detail if you go looking: the bundled `libstdc++.so.6` reports
+`GLIBCXX_3.4.35`, which is *not* evidence that a newer host libstdc++ leaked in.
+Installing `g++-13` also pulls the toolchain PPA's libstdc++6 runtime, which is
+built from a newer GCC but still against the base image's glibc. Compiled code
+needs 3.4.32 (GCC 13's headers) and the bundled runtime provides 3.4.35, so it
+is satisfied. The reliable provenance check is the *glibc* requirement of the
+bundled library — 2.34 from the container, versus 2.38 from a CachyOS host.
+
+Verify what you actually produced:
+
+```sh
+objdump -T out/container/build/linux-amd64-relwithdebinfo/renut \
+  | grep -oE 'GLIBC_[0-9.]+' | sort -uV | tail -1
+```
+
+## Unrelated floor worth knowing
+
+The SDK presets set `-march=x86-64-v2`, which is a *CPU* requirement (roughly
+Nehalem and newer), not a distro one. Nothing here changes it.

--- a/packaging/container/build.sh
+++ b/packaging/container/build.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+#
+# Builds reNut against an old glibc inside Docker and packages the AppImage.
+#
+# The SDK is already compiled inside the image (see Dockerfile), so nobody has
+# to build it -- the first 'image' run pays for it once, or you skip even that
+# by loading an image someone else published.
+#
+# Usage:
+#   packaging/container/build.sh image      # build the toolchain+SDK image
+#   packaging/container/build.sh build      # compile reNut inside it
+#   packaging/container/build.sh appimage   # package dist/reNut-x86_64.AppImage
+#   packaging/container/build.sh all        # build + appimage
+#   packaging/container/build.sh shell      # interactive shell in the image
+#
+# Env:
+#   RENUT_IMAGE   image tag                       (default renut-build:jammy)
+#   BASE          base image                      (default ubuntu:22.04)
+#   CODENAME      matching distro codename        (default jammy)
+#   PYTHON_VENV   matching venv package           (default python3.10-venv)
+#   SDK_REF       rexglue-sdk git tag/branch/SHA  (default pinned below)
+#
+# The container writes to out/container/ rather than out/, so it never fights
+# with a host build over the same CMake cache -- the two use different compilers
+# and different sysroots, and a shared cache would produce confusing failures.
+# dist/ is shared, because that is the artifact you actually ship.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+IMAGE="${RENUT_IMAGE:-renut-build:jammy}"
+BASE="${BASE:-ubuntu:22.04}"
+CODENAME="${CODENAME:-jammy}"
+PYTHON_VENV="${PYTHON_VENV:-python3.10-venv}"
+SDK_REF="${SDK_REF:-nightly-20260809-f5c85215}"
+
+PRESET=linux-amd64-relwithdebinfo
+CONTAINER_OUT="$REPO_ROOT/out/container"
+
+# The runtime shared libraries, which the build does not place next to the
+# executable itself. renut has RUNPATH=$ORIGIN and make-appimage.sh reads them
+# out of the build directory, so they are copied there after each build.
+LIBS=(librexruntimerd.so librexgpu-xenosrd.so libTracyClientrd.so)
+
+die() { printf 'error: %s\n' "$1" >&2; exit 1; }
+
+DOCKER="${DOCKER:-docker}"
+
+command -v "$DOCKER" >/dev/null 2>&1 \
+  || die "docker is not installed (Arch/CachyOS: sudo pacman -S docker && sudo systemctl enable --now docker)"
+
+$DOCKER info >/dev/null 2>&1 || die "cannot reach the docker daemon.
+  Either add yourself to the docker group (note that this grants root-equivalent
+  access to the machine):
+      sudo usermod -aG docker \$USER   # then log out and back in, or: newgrp docker
+  or run this script under sudo, which is handled:
+      sudo -E $0 ${1:-all}"
+
+# Under sudo, id -u is 0, which would leave root-owned artifacts in the source
+# tree. SUDO_UID/SUDO_GID name the invoking user, so prefer them when present.
+RUN_UID="${SUDO_UID:-$(id -u)}"
+RUN_GID="${SUDO_GID:-$(id -g)}"
+
+have_image() { $DOCKER image inspect "$IMAGE" >/dev/null 2>&1; }
+
+# 'all' deliberately does not rebuild the image -- that is the slow step and it
+# rarely needs redoing. The cost is that a Dockerfile edit silently does nothing
+# until someone reruns 'image', so say so rather than let it pass unnoticed.
+warn_if_image_stale() {
+  local created created_epoch dockerfile_epoch
+  created=$($DOCKER image inspect -f '{{.Created}}' "$IMAGE" 2>/dev/null) || return 0
+  created_epoch=$(date -d "$created" +%s 2>/dev/null) || return 0
+  dockerfile_epoch=$(stat -c %Y "$REPO_ROOT/packaging/container/Dockerfile" 2>/dev/null) || return 0
+  if (( dockerfile_epoch > created_epoch )); then
+    printf 'warning: Dockerfile has changed since %s was built.\n' "$IMAGE" >&2
+    printf "         run '%s image' to pick up those changes.\n" "$0" >&2
+  fi
+}
+
+build_image() {
+  echo "==> building $IMAGE (base=$BASE, sdk=$SDK_REF)"
+  echo "    the SDK compiles in here; expect this to take a while the first time"
+  $DOCKER build \
+    --build-arg "BASE=$BASE" \
+    --build-arg "CODENAME=$CODENAME" \
+    --build-arg "PYTHON_VENV=$PYTHON_VENV" \
+    --build-arg "SDK_REF=$SDK_REF" \
+    -t "$IMAGE" \
+    "$REPO_ROOT/packaging/container"
+}
+
+# Runs as the invoking user so build artifacts are not left root-owned on the
+# host. That leaves HOME pointing at a directory this user cannot write, which
+# CMake and git both dislike, so redirect it.
+run_in_container() {
+  mkdir -p "$CONTAINER_OUT"
+  # Under sudo the mkdir above runs as root, but the container runs as the
+  # invoking user and would then have nowhere to write. Hand the directory over.
+  # Recursive so a directory left behind by an earlier run repairs itself.
+  if [[ -n "${SUDO_UID:-}" ]]; then
+    chown -R "$RUN_UID:$RUN_GID" "$CONTAINER_OUT"
+  fi
+  $DOCKER run --rm -i \
+    --user "$RUN_UID:$RUN_GID" \
+    -e HOME=/tmp \
+    -v "$REPO_ROOT":/src/reNut \
+    -v "$CONTAINER_OUT":/src/reNut/out \
+    -w /src/reNut \
+    "$@"
+}
+
+cmd_build() {
+  have_image || die "image $IMAGE not found -- run '$0 image' first"
+  warn_if_image_stale
+  echo "==> configuring and building reNut (glibc floor set by $BASE)"
+  run_in_container "$IMAGE" bash -euc "
+    cmake --preset $PRESET -DCMAKE_PREFIX_PATH=/opt/rexglue-sdk
+    cmake --build --preset $PRESET --parallel
+    for lib in ${LIBS[*]}; do
+      cp /opt/rexglue-sdk/lib/\$lib out/build/$PRESET/\$lib
+    done
+  "
+}
+
+cmd_appimage() {
+  have_image || die "image $IMAGE not found -- run '$0 image' first"
+  warn_if_image_stale
+  [[ -x "$CONTAINER_OUT/build/$PRESET/renut" ]] \
+    || die "no container-built renut -- run '$0 build' first"
+  echo "==> packaging AppImage"
+  # Packaged inside the container on purpose: make-appimage.sh bundles the
+  # libstdc++ that ${CXX} points at, and that has to be the image's GCC 13 one.
+  # Running this step on the host would re-import the host's glibc 2.38
+  # libstdc++ and undo the whole exercise.
+  run_in_container "$IMAGE" \
+    packaging/make-appimage.sh "/src/reNut/out/build/$PRESET"
+}
+
+case "${1:-all}" in
+  image)    build_image ;;
+  build)    cmd_build ;;
+  appimage) cmd_appimage ;;
+  all)      cmd_build; cmd_appimage ;;
+  shell)    have_image || die "image $IMAGE not found -- run '$0 image' first"
+            run_in_container -t "$IMAGE" bash ;;
+  *)        die "unknown command '${1}' (image|build|appimage|all|shell)" ;;
+esac

--- a/packaging/make-appimage.sh
+++ b/packaging/make-appimage.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+#
+# Builds dist/reNut-x86_64.AppImage from an existing reNut build.
+#
+# Prerequisites: a completed build (linux-amd64-release is preferred over
+# relwithdebinfo, though this script strips either), ImageMagick for the icon,
+# and network access on first run to fetch appimagetool.
+#
+# Usage:
+#   packaging/make-appimage.sh [build-dir]
+#   RENUT_LOWER_GLIBC=1 packaging/make-appimage.sh    # see "glibc floor" below
+#
+# Why this needs no LD_LIBRARY_PATH or library-rewriting:
+#   renut is linked with RUNPATH=$ORIGIN, so the three rexglue .so files are
+#   found simply by sitting next to the binary -- which is also where the GPU
+#   plugin is dlopen'd from. libstdc++/libgcc ride along the same way (see
+#   "C++ runtime floor" below); everything else it links (libc, X11, xcb) is
+#   deliberately left to the host.
+#
+# Why it works on a read-only mount:
+#   renut writes its config to $XDG_CONFIG_HOME/renut and its logs to
+#   $XDG_STATE_HOME/renut (see src/renut_engine/linuxfixes/xdg_paths.h). Before
+#   that change it wrote both next to the executable, which cannot work inside
+#   an AppImage.
+#
+# There are two portability floors here, and they move independently.
+#
+# C++ runtime floor (handled unconditionally, below):
+#   clang++ compiles against whichever libstdc++ headers the build host's GCC
+#   installs, so on a bleeding-edge host librexruntimerd.so ends up calling
+#   GLIBCXX_3.4.35 symbols -- the C++20 atomic-wait machinery behind
+#   std::atomic::wait/latch/barrier, which only a GCC 15-or-newer libstdc++
+#   exports. That is a *stricter* limit than the glibc one, and it is easy to
+#   miss: Ubuntu 24.04 and Debian 13 both have new enough glibc but too old a
+#   libstdc++. So libstdc++.so.6 and libgcc_s.so.1 are staged next to renut and
+#   resolved through the same RUNPATH=$ORIGIN. Bundling a *newer* libstdc++ is
+#   safe -- Mesa/GL drivers dlopen'd later need older versions and a newer one
+#   satisfies them. The reverse would not hold, so never bundle an older one.
+#
+# glibc floor:
+#   The resulting AppImage inherits the build host's glibc requirement -- an
+#   AppImage bundles libraries, not libc. Building on a bleeding-edge distro
+#   therefore produces an AppImage that only runs on bleeding-edge distros.
+#   Setting RENUT_LOWER_GLIBC=1 runs polyfill-glibc to remap five float math
+#   symbols (sqrtf/acosf/asinf/atan2f/log10f) from their GLIBC_2.43 versions to
+#   the ABI-identical GLIBC_2.2.5 ones, which lowers the floor to 2.38 with no
+#   rebuild. Going below 2.38 currently does not work: polyfill-glibc crashes on
+#   librexruntimerd.so when targeting 2.34+, and targeting 2.32 yields a renut
+#   that segfaults in its own static initialisers. None of the symbols above
+#   2.28 are features the source actually asks for -- they are all picked by the
+#   build host -- so the real fix for anything lower is to build against an older
+#   glibc instead of rewriting symbols afterwards. See packaging/container/.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="${1:-$REPO_ROOT/out/build/linux-amd64-relwithdebinfo}"
+WORK_DIR="$REPO_ROOT/out/appimage"
+APP_DIR="$WORK_DIR/renut.AppDir"
+DIST_DIR="$REPO_ROOT/dist"
+OUTPUT="$DIST_DIR/reNut-x86_64.AppImage"
+
+LIBS=(librexruntimerd.so librexgpu-xenosrd.so libTracyClientrd.so)
+
+die() { printf 'error: %s\n' "$1" >&2; exit 1; }
+
+[[ -x "$BUILD_DIR/renut" ]] || die "no renut binary in $BUILD_DIR (build first)"
+for lib in "${LIBS[@]}"; do
+  [[ -f "$BUILD_DIR/$lib" ]] || die "missing $lib in $BUILD_DIR"
+done
+command -v magick >/dev/null 2>&1 || command -v convert >/dev/null 2>&1 \
+  || die "ImageMagick is required to convert icon/app.ico"
+
+rm -rf "$APP_DIR"
+mkdir -p "$APP_DIR/usr/bin" "$DIST_DIR"
+
+echo "==> staging binaries"
+cp "$BUILD_DIR/renut" "$APP_DIR/usr/bin/"
+for lib in "${LIBS[@]}"; do cp "$BUILD_DIR/$lib" "$APP_DIR/usr/bin/"; done
+
+echo "==> stripping"
+strip --strip-unneeded "$APP_DIR/usr/bin/renut" "$APP_DIR/usr/bin/"*.so 2>/dev/null || true
+
+if [[ "${RENUT_LOWER_GLIBC:-0}" == "1" ]]; then
+  echo "==> lowering glibc floor (2.43 -> 2.38)"
+  command -v polyfill-glibc >/dev/null 2>&1 \
+    || die "RENUT_LOWER_GLIBC=1 needs polyfill-glibc on PATH (github.com/corsix/polyfill-glibc)"
+  renames="$WORK_DIR/renames.txt"
+  cat > "$renames" <<'RENAMES'
+// glibc 2.43 added new symbol versions for these float math functions. The
+// GLIBC_2.2.5 versions are ABI-identical (they additionally set errno, which is
+// what every binary built before 2.43 already relied on), so binding to them is
+// safe and removes the hard 2.43 requirement.
+sqrtf@GLIBC_2.43   libm.so.6::sqrtf@GLIBC_2.2.5
+acosf@GLIBC_2.43   libm.so.6::acosf@GLIBC_2.2.5
+asinf@GLIBC_2.43   libm.so.6::asinf@GLIBC_2.2.5
+atan2f@GLIBC_2.43  libm.so.6::atan2f@GLIBC_2.2.5
+log10f@GLIBC_2.43  libm.so.6::log10f@GLIBC_2.2.5
+RENAMES
+  for f in "$APP_DIR/usr/bin/renut" "$APP_DIR/usr/bin/"*.so; do
+    polyfill-glibc --rename-dynamic-symbols="$renames" "$f"
+  done
+fi
+
+echo "==> bundling C++ runtime"
+# Deliberately staged after the strip and polyfill-glibc loops above: those glob
+# *.so, which does not match *.so.N, so these arrive verbatim as the toolchain
+# shipped them. They need at most GLIBC_2.38 themselves (libstdc++ 2.38, libgcc
+# 2.35), so they never raise the floor reported at the end.
+for lib in libstdc++.so.6 libgcc_s.so.1; do
+  src="$("${CXX:-clang++}" -print-file-name="$lib")"
+  [[ -f "$src" ]] || die "could not locate $lib via ${CXX:-clang++} -print-file-name"
+  cp -L "$src" "$APP_DIR/usr/bin/$lib"
+done
+
+echo "==> bundling extract-xiso"
+# Used by AppRun's first-run flow to extract game data from a disc image the
+# user owns. Optional: AppRun skips that flow entirely when the binary is
+# absent, falling back to renut's built-in path wizard. Prefer the copy the
+# build container produces, since a host-built one would carry the host's glibc
+# requirement into the AppImage.
+xiso=""
+if [[ -x /opt/extract-xiso/extract-xiso ]]; then
+  xiso=/opt/extract-xiso/extract-xiso
+elif command -v extract-xiso >/dev/null 2>&1; then
+  xiso="$(command -v extract-xiso)"
+fi
+if [[ -n "$xiso" ]]; then
+  cp "$xiso" "$APP_DIR/usr/bin/extract-xiso"
+  strip --strip-unneeded "$APP_DIR/usr/bin/extract-xiso" 2>/dev/null || true
+else
+  echo "    warning: extract-xiso not found, first-run ISO extraction will be"
+  echo "             unavailable in this build (the in-app wizard still works)"
+fi
+
+echo "==> icon"
+ico="$REPO_ROOT/icon/app.ico"
+if command -v magick >/dev/null 2>&1; then
+  magick "$ico[0]" -resize 256x256 "$APP_DIR/renut.png"
+else
+  convert "$ico[0]" -resize 256x256 "$APP_DIR/renut.png"
+fi
+cp "$APP_DIR/renut.png" "$APP_DIR/.DirIcon"
+
+echo "==> AppRun + desktop entry"
+# Kept as a real file rather than a heredoc so it can be shellchecked and diffed
+# on its own. It handles the first-run disc extraction as well as the launch.
+cp "$REPO_ROOT/packaging/AppRun" "$APP_DIR/AppRun"
+chmod +x "$APP_DIR/AppRun"
+
+cat > "$APP_DIR/renut.desktop" <<'DESKTOP'
+[Desktop Entry]
+Type=Application
+Name=reNut
+Comment=Xbox 360 game recompilation
+Exec=renut
+Icon=renut
+Categories=Game;
+Terminal=false
+DESKTOP
+
+echo "==> fetching appimagetool if needed"
+tool="$WORK_DIR/appimagetool"
+if [[ ! -x "$tool" ]]; then
+  curl -sSL -o "$tool" \
+    https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
+  chmod +x "$tool"
+fi
+
+echo "==> packaging"
+ARCH=x86_64 "$tool" "$APP_DIR" "$OUTPUT"
+
+echo
+echo "built: $OUTPUT"
+echo "  size:        $(du -h "$OUTPUT" | cut -f1)"
+# Every staged file, bundled C++ runtime included -- all of it has to load on the
+# target. GLIBC_ cannot match GLIBCXX_ here, since the pattern needs a digit
+# straight after the underscore.
+echo "  glibc floor: $(objdump -T "$APP_DIR/usr/bin/"* 2>/dev/null \
+                        | grep -oE 'GLIBC_[0-9.]+' | sort -uV | tail -1)"
+echo "  libstdc++:   bundled, $(objdump -T "$APP_DIR/usr/bin/libstdc++.so.6" 2>/dev/null \
+                        | grep -oE 'GLIBCXX_[0-9.]+' | sort -uV | tail -1) (host floor removed)"

--- a/src/renut_app.h
+++ b/src/renut_app.h
@@ -14,6 +14,16 @@
 #include <functional>
 #include <string>
 
+#ifndef _WIN32
+#include <rex/cvar.h>
+#include "renut_engine/linuxfixes/xdg_paths.h"
+
+// Defined in the SDK (src/core/logging.cpp) at global scope. When non-empty it
+// takes precedence over the exe-relative logs/ directory that rex_app.cpp would
+// otherwise hardcode.
+REXCVAR_DECLARE(std::string, log_file);
+#endif
+
 class RenutApp : public rex::ReXApp {
 public:
     RenutApp(rex::ui::WindowedAppContext& ctx, std::string_view name, rex::PPCImageInfo info)
@@ -24,6 +34,34 @@ public:
         return std::unique_ptr<RenutApp>(new RenutApp(ctx, "renut", PPCImageConfig));
     }
 
+#ifndef _WIN32
+    // Runs before the SDK loads the config and before logging is initialised
+    // (rex_app.cpp:146), which is the only point where both destinations can
+    // still be redirected.
+    //
+    // Without this, renut writes <exe_dir>/renut.toml and <exe_dir>/logs/ --
+    // fine in a build tree, fatal inside a read-only AppImage/Flatpak mount.
+    void OnConfigurePaths(rex::PathConfig& paths) override {
+        namespace lf = renut::linuxfixes;
+
+        // ~/.config/renut/renut.toml, migrating any existing exe-relative copy.
+        paths.config_path = lf::ResolveWithMigration(lf::ConfigDir(),
+                                                     std::string(GetName()) + ".toml");
+
+        // ~/.local/state/renut/logs/renut_NNN.log. Setting log_file is the only
+        // way to move the log directory, since rex_app.cpp hardcodes exe_dir/logs
+        // whenever this cvar is empty -- so we do the sequential numbering that
+        // the SDK would otherwise have done for us.
+        if (REXCVAR_GET(log_file).empty()) {
+            auto log_path = lf::NextSequentialLog(lf::LogDir(), std::string(GetName()));
+            if (!log_path.empty()) {
+                REXCVAR_SET(log_file, log_path.string());
+            }
+            // If the state dir could not be created we leave the cvar empty and
+            // let the SDK fall back to its exe-relative default.
+        }
+    }
+#endif
 
     // void OnPostSetup() override {
     //     rex::discord_rpc::Presence rpc;

--- a/src/renut_engine/cvar_menu.cpp
+++ b/src/renut_engine/cvar_menu.cpp
@@ -1,3 +1,37 @@
+// =============================================================================
+// cvar_menu.cpp
+//
+// Lets you edit every reNut cvar from inside the game's pause menu (selectable
+// ON/OFF or value next to each), instead of the F4 overlay. It adds a dedicated
+// "reNut Settings" tab/section to the pause section strip; its content is a
+// categorized, collapsible list ("[-]/[+] Category" headers + indented cvars).
+//
+// How it plugs into the game's XUI pause menu (all addresses from IDA):
+//   Content list (the rows within a section):
+//   * sub_825A89B0  - content-list builder. Fills dword_82FA32F8[] with item
+//                     type-IDs and dword_82FA32F4 with the count, then the tail
+//                     inserts that many XUI list rows.
+//   * sub_825A96C8  - per-item label callback.
+//   * sub_825A8D68  - selection/dispatch callback.
+//   * sub_825A76E0  - pause input handler; its "activate item" dispatch is a
+//                     jump table bounded to modes 0..7.
+//   Section strip (the tabs):
+//   * sub_825A6708  - strip builder. Fills dword_82FA32C4[] (section ids) +
+//                     dword_82FA32C0 (count).
+//   * sub_825A8110  - per-tab icon callback (off_82E51538[2*id]).
+//   * sub_825A7CF0  - selected-section title text (off_82E5153C[2*id]).
+//   * sub_825A7D90  - section switch / setMode(obj, id); jump table id<=7.
+//
+// In cvar mode we NEVER store rows in the guest item array: the injection hook
+// writes only the COUNT, and the label/dispatch overrides source everything
+// from the host-side model (g_cats -> g_rows). Section id 8 = "reNut Settings"
+// (game uses 0..7); its icon reuses section 0's. Because sub_825A76E0's activate
+// dispatch is bounded to modes 0..7, we present mode 0 while our section is
+// active so A-press routes to sub_825A8D68 (our toggle).
+//
+// See: https://github.com/rexglue/rexglue-sdk/wiki/Function-Overrides
+// =============================================================================
+
 #include <rex/hook.h>
 #include <rex/cvar.h>
 #include <rex/logging.h>
@@ -6,12 +40,18 @@
 #include <algorithm>
 #include <cstdint>
 #include <cstdlib>
+#include <filesystem>
 #include <fstream>
 #include <optional>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+
+#ifndef _WIN32
+// Keeps renut.toml out of the working directory so it survives an AppImage.
+#include "linuxfixes/xdg_paths.h"
+#endif
 
 #if defined(_MSC_VER)
 #include <stdlib.h>
@@ -326,7 +366,25 @@ static void ApplyCvarChange(const CvarRow& row, bool forward) {
 // cvars are appended. Commands are never written (they have no value). This is
 // why we don't use rex::cvar::SaveConfig(), which truncates the whole file.
 // -----------------------------------------------------------------------------
-static constexpr const char* kRenutConfigPath = "renut.toml";
+// Resolved once, on first use.
+//
+// This must not stay a bare relative path on Linux. A relative name resolves
+// against the process working directory, which for an AppImage is wherever the
+// user happened to launch it from -- so the cvar config was being created next
+// to the .AppImage and never found again. Running the build-dir binary hid this,
+// because there the working directory is the build directory.
+//
+// Windows keeps the executable-relative behaviour, matching path_config_store.h.
+static const std::filesystem::path& RenutConfigPath() {
+#ifdef _WIN32
+  static const std::filesystem::path path{"renut.toml"};
+#else
+  // Also migrates a copy sitting beside the executable from before this change.
+  static const std::filesystem::path path =
+      renut::linuxfixes::ResolveWithMigration(renut::linuxfixes::ConfigDir(), "renut.toml");
+#endif
+  return path;
+}
 
 static std::string TomlQuote(const std::string& s) {
   std::string out = "\"";
@@ -347,8 +405,8 @@ static std::string TrimWs(const std::string& s) {
   return s.substr(b, e - b + 1);
 }
 
-// Not static: the controls overlay (overlays/mnk_controls_dialog.h) persists
-// rebinds through this too.
+// Declared in overlays/mnk_controls_dialog.h, which calls it from the controls
+// overlay. Deliberately not static: a second translation unit needs it.
 void RenutSaveConfig() {
   // desired[name] = formatted TOML value, for every value cvar != its default.
   // managed = every value-cvar name, so we can update or drop its existing line.
@@ -367,7 +425,7 @@ void RenutSaveConfig() {
   std::vector<std::string> out;
   bool fileExisted = false;
   {
-    std::ifstream in(kRenutConfigPath);
+    std::ifstream in(RenutConfigPath());
     if (in) {
       fileExisted = true;
       std::string line;
@@ -408,9 +466,9 @@ void RenutSaveConfig() {
   for (const auto& kv : added)
     out.push_back(kv.first + " = " + kv.second);
 
-  std::ofstream f(kRenutConfigPath, std::ios::trunc);
+  std::ofstream f(RenutConfigPath(), std::ios::trunc);
   if (!f) {
-    REXLOG_ERROR("RenutSaveConfig: failed to open {}", kRenutConfigPath);
+    REXLOG_ERROR("RenutSaveConfig: failed to open {}", RenutConfigPath().string());
     return;
   }
   for (const auto& l : out)

--- a/src/renut_engine/frameHooks.cpp
+++ b/src/renut_engine/frameHooks.cpp
@@ -1,4 +1,10 @@
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
 #include <windows.h>
+#else
+#include <time.h>
+#endif
 
 #include <rex/hook.h>
 #include "rex_macros.h"
@@ -72,8 +78,10 @@ void klungoDestruct_hook() // Called at 8246f62c (End of the function)
 // almost no load of its own. It is deliberately named separately from rexglue's
 // GPU `vsync` cvar and does not touch the SDK.
 // =============================================================================
+#ifdef _WIN32
 #ifndef CREATE_WAITABLE_TIMER_HIGH_RESOLUTION
 #define CREATE_WAITABLE_TIMER_HIGH_RESOLUTION 0x00000002
+#endif
 #endif
 
 REXCVAR_DEFINE_STRING(frame_cap, "Off", "Nuts&Bolts/Performance",
@@ -81,6 +89,7 @@ REXCVAR_DEFINE_STRING(frame_cap, "Off", "Nuts&Bolts/Performance",
 	"Off = uncapped, Display = match monitor refresh.")
 	.allowed({ "Off", "30", "60", "120", "144", "Display" });
 
+#ifdef _WIN32
 // One process-wide timer, created on first use. Falls back to a normal waitable
 // timer (and then to sleep_for) if the high-resolution flag isn't supported.
 static HANDLE renutFrameTimer()
@@ -93,6 +102,7 @@ static HANDLE renutFrameTimer()
 	}();
 	return timer;
 }
+#endif
 
 // Resolve the cvar to a target FPS: 0 = uncapped, "Display" = monitor refresh
 // (queried once), otherwise the literal number.
@@ -101,6 +111,7 @@ static int renutFrameCapFps()
 	const std::string& v = REXCVAR_GET(frame_cap);
 	if (v.empty() || v == "Off") return 0;
 	if (v == "Display") {
+#ifdef _WIN32
 		static int hz = []() -> int {
 			DEVMODEW dm{}; dm.dmSize = sizeof(dm);
 			if (EnumDisplaySettingsW(nullptr, ENUM_CURRENT_SETTINGS, &dm) &&
@@ -109,6 +120,11 @@ static int renutFrameCapFps()
 			return 60;
 		}();
 		return hz;
+#else
+		// No portable display-refresh query without pulling in a windowing
+		// dependency here; assume a common default.
+		return 60;
+#endif
 	}
 	return std::atoi(v.c_str());
 }
@@ -136,7 +152,9 @@ void renutFrameLimit()
 		return;
 	}
 
+#ifdef _WIN32
 	HANDLE timer = renutFrameTimer();
+#endif
 	constexpr auto kSpinTail = std::chrono::microseconds(400);
 	for (;;) {
 		now = clock::now();
@@ -144,6 +162,7 @@ void renutFrameLimit()
 		const auto remaining = next - now;
 		if (remaining > kSpinTail) {
 			const auto waitFor = remaining - kSpinTail;
+#ifdef _WIN32
 			if (timer) {
 				LARGE_INTEGER due;
 				due.QuadPart = -static_cast<LONGLONG>(
@@ -155,6 +174,16 @@ void renutFrameLimit()
 			} else {
 				std::this_thread::sleep_for(waitFor);
 			}
+#else
+			// clock_nanosleep with TIMER_ABSTIME avoids drift from repeatedly
+			// re-measuring "now" the way sleep_for's relative wait would.
+			const auto target = next - kSpinTail;
+			const auto targetNs = std::chrono::time_point_cast<std::chrono::nanoseconds>(target);
+			struct timespec ts;
+			ts.tv_sec = static_cast<time_t>(targetNs.time_since_epoch().count() / 1000000000LL);
+			ts.tv_nsec = static_cast<long>(targetNs.time_since_epoch().count() % 1000000000LL);
+			clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &ts, nullptr);
+#endif
 		} else {
 			std::this_thread::yield();  // brief sub-ms tail for pacing accuracy
 		}

--- a/src/renut_engine/linuxfixes/audio_backend.cpp
+++ b/src/renut_engine/linuxfixes/audio_backend.cpp
@@ -1,0 +1,33 @@
+// Forces SDL's PulseAudio backend on Linux.
+//
+// SDL picks an audio backend by probing its compiled-in drivers in priority
+// order, and on this desktop it settles on PipeWire. That path opens a device
+// and PipeWire even shows the "rexglue" stream as active and routed, but no
+// audio actually comes out. The PulseAudio backend (served by pipewire-pulse)
+// works, so pin SDL to it.
+//
+// SDL_HINT_AUDIO_DRIVER is literally "SDL_AUDIO_DRIVER" and SDL falls back to
+// the environment variable when the hint has not been set programmatically, so
+// exporting it is enough -- and it keeps reNut from having to link SDL3
+// directly, which it currently does not (SDL lives inside librexruntimerd.so).
+//
+// This has to happen before SDL_InitSubSystem(SDL_INIT_AUDIO), which the SDK
+// calls from SDLAudioDriver::Initialize() the first time the guest registers an
+// audio client. A static initializer runs before main(), so it is comfortably
+// early.
+//
+// overwrite=0: an SDL_AUDIO_DRIVER already present in the environment wins, so
+// you can still override this from the shell without rebuilding, e.g.
+//   SDL_AUDIO_DRIVER=pipewire ./renut
+
+#include <cstdlib>
+
+namespace {
+
+const bool g_audio_backend_pinned = [] {
+  // Does nothing if the variable is already set.
+  ::setenv("SDL_AUDIO_DRIVER", "pulseaudio", 0);
+  return true;
+}();
+
+}  // namespace

--- a/src/renut_engine/linuxfixes/audio_client_guard.cpp
+++ b/src/renut_engine/linuxfixes/audio_client_guard.cpp
@@ -1,0 +1,249 @@
+// Fixes a hard hang on Linux caused by an XAudio use-after-unregister race.
+//
+// Symptom
+// -------
+// A few seconds into the game every guest thread stops making progress while
+// the window keeps redrawing. One host thread ("Audio Worker") sits at 100% CPU.
+//
+// Cause
+// -----
+// rex::audio::AudioSystem::WorkerThreadMain() reads clients_[i].callback under
+// the global critical region, *releases the lock*, and only then runs the guest
+// audio callback:
+//
+//     auto global_lock = global_critical_region_.Acquire();
+//     uint32_t client_callback = clients_[index].callback;
+//     ...
+//     global_lock.unlock();
+//     if (client_callback) { function_dispatcher_->Execute(client_callback, ...); }
+//
+// If another guest thread calls XAudioUnregisterRenderDriverClient while that
+// callback is in flight, AudioSystem::UnregisterClient() destroys the driver and
+// resets the slot to {nullptr, 0, 0, 0, false}. The still-running callback then
+// calls XAudioSubmitRenderDriverFrame, and AudioSystem::SubmitFrame() does:
+//
+//     auto global_lock = global_critical_region_.Acquire();   // audio_system.cpp:261
+//     assert_true(clients_[index].driver != NULL);            // compiled out (NDEBUG)
+//     (clients_[index].driver)->SubmitFrame(samples_ptr);     // audio_system.cpp:264
+//
+// ...which dereferences a null AudioDriver* while holding the global lock.
+//
+// Why it hangs instead of crashing
+// --------------------------------
+// On Linux this never reaches a crash handler. ExceptionHandlerCallback() in
+// the SDK's exception_handler_posix.cpp walks its registered handlers and, when
+// none of them claims the fault, simply falls off the end of the function and
+// returns. Returning from a SIGSEGV handler without advancing RIP makes the
+// kernel restart the faulting instruction, which faults again -- forever.
+//
+// The audio worker therefore spins at 100% CPU and never runs the destructor
+// that would release the global critical region. Every thread that needs that
+// lock blocks permanently: GPU vblank interrupt dispatch, KeSetEvent, and every
+// guest thread parked in NtWaitForSingleObjectEx waiting on events that can no
+// longer be signalled. Only the host UI thread keeps running, which is why the
+// window stays alive while the game is frozen.
+//
+// Fix
+// ---
+// The SDK is upstream and cannot be patched, so the three XAudio driver-client
+// exports are interposed here. renut imports them as undefined symbols from
+// librexruntimerd.so, so defining them in the executable binds every call in
+// the recompiled game code to these wrappers at link time.
+//
+// We track which client indices are actually registered and drop any frame
+// submitted for a dead index instead of letting it reach the null driver. A
+// shared_mutex makes the check-and-submit atomic with respect to unregistration,
+// so the frame cannot be dropped in the gap between the two. Our lock is always
+// taken *before* the SDK's global critical region and never the other way round,
+// so it cannot introduce a lock-order inversion.
+//
+// Dropping is not enough on its own
+// ---------------------------------
+// Not crashing still leaves the *guest* half-torn. Comparing runs:
+//
+//     reg=2 unreg=1 drops=0  -> game re-registers, boots fine
+//     reg=1 unreg=1 drops=1  -> game never re-registers, hangs at appMainBoot
+//                               with every guest thread in NtWaitForSingleObjectEx
+//
+// That held for every run observed, so a dropped frame reliably wedges the
+// game's audio state machine even though the crash is gone. (The guest ignores
+// the return value of XAudioSubmitRenderDriverFrame entirely -- it calls it and
+// immediately returns -- so reporting an error instead would change nothing.)
+//
+// So rather than dropping the frame, we stop the race from happening: on
+// unregister we wait, *without* holding the lock, until frame submissions have
+// gone quiet, letting an in-flight callback deliver to a still-live driver
+// before the teardown runs. Bounded by kUnregisterMaxGrace so a game that
+// submits continuously cannot stall the unregistering thread indefinitely. The
+// observed gap between unregister and the orphaned submit was 37 ms.
+//
+// The drop path is kept as the backstop for anything that still slips through
+// (for example a submit arriving after the grace period expires); it is what
+// prevents the null-deref hang.
+//
+// A complete fix belongs in the SDK: AudioSystem::WorkerThreadMain() should hold
+// the global critical region across the guest callback dispatch instead of
+// releasing it first. That cannot be done from reNut, since the dispatch lives
+// inside librexruntimerd.so.
+//
+// Note: this covers the XAudioUnregisterRenderDriverClient path. AudioSystem::
+// Shutdown() also clears every client slot directly, but it terminates the audio
+// worker thread first, so there is no callback left in flight to race with.
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <shared_mutex>
+#include <thread>
+
+#include <rex/hook.h>
+#include <rex/system/xtypes.h>
+#include <rex/types.h>
+
+#include "../renut_logging.h"
+
+// The X_* status macros expand to a cast to X_RESULT, which lives in namespace rex.
+using rex::X_RESULT;
+
+// Provided by librexruntimerd.so (src/kernel/xboxkrnl/xboxkrnl_audio.cpp).
+// Not declared in any public SDK header, so they are declared here; the
+// signatures must match exactly for the mangled names to resolve.
+namespace rex::kernel::xboxkrnl {
+u32 XAudioRegisterRenderDriverClient_entry(mapped_u32 callback_ptr, mapped_u32 driver_ptr);
+u32 XAudioUnregisterRenderDriverClient_entry(mapped_void driver_ptr);
+u32 XAudioSubmitRenderDriverFrame_entry(mapped_void driver_ptr, mapped_void samples_ptr);
+}  // namespace rex::kernel::xboxkrnl
+
+namespace {
+
+// Handle layout produced by XAudioRegisterRenderDriverClient_entry:
+//   *driver_ptr = 0x41550000 | (index & 0xFFFF)
+constexpr uint32_t kDriverHandleTag = 0x41550000u;
+constexpr uint32_t kDriverHandleTagMask = 0xFFFF0000u;
+constexpr uint32_t kDriverIndexMask = 0x0000FFFFu;
+
+// Mirrors AudioSystem::kMaximumClientCount.
+constexpr uint32_t kMaximumClientCount = 8;
+
+// Bit i set => client index i is registered and has a live driver.
+uint32_t g_live_clients = 0;
+
+// Guards g_live_clients *and* the window in which a submitted frame is handed
+// to the SDK, so a concurrent unregister cannot destroy the driver in between.
+std::shared_mutex g_clients_mutex;
+
+// Rate-limit the "dropped frame" warning; the game submits ~one frame per few
+// milliseconds and would otherwise flood the log.
+std::atomic<uint32_t> g_dropped_frames{0};
+
+// Bumped for every frame that reaches the SDK. Unregister watches this to tell
+// whether a guest audio callback is still in flight.
+std::atomic<uint64_t> g_submitted_frames{0};
+
+// Unregister waits for submissions to stay quiet this long before tearing the
+// driver down (the orphaned submit was observed 37 ms after unregister)...
+constexpr auto kUnregisterQuietPeriod = std::chrono::milliseconds(30);
+// ...but never waits longer than this in total, so a game that submits
+// continuously cannot stall the unregistering guest thread. Unregister happens
+// about once per run, so this costs nothing in practice.
+constexpr auto kUnregisterMaxGrace = std::chrono::milliseconds(250);
+
+// Returns kMaximumClientCount if the handle is not a driver handle we know.
+uint32_t ClientIndexFromHandle(uint32_t handle) {
+  if ((handle & kDriverHandleTagMask) != kDriverHandleTag) {
+    return kMaximumClientCount;
+  }
+  const uint32_t index = handle & kDriverIndexMask;
+  return index < kMaximumClientCount ? index : kMaximumClientCount;
+}
+
+u32 RegisterRenderDriverClient(mapped_u32 callback_ptr, mapped_u32 driver_ptr) {
+  std::unique_lock lock(g_clients_mutex);
+
+  const rex::u32 result =
+      rex::kernel::xboxkrnl::XAudioRegisterRenderDriverClient_entry(callback_ptr, driver_ptr);
+  if (result != X_ERROR_SUCCESS || !driver_ptr) {
+    return result;
+  }
+
+  const uint32_t index = ClientIndexFromHandle(driver_ptr.value());
+  if (index >= kMaximumClientCount) {
+    RNUT_WARN("audio guard: register returned unrecognized driver handle {:08X}",
+              driver_ptr.value());
+    return result;
+  }
+
+  g_live_clients |= (1u << index);
+  RNUT_INFO("audio guard: client {} registered (handle {:08X})", index, driver_ptr.value());
+  return result;
+}
+
+u32 UnregisterRenderDriverClient(mapped_void driver_ptr) {
+  const uint32_t index = ClientIndexFromHandle(driver_ptr.guest_address());
+
+  // Let any in-flight guest audio callback land its frame on the still-live
+  // driver before we tear it down. Deliberately done *before* taking the lock,
+  // so submissions can still run while we wait -- holding it here would block
+  // the very callback we are waiting for.
+  if (index < kMaximumClientCount && (g_live_clients & (1u << index))) {
+    const auto start = std::chrono::steady_clock::now();
+    auto last_submit = start;
+    uint64_t seen = g_submitted_frames.load(std::memory_order_relaxed);
+    for (;;) {
+      const auto now = std::chrono::steady_clock::now();
+      const uint64_t current = g_submitted_frames.load(std::memory_order_relaxed);
+      if (current != seen) {
+        seen = current;
+        last_submit = now;
+      }
+      if (now - last_submit >= kUnregisterQuietPeriod || now - start >= kUnregisterMaxGrace) {
+        break;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+  }
+
+  std::unique_lock lock(g_clients_mutex);
+
+  // Clear the bit before tearing the driver down, so any submit that is waiting
+  // on the mutex right now sees a dead index rather than a freed driver.
+  if (index < kMaximumClientCount) {
+    g_live_clients &= ~(1u << index);
+    RNUT_INFO("audio guard: client {} unregistered (handle {:08X}, {} frames submitted)", index,
+              driver_ptr.guest_address(), g_submitted_frames.load(std::memory_order_relaxed));
+  }
+
+  return rex::kernel::xboxkrnl::XAudioUnregisterRenderDriverClient_entry(driver_ptr);
+}
+
+u32 SubmitRenderDriverFrame(mapped_void driver_ptr, mapped_void samples_ptr) {
+  // Shared: many submits may run concurrently, but none may overlap an
+  // unregister. Held across the call into the SDK, not just the check.
+  std::shared_lock lock(g_clients_mutex);
+
+  const uint32_t handle = driver_ptr.guest_address();
+  const uint32_t index = ClientIndexFromHandle(handle);
+  if (index >= kMaximumClientCount || !(g_live_clients & (1u << index))) {
+    // The driver behind this handle is gone. Passing it through would null-deref
+    // inside AudioSystem::SubmitFrame while it holds the global critical region
+    // and wedge the whole emulator. Drop the frame instead; the guest treats
+    // this as a successful submit and carries on.
+    const uint32_t dropped = g_dropped_frames.fetch_add(1, std::memory_order_relaxed) + 1;
+    if (dropped <= 5 || (dropped % 1000) == 0) {
+      RNUT_WARN("audio guard: dropped frame for stale driver handle {:08X} (drop #{})", handle,
+                dropped);
+    }
+    return X_ERROR_SUCCESS;
+  }
+
+  g_submitted_frames.fetch_add(1, std::memory_order_relaxed);
+  return rex::kernel::xboxkrnl::XAudioSubmitRenderDriverFrame_entry(driver_ptr, samples_ptr);
+}
+
+}  // namespace
+
+// These definitions preempt the identically named exports in librexruntimerd.so
+// for every call site inside renut.
+REX_HOOK(__imp__XAudioRegisterRenderDriverClient, RegisterRenderDriverClient)
+REX_HOOK(__imp__XAudioUnregisterRenderDriverClient, UnregisterRenderDriverClient)
+REX_HOOK(__imp__XAudioSubmitRenderDriverFrame, SubmitRenderDriverFrame)

--- a/src/renut_engine/linuxfixes/posix_file_access.cpp
+++ b/src/renut_engine/linuxfixes/posix_file_access.cpp
@@ -1,0 +1,150 @@
+// Fixes corrupted save data on Linux, caused by a broken POSIX open() mode.
+//
+// Symptom
+// -------
+// The game reports its save data as corrupted, repeatedly.
+//
+// Cause
+// -----
+// The SDK's POSIX backend (src/core/filesystem_posix.cpp,
+// FileHandle::OpenExisting) builds its open() flags like this:
+//
+//     int open_access = 0;
+//     if (desired_access & FileAccess::kGenericRead)  open_access |= O_RDONLY;
+//     if (desired_access & FileAccess::kGenericWrite) open_access |= O_WRONLY;
+//     if (desired_access & FileAccess::kGenericAll)   open_access |= O_RDWR;
+//     ...
+//     int handle = open(path.c_str(), open_access);
+//
+// O_RDONLY/O_WRONLY/O_RDWR are not bit flags. They are mutually exclusive
+// values occupying the low two bits (O_ACCMODE):
+//
+//     O_RDONLY = 0    O_WRONLY = 1    O_RDWR = 2    O_ACCMODE = 3
+//
+// So OR-ing them silently produces the wrong mode:
+//
+//     kGenericRead | kGenericWrite  ->  0 | 1  =  1  =  O_WRONLY   (read lost!)
+//     kGenericWrite | kGenericAll   ->  1 | 2  =  3  =  O_ACCMODE  (invalid)
+//
+// A save file is opened for read *and* write, which lands on the first case:
+// the descriptor comes back write-only. Every subsequent pread() then fails
+// with EBADF, HostPathFile::ReadSync turns that into X_STATUS_END_OF_FILE, and
+// the guest sees a zero-length / unreadable save -- i.e. "corrupted". The
+// second case is worse: open() rejects mode 3 with EINVAL, so the file cannot
+// be opened at all.
+//
+// This only affects Linux; the Win32 backend passes real GENERIC_* flags to
+// CreateFile, which do combine.
+//
+// Fix
+// ---
+// The SDK is upstream and cannot be patched, so this file provides its own
+// definition of FileHandle::OpenExisting that collapses the requested access
+// down to exactly one O_ACCMODE value before OR-ing in the modifier flags.
+//
+// Unlike the XAudio hooks, every caller of this function lives *inside*
+// librexruntimerd.so, so a plain link-time definition here would not be seen by
+// them. It works because the symbol is exported with default visibility and the
+// library is not linked -Bsymbolic, so its calls go through the PLT and resolve
+// against the global scope -- where the executable is searched first. reNut's
+// CMakeLists passes -Wl,--export-dynamic-symbol=<mangled name> to put this
+// definition into renut's dynamic symbol table so that lookup can find it.
+//
+// Also fixed here: on a failed read/write the SDK assigns the raw -1 from
+// pread/pwrite into *out_bytes_*, which underflows to SIZE_MAX for callers that
+// look at the count before the status. This version reports 0.
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+
+#include <rex/filesystem.h>
+
+namespace {
+
+class LinuxFileHandle final : public rex::filesystem::FileHandle {
+ public:
+  LinuxFileHandle(const std::filesystem::path& path, int handle)
+      : FileHandle(path), handle_(handle) {}
+
+  ~LinuxFileHandle() override {
+    if (handle_ != -1) {
+      close(handle_);
+      handle_ = -1;
+    }
+  }
+
+  bool Read(size_t file_offset, void* buffer, size_t buffer_length,
+            size_t* out_bytes_read) override {
+    ssize_t out = pread(handle_, buffer, buffer_length, static_cast<off_t>(file_offset));
+    if (out < 0) {
+      *out_bytes_read = 0;
+      return false;
+    }
+    *out_bytes_read = static_cast<size_t>(out);
+    return true;
+  }
+
+  bool Write(size_t file_offset, const void* buffer, size_t buffer_length,
+             size_t* out_bytes_written) override {
+    ssize_t out = pwrite(handle_, buffer, buffer_length, static_cast<off_t>(file_offset));
+    if (out < 0) {
+      *out_bytes_written = 0;
+      return false;
+    }
+    *out_bytes_written = static_cast<size_t>(out);
+    return true;
+  }
+
+  bool SetLength(size_t length) override {
+    return ftruncate(handle_, static_cast<off_t>(length)) >= 0;
+  }
+
+  void Flush() override { fsync(handle_); }
+
+ private:
+  int handle_ = -1;
+};
+
+}  // namespace
+
+namespace rex::filesystem {
+
+// Interposes the SDK's definition. Marked used so it survives even though
+// nothing inside renut calls it directly.
+__attribute__((used)) std::unique_ptr<FileHandle> FileHandle::OpenExisting(
+    const std::filesystem::path& path, uint32_t desired_access, bool /*allow_share_delete*/) {
+  // POSIX has no share-delete analog; unlinking an open file is always allowed.
+  const bool wants_read = (desired_access & (FileAccess::kGenericRead | FileAccess::kGenericExecute |
+                                             FileAccess::kGenericAll | FileAccess::kFileReadData)) != 0;
+  const bool wants_write =
+      (desired_access & (FileAccess::kGenericWrite | FileAccess::kGenericAll |
+                         FileAccess::kFileWriteData | FileAccess::kFileAppendData)) != 0;
+
+  // Exactly one access mode, never a bitwise mix.
+  int open_flags;
+  if (wants_read && wants_write) {
+    open_flags = O_RDWR;
+  } else if (wants_write) {
+    open_flags = O_WRONLY;
+  } else {
+    open_flags = O_RDONLY;
+  }
+
+  // Modifier flags are real bits and may be OR-ed in.
+  if (desired_access & FileAccess::kFileAppendData) {
+    open_flags |= O_APPEND;
+  }
+
+  int handle = open(path.c_str(), open_flags);
+  if (handle == -1) {
+    return nullptr;
+  }
+  return std::make_unique<LinuxFileHandle>(path, handle);
+}
+
+}  // namespace rex::filesystem

--- a/src/renut_engine/linuxfixes/xdg_paths.h
+++ b/src/renut_engine/linuxfixes/xdg_paths.h
@@ -1,0 +1,161 @@
+// XDG base-directory paths, so renut never writes next to its own executable.
+//
+// Why
+// ---
+// By default the SDK puts everything beside the binary:
+//
+//   rex_app.cpp:145   config_path = exe_dir / "<app>.toml"
+//   rex_app.cpp:170   log_dir     = exe_dir / "logs"
+//   path_config_store.h  <exe_dir>/<app>.cfg
+//
+// That is fine when running out of a build tree, but it breaks the moment renut
+// ships as anything users don't own the directory of -- an AppImage (read-only
+// squashfs mount), a Flatpak, or a system-wide install under /opt or /usr. The
+// app would fail to save its config and, worse, fail to open a log file just
+// when you most want one.
+//
+// This header resolves the three writable locations to the XDG base directory
+// spec instead:
+//
+//   config   $XDG_CONFIG_HOME/renut   (default ~/.config/renut)
+//   state    $XDG_STATE_HOME/renut    (default ~/.local/state/renut)
+//   logs     <state>/logs
+//
+// Game/user data already lands in ~/.local/share/renut via the path wizard, so
+// it needs no change here.
+//
+// Linux only, by design: on Windows the exe-relative layout is conventional and
+// writable, so that path is left exactly as it was. Every include of this header
+// is guarded by #ifndef _WIN32.
+//
+// Existing installs are migrated rather than abandoned: the first time a file is
+// wanted at its new location and is not there, an old copy sitting beside the
+// executable is copied across. That keeps a developer's working renut.cfg (with
+// their asset paths already filled in) after the switch.
+
+#pragma once
+
+#ifndef _WIN32
+
+#include <climits>
+#include <cstdlib>
+#include <filesystem>
+#include <string>
+#include <system_error>
+#include <unistd.h>
+
+namespace renut::linuxfixes {
+
+// Directory containing the running executable. Used only to find legacy files
+// to migrate, never as a write target.
+inline std::filesystem::path ExecutableDir() {
+  char buffer[PATH_MAX] = {};
+  const ssize_t len = ::readlink("/proc/self/exe", buffer, sizeof(buffer) - 1);
+  if (len > 0) {
+    return std::filesystem::path(std::string(buffer, static_cast<size_t>(len))).parent_path();
+  }
+  std::error_code ec;
+  auto cwd = std::filesystem::current_path(ec);
+  return ec ? std::filesystem::path(".") : cwd;
+}
+
+// Reads an XDG environment variable, ignoring the relative paths the spec says
+// to treat as unset. Falls back to $HOME/<fallback_suffix>.
+inline std::filesystem::path XdgDir(const char* env_name, const char* fallback_suffix) {
+  if (const char* value = std::getenv(env_name)) {
+    // The spec requires absolute paths; anything else must be ignored.
+    if (value[0] == '/') {
+      return std::filesystem::path(value);
+    }
+  }
+  const char* home = std::getenv("HOME");
+  if (!home || home[0] == '\0') {
+    // No HOME at all (unusual). Fall back to the CWD so we still land somewhere
+    // writable rather than trying to write into a read-only mount.
+    std::error_code ec;
+    auto cwd = std::filesystem::current_path(ec);
+    return (ec ? std::filesystem::path(".") : cwd) / ".renut";
+  }
+  return std::filesystem::path(home) / fallback_suffix;
+}
+
+inline std::filesystem::path ConfigDir() {
+  return XdgDir("XDG_CONFIG_HOME", ".config") / "renut";
+}
+
+inline std::filesystem::path StateDir() {
+  return XdgDir("XDG_STATE_HOME", ".local/state") / "renut";
+}
+
+inline std::filesystem::path LogDir() {
+  return StateDir() / "logs";
+}
+
+// Creates dir if needed. Returns false if it could not be created, letting
+// callers fall back rather than handing the SDK an unusable path.
+inline bool EnsureDir(const std::filesystem::path& dir) {
+  std::error_code ec;
+  std::filesystem::create_directories(dir, ec);
+  return !ec && std::filesystem::is_directory(dir, ec);
+}
+
+// Resolves a writable path for file_name inside dir, migrating a pre-existing
+// copy from beside the executable on first use.
+inline std::filesystem::path ResolveWithMigration(const std::filesystem::path& dir,
+                                                  const std::string& file_name) {
+  const auto target = dir / file_name;
+  std::error_code ec;
+
+  if (std::filesystem::exists(target, ec)) {
+    return target;
+  }
+  if (!EnsureDir(dir)) {
+    // Nowhere to put it; let the caller keep the old behaviour.
+    return ExecutableDir() / file_name;
+  }
+
+  const auto legacy = ExecutableDir() / file_name;
+  if (std::filesystem::exists(legacy, ec)) {
+    std::filesystem::copy_file(legacy, target, std::filesystem::copy_options::skip_existing, ec);
+    // If the copy failed the target simply will not exist yet, which is the same
+    // as a clean first run -- nothing is lost, so ec is deliberately ignored.
+  }
+  return target;
+}
+
+// Path for the next sequential log file, mirroring the SDK's NextSequentialLogPath
+// ("<app>_NNN.log"). Reimplemented here because setting the log_file cvar bypasses
+// the SDK's own sequencing, and losing per-run logs would be a regression.
+inline std::filesystem::path NextSequentialLog(const std::filesystem::path& dir,
+                                               const std::string& app_name) {
+  if (!EnsureDir(dir)) {
+    return {};
+  }
+
+  const std::string prefix = app_name + "_";
+  unsigned max_seq = 0;
+  std::error_code ec;
+  for (const auto& entry : std::filesystem::directory_iterator(dir, ec)) {
+    const std::string name = entry.path().filename().string();
+    if (name.size() < prefix.size() + 5 || name.compare(0, prefix.size(), prefix) != 0) {
+      continue;
+    }
+    if (entry.path().extension() != ".log") {
+      continue;
+    }
+    // Digits between the prefix and ".log"; skip rotated names like renut_001.1.log.
+    const std::string stem = entry.path().stem().string().substr(prefix.size());
+    if (stem.empty() || stem.find_first_not_of("0123456789") != std::string::npos) {
+      continue;
+    }
+    max_seq = std::max(max_seq, static_cast<unsigned>(std::strtoul(stem.c_str(), nullptr, 10)));
+  }
+
+  char name[64];
+  std::snprintf(name, sizeof(name), "%s_%03u.log", app_name.c_str(), max_seq + 1);
+  return dir / name;
+}
+
+}  // namespace renut::linuxfixes
+
+#endif  // !_WIN32

--- a/src/renut_engine/overlays/path_setup_wizard.h
+++ b/src/renut_engine/overlays/path_setup_wizard.h
@@ -6,8 +6,15 @@
 #include <filesystem>
 #include <functional>
 #include <string>
+
+#ifdef _WIN32
 #include <shobjidl.h>
 #include <windows.h>
+#else
+#include <array>
+#include <cstdio>
+#include <sys/wait.h>
+#endif
 
 class PathSetupWizard : public rex::ui::ImGuiDialog {
 public:
@@ -27,7 +34,7 @@ public:
 
         // First-run check — if a valid saved config exists, skip the wizard entirely
         if (auto saved = PathConfigStore::TryLoad(app_name)) {
-            rex::PathConfig cfg;
+            rex::PathConfig cfg = defaults;
             cfg.game_data_root = saved->game_data_root;
             cfg.user_data_root = saved->user_data_root;
             cfg.update_data_root = saved->update_data_root;
@@ -36,6 +43,7 @@ public:
         }
 
         // No saved config — show the wizard
+        defaults_ = defaults;
         game_data_buf_ = defaults.game_data_root.string();
         user_data_buf_ = defaults.user_data_root.string();
         update_data_buf_ = defaults.update_data_root.string();
@@ -108,6 +116,7 @@ private:
         }
     }
 
+#ifdef _WIN32
     static std::string BrowseForFolder(const char* default_path) {
         std::string result;
         IFileDialog* dlg = nullptr;
@@ -152,6 +161,58 @@ private:
         dlg->Release();
         return result;
     }
+#else
+    static std::string ShellQuote(const std::string& s) {
+        std::string out = "'";
+        for (char c : s) {
+            if (c == '\'') out += "'\\''";
+            else out += c;
+        }
+        out += "'";
+        return out;
+    }
+
+    // Runs a picker command and returns its trimmed stdout, or (found=false) if
+    // the command itself couldn't be run (e.g. the binary isn't installed).
+    static std::string RunPicker(const std::string& cmd, bool& found) {
+        found = true;
+        FILE* pipe = popen(cmd.c_str(), "r");
+        if (!pipe) { found = false; return std::string(); }
+
+        std::string result;
+        std::array<char, 512> buf;
+        size_t n;
+        while ((n = fread(buf.data(), 1, buf.size(), pipe)) > 0)
+            result.append(buf.data(), n);
+
+        int status = pclose(pipe);
+        if (WIFEXITED(status) && WEXITSTATUS(status) == 127)
+            found = false;  // shell couldn't find the binary
+
+        while (!result.empty() && (result.back() == '\n' || result.back() == '\r'))
+            result.pop_back();
+        return result;
+    }
+
+    // No SDL/portal dialog integration here (would need to pump the event loop
+    // while blocked); shell out to whichever native picker is installed instead.
+    static std::string BrowseForFolder(const char* default_path) {
+        bool found = false;
+        std::string cmd = "zenity --file-selection --directory --title=\"Select Folder\"";
+        if (default_path && default_path[0])
+            cmd += " --filename=" + ShellQuote(std::string(default_path) + "/");
+        cmd += " 2>/dev/null";
+
+        std::string result = RunPicker(cmd, found);
+        if (found) return result;
+
+        cmd = "kdialog --getexistingdirectory " +
+            ShellQuote((default_path && default_path[0]) ? default_path : ".") +
+            " 2>/dev/null";
+        result = RunPicker(cmd, found);
+        return result;
+    }
+#endif
 
     void TryCommit() {
         std::filesystem::path game = game_data_buf_.c_str();
@@ -174,7 +235,7 @@ private:
         visible_ = false;
         error_.clear();
 
-        rex::PathConfig cfg;
+        rex::PathConfig cfg = defaults_;
         cfg.game_data_root = std::move(game);
         cfg.user_data_root = std::move(user);
         cfg.update_data_root = std::move(update);
@@ -188,11 +249,12 @@ private:
         on_complete_(std::move(cfg));
     }
 
-    std::string  app_name_;
-    bool         visible_ = false;
-    std::string  game_data_buf_;
-    std::string  user_data_buf_;
-    std::string  update_data_buf_;
-    std::string  error_;
-    CompletionFn on_complete_;
+    std::string     app_name_;
+    rex::PathConfig defaults_;
+    bool            visible_ = false;
+    std::string     game_data_buf_;
+    std::string     user_data_buf_;
+    std::string     update_data_buf_;
+    std::string     error_;
+    CompletionFn    on_complete_;
 };

--- a/src/renut_engine/path_config_store.h
+++ b/src/renut_engine/path_config_store.h
@@ -3,7 +3,16 @@
 #include <fstream>
 #include <optional>
 #include <string>
+
+#ifdef _WIN32
 #include <windows.h>
+#else
+#include <climits>
+#include <unistd.h>
+// Keeps the .cfg out of the executable's directory so renut still works when
+// installed read-only (AppImage/Flatpak/system install). See that header.
+#include "linuxfixes/xdg_paths.h"
+#endif
 
 namespace PathConfigStore {
 
@@ -31,10 +40,19 @@ namespace PathConfigStore {
     }
 
     inline std::filesystem::path GetStorePath(const std::string& app_name) {
+#ifdef _WIN32
         wchar_t exe_path[MAX_PATH] = {};
         GetModuleFileNameW(nullptr, exe_path, MAX_PATH);
         std::filesystem::path dir = std::filesystem::path(exe_path).parent_path();
+#else
+        // ~/.config/renut/<app>.cfg, migrating an existing file from beside the
+        // executable on first use so current setups keep their asset paths.
+        return renut::linuxfixes::ResolveWithMigration(renut::linuxfixes::ConfigDir(),
+                                                       app_name + ".cfg");
+#endif
+#ifdef _WIN32
         return dir / (app_name + ".cfg");
+#endif
     }
 
     inline std::optional<SavedPaths> TryLoad(const std::string& app_name) {

--- a/src/renut_engine/sleep.h
+++ b/src/renut_engine/sleep.h
@@ -43,4 +43,4 @@ ppc_u32_result_t Sleep_hook(ppc_u32_t ms) {
 
     return 0;
 }
-PPC_HOOK(sub_82715B60, Sleep_hook);
+REX_HOOK(sub_82715B60, Sleep_hook);


### PR DESCRIPTION
- Audio: audio_backend.cpp, audio_client_guard.cpp — real UAF/lifetime fix.
- Paths: posix_file_access.cpp, xdg_paths.h — XDG config/state dirs with migration from exe-relative files, needed for AppImage/read-only installs. Wired into renut_app.h, cvar_menu.cpp, path_config_store.h.
- UX: path_setup_wizard.h — portable zenity/kdialog folder picker replacing the Windows-only IFileDialog path.
- Frame pacing: frameHooks.cpp — portable clock_nanosleep replacing the Windows-only waitable timer.
- Compile fix: sleep.h's PPC_HOOK→REX_HOOK (not platform-specific, but nothing builds without it).
- Packaging: AppImage build script + AppRun, container build.